### PR TITLE
feat(ui): create Profile picture components

### DIFF
--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -1,0 +1,2 @@
+# Do not ignore the following
+!*.d.ts

--- a/packages/ui/src/typings/png.d.ts
+++ b/packages/ui/src/typings/png.d.ts
@@ -1,0 +1,5 @@
+declare module '*.png' {
+  const value: string;
+  // eslint-disable-next-line import/no-default-export
+  export default value;
+}

--- a/packages/ui/src/typings/svg.modules.d.ts
+++ b/packages/ui/src/typings/svg.modules.d.ts
@@ -1,0 +1,3 @@
+declare module '*.svg' {
+  export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+}


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-6632
- [x] Chromatic checks passed
- [x] Screenshots added.

\*\* The label 'run-chromatic' must be toggled on/off for the job to run on pull requests.

---

## Proposed solution

This pull request adds new components to the project that allow users to display user profiles with initials or images. It uses [RadixUI's Avatar](https://www.radix-ui.com/docs/primitives/components/avatar) to display image fallback.

```jsx

<UserProfile imageSrc="" fallback="L" delayMs={0} />
<Initials letter="M" />
<Image imageSrc={cardanoImage} />
```

## Screenshots

<img width="1699" alt="Screenshot 2023-05-29 at 10 31 59" src="https://github.com/input-output-hk/wallet-world/assets/2846918/c334d7f0-8a75-4fec-8988-952c4ae114d6">

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/9/5132307276/index.html) for [b45ce000](https://github.com/input-output-hk/lace/pull/8/commits/b45ce000ab5d7497b0993eefc39d2601a0b73ce7)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->