### PR TITLE
feat(ui): create <NavigationButton /> component

### DIFF
--- a/packages/ui/src/design-system/navigation-buttons/back-button.component.tsx
+++ b/packages/ui/src/design-system/navigation-buttons/back-button.component.tsx
@@ -5,18 +5,16 @@ import { ReactComponent as ArrowLeftIcon } from '../../assets/icons/arrow-left.c
 import * as cx from './back-button.css';
 import { NavigationSkeletonButton } from './navigation-skeleton-button.component';
 
-import type { OmitClassName } from '../../types';
+import type { Props as SkeletonButtonProps } from './navigation-skeleton-button.component';
 
-type Props = OmitClassName<HTMLButtonElement> & {
+type Props = Omit<SkeletonButtonProps, 'children'> & {
   disabled?: boolean;
   // Needed for @storybook/addon-docs
-  onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
-export const Back = ({ ...props }: Readonly<Props>): JSX.Element => {
-  return (
-    <NavigationSkeletonButton {...props}>
-      <ArrowLeftIcon className={cx.icon} />
-    </NavigationSkeletonButton>
-  );
-};
+export const Back = ({ ...props }: Readonly<Props>): JSX.Element => (
+  <NavigationSkeletonButton {...props}>
+    <ArrowLeftIcon className={cx.icon} />
+  </NavigationSkeletonButton>
+);

--- a/packages/ui/src/design-system/navigation-buttons/close-button.component.tsx
+++ b/packages/ui/src/design-system/navigation-buttons/close-button.component.tsx
@@ -5,18 +5,16 @@ import { ReactComponent as CloseIcon } from '../../assets/icons/close.component.
 import * as cx from './close-button.css';
 import { NavigationSkeletonButton } from './navigation-skeleton-button.component';
 
-import type { OmitClassName } from '../../types';
+import type { Props as SkeletonButtonProps } from './navigation-skeleton-button.component';
 
-type Props = OmitClassName<HTMLButtonElement> & {
+type Props = Omit<SkeletonButtonProps, 'children'> & {
   disabled?: boolean;
   // Needed for @storybook/addon-docs
   onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
 };
 
-export const Close = ({ ...props }: Readonly<Props>): JSX.Element => {
-  return (
-    <NavigationSkeletonButton {...props}>
-      <CloseIcon className={cx.icon} />
-    </NavigationSkeletonButton>
-  );
-};
+export const Close = ({ ...props }: Readonly<Props>): JSX.Element => (
+  <NavigationSkeletonButton {...props}>
+    <CloseIcon className={cx.icon} />
+  </NavigationSkeletonButton>
+);

--- a/packages/ui/src/design-system/navigation-buttons/navigation-skeleton-button.component.tsx
+++ b/packages/ui/src/design-system/navigation-buttons/navigation-skeleton-button.component.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { PropsWithChildren } from 'react';
 import React from 'react';
 
 import { Flex } from '../flex';
@@ -7,10 +7,10 @@ import * as cx from './navigation-skeleton-button.css';
 
 import type { OmitClassName } from '../../types';
 
-export type Props = OmitClassName<HTMLButtonElement> & {
-  disabled?: boolean;
-  children: ReactNode;
-};
+export type Props = OmitClassName<HTMLButtonElement> &
+  PropsWithChildren<{
+    disabled?: boolean;
+  }>;
 
 export const NavigationSkeletonButton = ({
   id,


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-6664
- [x] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

It can be used by importing the NavigationButton namespace

```ts
import { NavigationButton } from '@lace/ui'


<NavigationButton.Close />
<NavigationButton.Back />
```

## Docs

<img width="986" alt="Screenshot 2023-05-24 at 12 55 55" src="https://github.com/input-output-hk/wallet-world/assets/2846918/0d03b7d4-04c4-4c72-b75d-cf3a6c45cd65">
<img width="982" alt="Screenshot 2023-05-24 at 12 55 58" src="https://github.com/input-output-hk/wallet-world/assets/2846918/0127a168-d557-4573-901c-cd5b424a4f1b">


## Screenshots

Attach screenshots here if implementation involves some UI changes
<img width="1460" alt="Screenshot 2023-05-23 at 12 21 24" src="https://github.com/input-output-hk/wallet-world/assets/2846918/dca01517-4f58-44be-93b4-ff90fa118d6e">

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/10/5132323661/index.html) for [aa7f2fc6](https://github.com/input-output-hk/lace/pull/9/commits/aa7f2fc639489d0fc705cf8445f4a880d7f4e98e)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->