### PR TITLE
chore(ui): copy icons to dist folder

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -73,6 +73,7 @@
     "http-server": "^14.1.1",
     "jest-image-snapshot": "^6.1.0",
     "prettier": "^2.4.1",
+    "rollup-plugin-copy": "^3.4.0",
     "storybook-addon-pseudo-states": "^1.15.2",
     "url-loader": "^4.1.1",
     "wait-on": "^7.0.1",

--- a/packages/ui/rollup.config.js
+++ b/packages/ui/rollup.config.js
@@ -3,6 +3,7 @@ import image from '@rollup/plugin-image';
 import typescript from '@rollup/plugin-typescript';
 import svgr from '@svgr/rollup';
 import { vanillaExtractPlugin } from '@vanilla-extract/rollup-plugin';
+import copy from 'rollup-plugin-copy';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 
 import packageJson from './package.json';
@@ -11,14 +12,18 @@ export default () => ({
   input: 'src/index.ts',
   plugins: [
     typescript({
-      tsconfig: 'tsconfig.json',
+      tsconfig: './tsconfig.json',
       composite: false,
+      exclude: ['**/*.stories.tsx'],
     }),
     peerDepsExternal(),
     commonjs(),
     image(),
     svgr({ icon: true }),
     vanillaExtractPlugin(),
+    copy({
+      targets: [{ src: 'src/assets/icons/*', dest: 'dist/assets/icons' }],
+    }),
   ],
   output: [
     {


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-6762

---

## Proposed solution

Copy the `assets/icons` folder to `dist.`

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/7/5132198354/index.html) for [deda0bf1](https://github.com/input-output-hk/lace/pull/6/commits/deda0bf1ec1daccca3a72677c504de702381c828)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->