### PR TITLE
test(extension): e2e - return proper exit code on error for encrypt/d…

### DIFF
--- a/packages/e2e-tests/decrypt_secret.sh
+++ b/packages/e2e-tests/decrypt_secret.sh
@@ -6,7 +6,7 @@ DECRYPTED_FILE="$FILE_LOCATION/walletConfiguration.ts"
 
 if [ -z "${WALLET_1_PASSWORD}" ]; then
   echo "WALLET_1_PASSWORD environment variable is not set, aborting"
-  exit
+  exit 1
 fi
 
 # Decrypt the file

--- a/packages/e2e-tests/encrypt_secret.sh
+++ b/packages/e2e-tests/encrypt_secret.sh
@@ -5,7 +5,7 @@ DECRYPTED_FILE="$FILE_LOCATION/walletConfiguration.ts"
 
 if [ -z "${WALLET_1_PASSWORD}" ]; then
   echo "WALLET_1_PASSWORD environment variable is not set, aborting"
-  exit
+  exit 1
 fi
 
 gpg --symmetric --cipher-algo AES256 --batch --passphrase "$WALLET_1_PASSWORD" $DECRYPTED_FILE


### PR DESCRIPTION
return proper exit code on error for encrypt/decrypt scripts
it should break workflow on decrypt step

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/97/5157217962/index.html) for [0f68f0d4](https://github.com/input-output-hk/lace/pull/39/commits/0f68f0d4374a3945bd51bc95ba1c87eafe5dea6f)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->