### PR TITLE
test(extension): e2e - add e2e tests for sending ada/assets from DApp

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/DappTransactionSuccess.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/DappTransactionSuccess.tsx
@@ -12,11 +12,19 @@ export const DappTransactionSuccess = (): React.ReactElement => {
     <div data-testid="dapp-sign-tx-success" className={styles.noWalletContainer}>
       <div className={styles.noWalletContent}>
         <Image data-testid="dapp-sign-tx-success-image" preview={false} width={112} src={Success} />
-        <div className={styles.heading}>{t('browserView.transaction.success.youCanSafelyCloseThisPanel')}</div>
-        <div className={styles.description}>{t('core.dappTransaction.signedSuccessfully')}</div>
+        <div data-testid="dapp-sign-tx-success-heading" className={styles.heading}>
+          {t('browserView.transaction.success.youCanSafelyCloseThisPanel')}
+        </div>
+        <div data-testid="dapp-sign-tx-success-description" className={styles.description}>
+          {t('core.dappTransaction.signedSuccessfully')}
+        </div>
       </div>
       <div className={styles.footer}>
-        <Button data-test-id="window-close-btn" className={styles.footerBtn} onClick={() => window.close()}>
+        <Button
+          data-testid="dapp-sign-tx-success-close-button"
+          className={styles.footerBtn}
+          onClick={() => window.close()}
+        >
           {t('general.button.close')}
         </Button>
       </div>

--- a/apps/browser-extension-wallet/src/features/dapp/components/SignTransaction.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/SignTransaction.tsx
@@ -68,7 +68,7 @@ export const SignTransaction = (): React.ReactElement => {
     <Layout title={undefined}>
       <div className={styles.passwordContainer}>
         <Spin spinning={isLoading}>
-          <h5 className={styles.message}>
+          <h5 className={styles.message} data-testid="sign-transaction-description">
             {t('browserView.transaction.send.enterWalletPasswordToConfirmTransaction')}
           </h5>
           <Password
@@ -81,10 +81,20 @@ export const SignTransaction = (): React.ReactElement => {
         </Spin>
       </div>
       <div className={styles.actions}>
-        <Button onClick={onConfirm} disabled={confirmIsDisabled} className={styles.actionBtn}>
+        <Button
+          onClick={onConfirm}
+          disabled={confirmIsDisabled}
+          className={styles.actionBtn}
+          data-testid="sign-transaction-confirm"
+        >
           {t('dapp.confirm.btn.confirm')}
         </Button>
-        <Button onClick={setPreviousView} color="secondary" className={styles.actionBtn}>
+        <Button
+          onClick={setPreviousView}
+          color="secondary"
+          className={styles.actionBtn}
+          data-testid="sign-transaction-cancel"
+        >
           {t('dapp.confirm.btn.cancel')}
         </Button>
       </div>

--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
@@ -49,33 +49,43 @@ export const DappTransaction = ({
       </div>
     )}
     {errorMessage && <ErrorPane error={errorMessage} className={styles.error} />}
-    <div className={styles.details}>
+    <div data-testid="dapp-transaction-container" className={styles.details}>
       <div className={styles.header}>
-        <div className={styles.title}>{translations.transaction}</div>
-        <div className={styles.type}>{type}</div>
+        <div data-testid="dapp-transaction-title" className={styles.title}>
+          {translations.transaction}
+        </div>
+        <div data-testid="dapp-transaction-type" className={styles.type}>
+          {type}
+        </div>
       </div>
       {outputs.map((output) => (
         <div className={styles.body} key={output.recipient}>
           <div className={styles.detail}>
-            <div className={styles.title}>{translations.amount}</div>
+            <div data-testid="dapp-transaction-amount-title" className={styles.title}>
+              {translations.amount}
+            </div>
             <div className={styles.value}>
-              <div className={styles.bold}>{output.coins.toString()} ADA</div>
+              <div data-testid="dapp-transaction-amount-value" className={styles.bold}>
+                {output.coins.toString()} ADA
+              </div>
               {outputs.length === 1 && (
-                <div className={styles.sub}>
+                <div data-testid="dapp-transaction-amount-fee" className={styles.sub}>
                   {translations.fee}: {fee.toString()} ADA
                 </div>
               )}
               {output.assets &&
                 output.assets.map((asset) => (
-                  <div className={styles.bold} key={asset.name.toString()}>
+                  <div data-testid="dapp-transaction-asset" className={styles.bold} key={asset.name.toString()}>
                     {asset.amount} {asset.ticker || asset.name}
                   </div>
                 ))}
             </div>
           </div>
           <div className={styles.detail}>
-            <div className={styles.title}>{translations.recipient}</div>
-            <div className={styles.value}>
+            <div data-testid="dapp-transaction-recipient-title" className={styles.title}>
+              {translations.recipient}
+            </div>
+            <div data-testid="dapp-transaction-recipient-address" className={styles.value}>
               <Ellipsis className={styles.rightAligned} text={output.recipient} ellipsisInTheMiddle />
             </div>
           </div>

--- a/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
+++ b/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
@@ -4,27 +4,48 @@ import AuthorizeDAppPage from '../elements/dappConnector/authorizeDAppPage';
 import AuthorizedDAppsPage from '../elements/dappConnector/authorizedDAppsPage';
 import AuthorizeDAppModal from '../elements/dappConnector/authorizeDAppModal';
 import ExampleDAppPage from '../elements/dappConnector/testDAppPage';
+import ConfirmTransactionPage from '../elements/dappConnector/confirmTransactionPage';
+import CommonDappPageElements from '../elements/dappConnector/commonDappPageElements';
+import SignTransactionPage from '../elements/dappConnector/signTransactionPage';
+import DAppTransactionAllDonePage from '../elements/dappConnector/dAppTransactionAllDonePage';
+import { Logger } from '../support/logger';
+import testContext from '../utils/testContext';
 
-export type ExpectedAuthorizedDAppDetails = {
+export type ExpectedDAppDetails = {
   hasLogo: boolean;
   name: string;
   url: string;
 };
 
+export type ExpectedTransactionData = {
+  typeOfTransaction: string;
+  amountADA: string;
+  amountAsset?: string;
+  recipientAddress: string;
+};
+
 class DAppConnectorAssert {
-  async assertSeeAuthorizeDAppPage(expectedDappName: string, expectedDappUrl: string) {
-    await AuthorizeDAppPage.headerLogo.waitForDisplayed();
-    await AuthorizeDAppPage.betaPill.waitForDisplayed();
-    await expect(await AuthorizeDAppPage.betaPill.getText()).to.equal(await t('core.dapp.beta'));
+  async assertSeeHeader() {
+    const commonDappPageElements = new CommonDappPageElements();
+    await commonDappPageElements.headerLogo.waitForDisplayed();
+    await commonDappPageElements.betaPill.waitForDisplayed();
+    await expect(await commonDappPageElements.betaPill.getText()).to.equal(await t('core.dapp.beta'));
+  }
 
-    await AuthorizeDAppPage.pageTitle.waitForDisplayed();
-    await expect(await AuthorizeDAppPage.pageTitle.getText()).to.equal(await t('dapp.connect.header'));
+  async assertSeeTitleAndDappDetails(expectedTitleKey: string, expectedDappDetails: ExpectedDAppDetails) {
+    const commonDappPageElements = new CommonDappPageElements();
+    await commonDappPageElements.pageTitle.waitForDisplayed();
+    await expect(await commonDappPageElements.pageTitle.getText()).to.equal(await t(expectedTitleKey));
+    await commonDappPageElements.dAppLogo.waitForDisplayed({ reverse: !expectedDappDetails.hasLogo });
+    await commonDappPageElements.dAppName.waitForDisplayed();
+    await expect(await commonDappPageElements.dAppName.getText()).to.equal(expectedDappDetails.name);
+    await commonDappPageElements.dAppUrl.waitForDisplayed();
+    await expect(await commonDappPageElements.dAppUrl.getText()).to.equal(expectedDappDetails.url);
+  }
 
-    await AuthorizeDAppPage.dAppLogo.waitForDisplayed();
-    await AuthorizeDAppPage.dAppName.waitForDisplayed();
-    await expect(await AuthorizeDAppPage.dAppName.getText()).to.equal(expectedDappName);
-    await AuthorizeDAppPage.dAppUrl.waitForDisplayed();
-    await expect(await AuthorizeDAppPage.dAppUrl.getText()).to.equal(expectedDappUrl);
+  async assertSeeAuthorizeDAppPage(expectedDappDetails: ExpectedDAppDetails) {
+    await this.assertSeeHeader();
+    await this.assertSeeTitleAndDappDetails('dapp.connect.header', expectedDappDetails);
 
     await AuthorizeDAppPage.banner.container.waitForDisplayed();
     await AuthorizeDAppPage.banner.icon.waitForDisplayed();
@@ -112,7 +133,7 @@ class DAppConnectorAssert {
     expect(await AuthorizedDAppsPage.dAppContainers.length).to.equal(0);
   }
 
-  async assertSeeAuthorizedDAppsOnTheList(expectedDApps: ExpectedAuthorizedDAppDetails[]) {
+  async assertSeeAuthorizedDAppsOnTheList(expectedDApps: ExpectedDAppDetails[]) {
     expect(await AuthorizedDAppsPage.dAppContainers.length).to.equal(expectedDApps.length);
     for (const [i, expectedDapp] of expectedDApps.entries()) {
       await AuthorizedDAppsPage.dAppLogos[i].waitForDisplayed({ reverse: !expectedDApps[i].hasLogo });
@@ -120,6 +141,85 @@ class DAppConnectorAssert {
       await expect(await AuthorizedDAppsPage.dAppUrls[i].getText()).to.equal(expectedDapp.url);
       await AuthorizedDAppsPage.dAppRemoveButtons[i].waitForDisplayed();
     }
+  }
+
+  async assertSeeConfirmTransactionPage(
+    expectedDApp: ExpectedDAppDetails,
+    expectedTransactionData: ExpectedTransactionData
+  ) {
+    await this.assertSeeHeader();
+    await this.assertSeeTitleAndDappDetails('dapp.confirm.header', expectedDApp);
+    await ConfirmTransactionPage.transactionTypeTitle.waitForDisplayed();
+    await expect(await ConfirmTransactionPage.transactionTypeTitle.getText()).to.equal(
+      await t('dapp.confirm.details.header')
+    );
+    await ConfirmTransactionPage.transactionType.waitForDisplayed();
+    await expect(await ConfirmTransactionPage.transactionType.getText()).to.equal(
+      expectedTransactionData.typeOfTransaction
+    );
+
+    await ConfirmTransactionPage.transactionAmountTitle.waitForDisplayed();
+    await expect(await ConfirmTransactionPage.transactionAmountTitle.getText()).to.equal(
+      await t('dapp.confirm.details.amount')
+    );
+
+    await ConfirmTransactionPage.transactionAmountValue.waitForDisplayed();
+    await expect(await ConfirmTransactionPage.transactionAmountValue.getText()).to.equal(
+      expectedTransactionData.amountADA
+    );
+
+    await ConfirmTransactionPage.transactionAmountFee.waitForDisplayed();
+
+    if (expectedTransactionData.amountAsset && expectedTransactionData.amountAsset !== '0') {
+      await ConfirmTransactionPage.transactionAmountAsset.waitForDisplayed();
+      await expect(await ConfirmTransactionPage.transactionAmountAsset.getText()).to.equal(
+        expectedTransactionData.amountAsset
+      );
+    }
+
+    await ConfirmTransactionPage.transactionRecipientTitle.waitForDisplayed();
+    await expect(await ConfirmTransactionPage.transactionRecipientTitle.getText()).to.equal(
+      await t('dapp.confirm.details.recepient')
+    );
+    await expect(await ConfirmTransactionPage.transactionRecipientAddress.getText()).to.contain(
+      expectedTransactionData.recipientAddress.slice(-10)
+    );
+
+    await ConfirmTransactionPage.confirmButton.waitForDisplayed();
+    await expect(await ConfirmTransactionPage.confirmButton.getText()).to.equal(await t('dapp.confirm.btn.confirm'));
+
+    await ConfirmTransactionPage.cancelButton.waitForDisplayed();
+    await expect(await ConfirmTransactionPage.cancelButton.getText()).to.equal(await t('dapp.confirm.btn.cancel'));
+  }
+
+  async assertSeeSignTransactionPage() {
+    await this.assertSeeHeader();
+    await SignTransactionPage.passwordInput.container.waitForDisplayed();
+    await SignTransactionPage.confirmButton.waitForDisplayed();
+    await expect(await SignTransactionPage.confirmButton.getText()).to.equal(await t('dapp.confirm.btn.confirm'));
+    await SignTransactionPage.cancelButton.waitForDisplayed();
+    await expect(await SignTransactionPage.cancelButton.getText()).to.equal(await t('dapp.confirm.btn.cancel'));
+  }
+
+  async assertSeeAllDonePage() {
+    await this.assertSeeHeader();
+    await DAppTransactionAllDonePage.image.waitForDisplayed();
+
+    await DAppTransactionAllDonePage.heading.waitForDisplayed();
+    await expect(await DAppTransactionAllDonePage.heading.getText()).to.equal(
+      await t('browserView.transaction.success.youCanSafelyCloseThisPanel')
+    );
+
+    await DAppTransactionAllDonePage.description.waitForDisplayed();
+    await expect(await DAppTransactionAllDonePage.description.getText()).to.equal(
+      await t('core.dappTransaction.signedSuccessfully')
+    );
+
+    await DAppTransactionAllDonePage.closeButton.waitForDisplayed();
+    await expect(await DAppTransactionAllDonePage.closeButton.getText()).to.equal(await t('general.button.close'));
+
+    Logger.log('saving tx hash: null'); // TODO save proper hash once it's added to the all done page
+    testContext.save('txHashValue', false);
   }
 }
 

--- a/packages/e2e-tests/src/assert/tokensPageAssert.ts
+++ b/packages/e2e-tests/src/assert/tokensPageAssert.ts
@@ -142,7 +142,12 @@ class TokensPageAssert {
     }
   }
 
-  async assertSeeValueSubtracted(tokenName: string, subtractedAmount: string, fee: string, mode: 'extended' | 'popup') {
+  async assertSeeValueSubtractedAda(
+    tokenName: string,
+    subtractedAmount: string,
+    fee: string,
+    mode: 'extended' | 'popup'
+  ) {
     const tokensPage = new TokensPage();
     const expectedValue =
       Number.parseFloat(await testContext.load(`${Asset.getByName(tokenName).ticker}tokenBalance`)) -
@@ -155,6 +160,23 @@ class TokensPageAssert {
         (await tokensPage.getTokenTableItemValueByName(tokenName, mode)) === expectedValueRounded + 0.01 ||
         (await tokensPage.getTokenTableItemValueByName(tokenName, mode)) === expectedValueRounded - 0.01 ||
         (await tokensPage.getTokenTableItemValueByName(tokenName, mode)) === expectedValueRounded,
+      {
+        timeout: 30_000,
+        interval: 3000,
+        timeoutMsg: `failed while waiting for ${tokenName} value update`
+      }
+    );
+  }
+
+  async assertSeeValueSubtractedAsset(tokenName: string, subtractedAmount: string, mode: 'extended' | 'popup') {
+    const tokensPage = new TokensPage();
+    const expectedValue =
+      Number.parseFloat(await testContext.load(`${Asset.getByName(tokenName).ticker}tokenBalance`)) -
+      Number.parseFloat(subtractedAmount);
+    const expectedValueRounded = Number.parseFloat(expectedValue.toFixed(2));
+    Logger.log(`waiting for token: ${tokenName} with value: ${expectedValueRounded}`);
+    await browser.waitUntil(
+      async () => (await tokensPage.getTokenTableItemValueByName(tokenName, mode)) === expectedValueRounded,
       {
         timeout: 30_000,
         interval: 3000,

--- a/packages/e2e-tests/src/assert/transactionDetailsAssert.ts
+++ b/packages/e2e-tests/src/assert/transactionDetailsAssert.ts
@@ -5,7 +5,7 @@ import webTester from '../actor/webTester';
 import { expect } from 'chai';
 import testContext from '../utils/testContext';
 
-type ExpectedTransactionDetails = {
+export type ExpectedTransactionDetails = {
   transactionDescription: string;
   hash?: string;
   transactionData?: transactionData[];
@@ -40,7 +40,7 @@ class TransactionsDetailsAssert {
     );
     if (expectedTransactionDetails.hash) {
       await expect(await transactionsDetails.transactionDetailsHash.getText()).to.equal(
-        expectedTransactionDetails.hash
+        String(expectedTransactionDetails.hash)
       );
     }
     await expect(

--- a/packages/e2e-tests/src/elements/dappConnector/authorizeDAppPage.ts
+++ b/packages/e2e-tests/src/elements/dappConnector/authorizeDAppPage.ts
@@ -2,42 +2,13 @@
 import Banner from '../banner';
 import { ChainablePromiseElement } from 'webdriverio';
 import { ChainablePromiseArray } from 'webdriverio/build/types';
+import CommonDappPageElements from './commonDappPageElements';
 
-class AuthorizeDAppPage {
-  private HEADER_LOGO = '[data-testid="header-logo"]';
-  private BETA_PILL = '[data-testid="beta-pill"]';
-  private PAGE_TITLE = '[data-testid="layout-title"]';
-  private DAPP_LOGO = '[data-testid="dapp-info-logo"]';
-  private DAPP_NAME = '[data-testid="dapp-info-name"]';
-  private DAPP_URL = '[data-testid="dapp-info-url"]';
+class AuthorizeDAppPage extends CommonDappPageElements {
   private PERMISSIONS_TITLE = '[data-testid="authorize-dapp-title"]';
   private PERMISSIONS_LIST = '[data-testid="authorize-dapp-permissions"]';
   private AUTHORIZE_BUTTON = '[data-testid="connect-authorize-button"]';
   private CANCEL_BUTTON = '[data-testid="connect-cancel-button"]';
-
-  get headerLogo(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(this.HEADER_LOGO);
-  }
-
-  get betaPill(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(this.BETA_PILL);
-  }
-
-  get pageTitle(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(this.PAGE_TITLE);
-  }
-
-  get dAppLogo(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(this.DAPP_LOGO);
-  }
-
-  get dAppName(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(this.DAPP_NAME);
-  }
-
-  get dAppUrl(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(this.DAPP_URL);
-  }
 
   get banner(): typeof Banner {
     return Banner;

--- a/packages/e2e-tests/src/elements/dappConnector/commonDappPageElements.ts
+++ b/packages/e2e-tests/src/elements/dappConnector/commonDappPageElements.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-undef */
+import { ChainablePromiseElement } from 'webdriverio';
+
+class CommonDappPageElements {
+  private HEADER_LOGO = '[data-testid="header-logo"]';
+  private BETA_PILL = '[data-testid="beta-pill"]';
+  private PAGE_TITLE = '[data-testid="layout-title"]';
+  private DAPP_LOGO = '[data-testid="dapp-info-logo"]';
+  private DAPP_NAME = '[data-testid="dapp-info-name"]';
+  private DAPP_URL = '[data-testid="dapp-info-url"]';
+
+  get headerLogo(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.HEADER_LOGO);
+  }
+
+  get betaPill(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.BETA_PILL);
+  }
+
+  get pageTitle(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.PAGE_TITLE);
+  }
+
+  get dAppLogo(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.DAPP_LOGO);
+  }
+
+  get dAppName(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.DAPP_NAME);
+  }
+
+  get dAppUrl(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.DAPP_URL);
+  }
+}
+
+export default CommonDappPageElements;

--- a/packages/e2e-tests/src/elements/dappConnector/confirmTransactionPage.ts
+++ b/packages/e2e-tests/src/elements/dappConnector/confirmTransactionPage.ts
@@ -1,0 +1,58 @@
+/* eslint-disable no-undef */
+import { ChainablePromiseElement } from 'webdriverio';
+import CommonDappPageElements from './commonDappPageElements';
+
+class ConfirmTransactionPage extends CommonDappPageElements {
+  private TRANSACTION_TYPE_TITLE = '[data-testid="dapp-transaction-title"]';
+  private TRANSACTION_TYPE = '[data-testid="dapp-transaction-type"]';
+  private TRANSACTION_AMOUNT_TITLE = '[data-testid="dapp-transaction-amount-title"]';
+  private TRANSACTION_AMOUNT_VALUE = '[data-testid="dapp-transaction-amount-value"]';
+  private TRANSACTION_AMOUNT_FEE = '[data-testid="dapp-transaction-amount-fee"]';
+  private TRANSACTION_AMOUNT_ASSET = '[data-testid="dapp-transaction-asset"]';
+  private TRANSACTION_RECIPIENT_TITLE = '[data-testid="dapp-transaction-recipient-title"]';
+  private TRANSACTION_RECIPIENT_ADDRESS = '[data-testid="dapp-transaction-recipient-address"]';
+  private CONFIRM_BUTTON = '[data-testid="dapp-transaction-confirm"]';
+  private CANCEL_BUTTON = '[data-testid="dapp-transaction-cancel"]';
+
+  get transactionTypeTitle(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TRANSACTION_TYPE_TITLE);
+  }
+
+  get transactionType(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TRANSACTION_TYPE);
+  }
+
+  get transactionAmountTitle(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TRANSACTION_AMOUNT_TITLE);
+  }
+
+  get transactionAmountValue(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TRANSACTION_AMOUNT_VALUE);
+  }
+
+  get transactionAmountFee(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TRANSACTION_AMOUNT_FEE);
+  }
+
+  get transactionAmountAsset(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TRANSACTION_AMOUNT_ASSET);
+  }
+
+  get transactionRecipientTitle(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TRANSACTION_RECIPIENT_TITLE);
+  }
+
+  get transactionRecipientAddress(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TRANSACTION_RECIPIENT_ADDRESS);
+  }
+
+  get confirmButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CONFIRM_BUTTON);
+  }
+
+  get cancelButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CANCEL_BUTTON);
+  }
+}
+
+export default new ConfirmTransactionPage();

--- a/packages/e2e-tests/src/elements/dappConnector/dAppTransactionAllDonePage.ts
+++ b/packages/e2e-tests/src/elements/dappConnector/dAppTransactionAllDonePage.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-undef */
+import { ChainablePromiseElement } from 'webdriverio';
+
+class DAppTransactionAllDonePage {
+  private IMAGE = '[data-testid="dapp-sign-tx-success-image"]';
+  private HEADING = '[data-testid="dapp-sign-tx-success-heading"]';
+  private DESCRIPTION = '[data-testid="dapp-sign-tx-success-description"]';
+  private CLOSE_BUTTON = '[data-testid="dapp-sign-tx-success-close-button"]';
+
+  get image(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.IMAGE);
+  }
+
+  get heading(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.HEADING);
+  }
+
+  get description(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.DESCRIPTION);
+  }
+
+  get closeButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CLOSE_BUTTON);
+  }
+}
+
+export default new DAppTransactionAllDonePage();

--- a/packages/e2e-tests/src/elements/dappConnector/signTransactionPage.ts
+++ b/packages/e2e-tests/src/elements/dappConnector/signTransactionPage.ts
@@ -1,0 +1,28 @@
+/* eslint-disable no-undef */
+import { ChainablePromiseElement } from 'webdriverio';
+import CommonDappPageElements from './commonDappPageElements';
+import PasswordInput from '../passwordInput';
+
+class SignTransactionPage extends CommonDappPageElements {
+  private DESCRIPTION = '[data-testid="sign-transaction-description"]';
+  private CONFIRM_BUTTON = '[data-testid="sign-transaction-confirm"]';
+  private CANCEL_BUTTON = '[data-testid="sign-transaction-cancel"]';
+
+  get description(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.DESCRIPTION);
+  }
+
+  get passwordInput(): typeof PasswordInput {
+    return PasswordInput;
+  }
+
+  get confirmButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CONFIRM_BUTTON);
+  }
+
+  get cancelButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CANCEL_BUTTON);
+  }
+}
+
+export default new SignTransactionPage();

--- a/packages/e2e-tests/src/elements/dappConnector/testDAppPage.ts
+++ b/packages/e2e-tests/src/elements/dappConnector/testDAppPage.ts
@@ -21,7 +21,8 @@ class TestDAppPage {
   private SEND_TOKEN_VALUE_INPUT = '[data-testid="send-token-value-input"]';
   private SEND_TOKEN_POLICY_ID = '[data-testid="send-token-asset-policy-id"]';
   private SEND_TOKEN_ASSET_NAME = '[data-testid="send-token-asset-name-hex"]';
-  private RUN_BUTTON = '[data-testid="run-button"]';
+  private SEND_ADA_RUN_BUTTON = '[data-testid="send-ada-run-button"]';
+  private SEND_TOKEN_RUN_BUTTON = '[data-testid="send-token-run-button"]';
 
   get walletItem(): ChainablePromiseElement<WebdriverIO.Element> {
     return $(this.WALLET_ITEM);
@@ -103,8 +104,12 @@ class TestDAppPage {
     return $(this.SEND_TOKEN_ASSET_NAME);
   }
 
-  get runButton(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(this.RUN_BUTTON);
+  get sendAdaRunButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.SEND_ADA_RUN_BUTTON);
+  }
+
+  get sendTokenRunButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.SEND_TOKEN_RUN_BUTTON);
   }
 }
 

--- a/packages/e2e-tests/src/features/DAppConnector.feature
+++ b/packages/e2e-tests/src/features/DAppConnector.feature
@@ -36,4 +36,4 @@ Feature: DAppConnector - Common
     And I switch to window with Lace
     And I close all remaining tabs except current one
     And I open test DApp
-    Then I don't see DApp authorization window
+    Then I don't see DApp window

--- a/packages/e2e-tests/src/features/e2e/SendTransactionBundlesE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/SendTransactionBundlesE2E.feature
@@ -32,7 +32,7 @@ Feature: Send Transaction bundles - E2E
       | Subtitle: "The transaction will complete..." |
     When I close the drawer by clicking close button
     And I navigate to Tokens extended page
-    Then the sent amount of: 4.50 with fee: saved for token "Cardano" is subtracted from the total balance in extended mode
+    Then the sent amount of: "4.50" with "saved" fee for token "Cardano" is subtracted from the total balance in extended mode
     When I navigate to Transactions extended page
     Then the Sent transaction is displayed with value: "4.50 tADA, 0.2333 LaceCoin3, 3 LaceCoin , +1" and tokens count 4
     And I click and open recent transactions details until find transaction with correct hash

--- a/packages/e2e-tests/src/features/e2e/SendTransactionDappE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/SendTransactionDappE2E.feature
@@ -1,0 +1,60 @@
+@SendTransactionDapp-E2E @Testnet
+Feature: Send Transactions from Dapp - E2E
+
+  Background:
+    Given Wallet is synced
+
+  @LW-3761 @Testnet
+  Scenario: Send ADA from DApp E2E
+    And I save token: "Cardano" balance in extended mode
+    And I open and authorize test DApp with "Only once" setting
+    When I click "Send ADA" "Run" button in test DApp
+    Then I see DApp connector "Confirm transaction" page with: "3.00 ADA" and: "0" assets
+    And I save fee value on DApp "Confirm transaction" page
+    And I click "Confirm" button on "Confirm transaction" page
+    And I see DApp connector "Sign transaction" page
+    And I fill correct password
+    And I click "Confirm" button on "Sign transaction" page
+    And I see DApp connector "All done" page
+    And I click "Close" button on DApp "All done" page
+    And I don't see DApp window
+    And I switch to window with Lace
+    And I navigate to Tokens extended page
+    Then the sent amount of: "3" with "DApp transaction" fee for token "Cardano" is subtracted from the total balance in extended mode
+    When I navigate to Transactions extended page
+    Then the Sent transaction is displayed with value: "3.00 tADA" and tokens count 1
+    And I click on a transaction: 1
+    Then The Tx details are displayed as "package.core.transactionDetailBrowser.sent" for ADA with value: 3.00 and wallet: "WalletReceiveSimpleTransactionE2E" address
+    When I open wallet: "WalletReceiveSimpleTransactionE2E" in: extended mode
+    And I navigate to Transactions extended page
+    Then the Received transaction is displayed with value: "3.00 tADA" and tokens count 1
+    And I click on a transaction: 1
+    Then The Tx details are displayed as "package.core.transactionDetailBrowser.received" for ADA with value: 3.00 and wallet: "WalletSendSimpleTransactionE2E" address
+
+  @LW-6797 @Testnet
+  Scenario: Send Token from DApp E2E
+    And I save token: "LaceCoin2" balance in extended mode
+    And I open and authorize test DApp with "Only once" setting
+    And I click "Send Token" button in test DApp
+    When I click "Send Token" "Run" button in test DApp
+    Then I see DApp connector "Confirm transaction" page with: "1.38 ADA" and: "2 LaceCoin2" assets
+    And I save fee value on DApp "Confirm transaction" page
+    And I click "Confirm" button on "Confirm transaction" page
+    And I see DApp connector "Sign transaction" page
+    And I fill correct password
+    And I click "Confirm" button on "Sign transaction" page
+    And I see DApp connector "All done" page
+    And I click "Close" button on DApp "All done" page
+    And I don't see DApp window
+    And I switch to window with Lace
+    And I navigate to Tokens extended page
+    Then the sent amount of: "2" for token "LaceCoin2" is subtracted from the total balance in extended mode
+    When I navigate to Transactions extended page
+    Then the Sent transaction is displayed with value: "1.38 tADA, 2 LaceCoin2" and tokens count 2
+    And I click on a transaction: 1
+    Then The Tx details are displayed as "package.core.transactionDetailBrowser.sent" for ADA with value: "1.38" and LaceCoin2 with value: "2" and wallet: "WalletReceiveSimpleTransactionE2E" address
+    When I open wallet: "WalletReceiveSimpleTransactionE2E" in: extended mode
+    And I navigate to Transactions extended page
+    Then the Received transaction is displayed with value: "1.38 tADA" and tokens count 2
+    And I click on a transaction: 1
+    Then The Tx details are displayed as "package.core.transactionDetailBrowser.received" for ADA with value: "1.38" and LaceCoin2 with value: "2" and wallet: "WalletSendSimpleTransactionE2E" address

--- a/packages/e2e-tests/src/features/e2e/SendTransactionSimpleExtendedE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/SendTransactionSimpleExtendedE2E.feature
@@ -23,7 +23,7 @@ Feature: Send Simple Transactions - Extended view - E2E
       | Button: "Close"                              |
     When I close the drawer by clicking close button
     And I navigate to Tokens extended page
-    Then the sent amount of: 1.123 with fee: saved for token "Cardano" is subtracted from the total balance in extended mode
+    Then the sent amount of: "1.123" with "saved" fee for token "Cardano" is subtracted from the total balance in extended mode
     When I navigate to Transactions extended page
     Then the Sent transaction is displayed with value: "1.12 tADA" and tokens count 1
     And I click and open recent transactions details until find transaction with correct hash

--- a/packages/e2e-tests/src/features/e2e/SendTransactionSimplePopupE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/SendTransactionSimplePopupE2E.feature
@@ -23,7 +23,7 @@ Feature: Send Simple Transactions - Popup view - E2E
       | Button: "Close"                              |
     When I close the drawer by clicking close button
     And I navigate to Tokens popup page
-    Then the sent amount of: 1.123 with fee: saved for token "Cardano" is subtracted from the total balance in popup mode
+    Then the sent amount of: "1.123" with "saved" fee for token "Cardano" is subtracted from the total balance in popup mode
     When I navigate to Transactions popup page
     Then the Sent transaction is displayed with value: "1.12 tADA" and tokens count 1
     And I click and open recent transactions details until find transaction with correct hash

--- a/packages/e2e-tests/src/hooks/beforeTagHooks.ts
+++ b/packages/e2e-tests/src/hooks/beforeTagHooks.ts
@@ -56,7 +56,7 @@ Before(
 );
 
 Before(
-  { tags: '@SendSimpleTransaction-Extended-E2E' },
+  { tags: '@SendSimpleTransaction-Extended-E2E or @SendTransactionDapp-E2E' },
   async () => await extendedViewWalletInitialization(TestWalletName.WalletSendSimpleTransactionE2E)
 );
 

--- a/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
@@ -8,11 +8,13 @@ import AuthorizedDappsPage from '../elements/dappConnector/authorizedDAppsPage';
 import popupView from '../page/popupView';
 import ToastMessage from '../elements/toastMessage';
 import RemoveDAppModal from '../elements/dappConnector/removeDAppModal';
+import testContext from '../utils/testContext';
+import ConfirmTransactionPage from '../elements/dappConnector/confirmTransactionPage';
 
 class DAppConnectorPageObject {
   TEST_DAPP_URL = this.getTestDAppUrl();
   TEST_DAPP_NAME = 'React App';
-  DAPP_AUTHORIZATION_MODAL_HANDLE = 'dappConnector.html';
+  DAPP_CONNECTOR_WINDOW_HANDLE = 'dappConnector.html';
 
   getTestDAppUrl(): string {
     if (process.env.TEST_DAPP_URL) return process.env.TEST_DAPP_URL;
@@ -23,9 +25,13 @@ class DAppConnectorPageObject {
     await browser.newWindow(this.TEST_DAPP_URL);
   }
 
-  async waitAndSwitchToAuthorizationWindow() {
+  async waitAndSwitchToDAppConnectorWindow() {
     await waitUntilExpectedNumberOfHandles(3);
-    await browser.switchWindow(this.DAPP_AUTHORIZATION_MODAL_HANDLE);
+    await browser.switchWindow(this.DAPP_CONNECTOR_WINDOW_HANDLE);
+  }
+
+  async switchToTestDAppWindow() {
+    await browser.switchWindow(this.TEST_DAPP_NAME);
   }
 
   async clickButtonInDAppAuthorizationWindow(button: 'Authorize' | 'Cancel') {
@@ -52,6 +58,12 @@ class DAppConnectorPageObject {
 
       await ToastMessage.container.waitForDisplayed();
     }
+  }
+
+  async saveDappTransactionFeeValue() {
+    let feeValue = await ConfirmTransactionPage.transactionAmountFee.getText();
+    feeValue = feeValue.replace(' ADA', '').replace('Fee: ', '');
+    await testContext.save('feeValueDAppTx', feeValue);
   }
 }
 

--- a/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
+++ b/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
@@ -1,22 +1,55 @@
 import { Then, When } from '@cucumber/cucumber';
-import DAppConnectorAssert, { ExpectedAuthorizedDAppDetails } from '../assert/dAppConnectorAssert';
+import DAppConnectorAssert, { ExpectedDAppDetails, ExpectedTransactionData } from '../assert/dAppConnectorAssert';
 import DAppConnectorPageObject from '../pageobject/dAppConnectorPageObject';
 import { browser } from '@wdio/globals';
 import { waitUntilExpectedNumberOfHandles } from '../utils/window';
+import { getTestWallet } from '../support/walletConfiguration';
+import ConfirmTransactionPage from '../elements/dappConnector/confirmTransactionPage';
+import SignTransactionPage from '../elements/dappConnector/signTransactionPage';
+import AllDonePage from '../elements/dappConnector/dAppTransactionAllDonePage';
+import TestDAppPage from '../elements/dappConnector/testDAppPage';
+
+const testDAppDetails: ExpectedDAppDetails = {
+  hasLogo: true,
+  name: DAppConnectorPageObject.TEST_DAPP_NAME,
+  url: DAppConnectorPageObject.TEST_DAPP_URL
+};
 
 When(/^I open test DApp$/, async () => {
   await DAppConnectorPageObject.openTestDApp();
 });
 
 Then(/^I see DApp authorization window$/, async () => {
-  await DAppConnectorPageObject.waitAndSwitchToAuthorizationWindow();
-  await DAppConnectorAssert.assertSeeAuthorizeDAppPage(
-    DAppConnectorPageObject.TEST_DAPP_NAME,
-    DAppConnectorPageObject.TEST_DAPP_URL
-  );
+  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+  await DAppConnectorAssert.assertSeeAuthorizeDAppPage(testDAppDetails);
 });
 
-Then(/^I don't see DApp authorization window$/, async () => {
+Then(
+  /^I see DApp connector "Confirm transaction" page with: "([^"]*)" and: "([^"]*)" assets$/,
+  async (adaValue: string, assetValue: string) => {
+    await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+
+    const expectedTransactionData: ExpectedTransactionData = {
+      typeOfTransaction: 'Send',
+      amountADA: adaValue,
+      amountAsset: assetValue,
+      recipientAddress: getTestWallet('WalletReceiveSimpleTransactionE2E').address
+    };
+    await DAppConnectorAssert.assertSeeConfirmTransactionPage(testDAppDetails, expectedTransactionData);
+  }
+);
+
+Then(/^I see DApp connector "Sign transaction" page$/, async () => {
+  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+  await DAppConnectorAssert.assertSeeSignTransactionPage();
+});
+
+Then(/^I see DApp connector "All done" page$/, async () => {
+  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+  await DAppConnectorAssert.assertSeeAllDonePage();
+});
+
+Then(/^I don't see DApp window$/, async () => {
   await browser.pause(2000);
   await waitUntilExpectedNumberOfHandles(2);
 });
@@ -42,26 +75,72 @@ Then(/^I see "Authorized DApps" section empty state in (extended|popup) mode$/, 
 });
 
 Then(/^I see test DApp on the Authorized DApps list$/, async () => {
-  const expectedDapp: ExpectedAuthorizedDAppDetails = {
+  const expectedDApp: ExpectedDAppDetails = {
     hasLogo: true,
     name: DAppConnectorPageObject.TEST_DAPP_NAME,
     url: DAppConnectorPageObject.TEST_DAPP_URL.split('/')[2]
   };
-  await DAppConnectorAssert.assertSeeAuthorizedDAppsOnTheList([expectedDapp]);
+  await DAppConnectorAssert.assertSeeAuthorizedDAppsOnTheList([expectedDApp]);
 });
 
 When(/^I open and authorize test DApp with "(Always|Only once)" setting$/, async (mode: 'Always' | 'Only once') => {
   await DAppConnectorPageObject.openTestDApp();
 
-  await DAppConnectorPageObject.waitAndSwitchToAuthorizationWindow();
-  await DAppConnectorAssert.assertSeeAuthorizeDAppPage(
-    DAppConnectorPageObject.TEST_DAPP_NAME,
-    DAppConnectorPageObject.TEST_DAPP_URL
-  );
+  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+  await DAppConnectorAssert.assertSeeAuthorizeDAppPage(testDAppDetails);
   await DAppConnectorPageObject.clickButtonInDAppAuthorizationWindow('Authorize');
   await DAppConnectorPageObject.clickButtonInDAppAuthorizationModal(mode);
 });
 
 Then(/^I de-authorize all DApps in (extended|popup) mode$/, async (mode: 'extended' | 'popup') => {
   await DAppConnectorPageObject.deauthorizeAllDApps(mode);
+});
+
+Then(/^I click "(Send ADA|Send Token)" "Run" button in test DApp$/, async (runButton: 'Send ADA' | 'Send Token') => {
+  await DAppConnectorPageObject.switchToTestDAppWindow();
+  await browser.pause(1000);
+  switch (runButton) {
+    case 'Send ADA':
+      await TestDAppPage.sendAdaRunButton.click();
+      break;
+    case 'Send Token':
+      await TestDAppPage.sendTokenRunButton.click();
+      break;
+    default:
+      break;
+  }
+});
+
+Then(/^I click "(Send ADA|Send Token)" button in test DApp$/, async (buttonId: 'Send ADA' | 'Send Token') => {
+  await DAppConnectorPageObject.switchToTestDAppWindow();
+  switch (buttonId) {
+    case 'Send ADA':
+      await TestDAppPage.sendAdaOption.click();
+      break;
+    case 'Send Token':
+      await TestDAppPage.sendTokenOption.click();
+      break;
+    default:
+      break;
+  }
+});
+
+Then(/^I click "(Confirm|Cancel)" button on "Confirm transaction" page$/, async (button: 'Confirm' | 'Cancel') => {
+  button === 'Confirm'
+    ? await ConfirmTransactionPage.confirmButton.click()
+    : await ConfirmTransactionPage.cancelButton.click();
+});
+
+Then(/^I click "(Confirm|Cancel)" button on "Sign transaction" page$/, async (button: 'Confirm' | 'Cancel') => {
+  button === 'Confirm'
+    ? await SignTransactionPage.confirmButton.click()
+    : await SignTransactionPage.cancelButton.click();
+});
+
+Then(/^I click "Close" button on DApp "All done" page$/, async () => {
+  await AllDonePage.closeButton.click();
+});
+
+Then(/^I save fee value on DApp "Confirm transaction" page$/, async () => {
+  await DAppConnectorPageObject.saveDappTransactionFeeValue();
 });

--- a/packages/e2e-tests/src/steps/sendTransactionSimpleSteps.ts
+++ b/packages/e2e-tests/src/steps/sendTransactionSimpleSteps.ts
@@ -24,7 +24,7 @@ import indexedDB from '../fixture/indexedDB';
 import transactionBundleAssert from '../assert/transaction/transactionBundleAssert';
 import { getTestWallet } from '../support/walletConfiguration';
 import testContext from '../utils/testContext';
-import transactionDetailsAssert from '../assert/transactionDetailsAssert';
+import transactionDetailsAssert, { ExpectedTransactionDetails } from '../assert/transactionDetailsAssert';
 import { t } from '../utils/translationService';
 import nftsPageObject from '../pageobject/nftsPageObject';
 import transactionsPageObject from '../pageobject/transactionsPageObject';
@@ -368,10 +368,29 @@ When(/^I save fee value$/, async () => {
 Then(
   /^The Tx details are displayed as "([^"]*)" for ADA with value: ([^"]*) and wallet: "([^"]*)" address$/,
   async (type: string, adaValue: string, walletName: string) => {
-    const expectedTransactionDetails = {
+    const expectedTransactionDetails: ExpectedTransactionDetails = {
       transactionDescription: `${await t(type)}\n(1)`,
-      hash: String(testContext.load('txHashValue')),
+      hash: testContext.load('txHashValue'),
       transactionData: [{ ada: `${adaValue} ${Asset.CARDANO.ticker}`, address: getTestWallet(walletName).address }],
+      status: 'Success'
+    };
+    await transactionDetailsAssert.assertSeeTransactionDetails(expectedTransactionDetails);
+  }
+);
+
+Then(
+  /^The Tx details are displayed as "([^"]*)" for ADA with value: "([^"]*)" and LaceCoin2 with value: "([^"]*)" and wallet: "([^"]*)" address$/,
+  async (type: string, adaValue: string, laceCoin2Value: string, walletName: string) => {
+    const expectedTransactionDetails: ExpectedTransactionDetails = {
+      transactionDescription: `${await t(type)}\n(2)`,
+      hash: testContext.load('txHashValue'),
+      transactionData: [
+        {
+          ada: `${adaValue} ${Asset.CARDANO.ticker}`,
+          address: getTestWallet(walletName).address,
+          assets: [`${laceCoin2Value} LaceCoin2`]
+        }
+      ],
       status: 'Success'
     };
     await transactionDetailsAssert.assertSeeTransactionDetails(expectedTransactionDetails);

--- a/packages/e2e-tests/src/steps/tokensPageSteps.ts
+++ b/packages/e2e-tests/src/steps/tokensPageSteps.ts
@@ -143,10 +143,32 @@ Then(
 
 Then(
   // eslint-disable-next-line max-len
-  /^the sent amount of: ([^"]*) with fee: ([^"]*) for token "([^"]*)" is subtracted from the total balance in (extended|popup) mode$/,
-  async (subtractedAmount: string, fee: string, tokenName: string, mode: 'extended' | 'popup') => {
-    if (fee === 'saved') fee = await testContext.load('feeValue');
-    await tokensPageAssert.assertSeeValueSubtracted(tokenName, subtractedAmount, fee, mode);
+  /^the sent amount of: "([^"]*)" with "(saved|DApp transaction)" fee for token "([^"]*)" is subtracted from the total balance in (extended|popup) mode$/,
+  async (
+    subtractedAmount: string,
+    feeType: 'saved' | 'DApp transaction',
+    tokenName: string,
+    mode: 'extended' | 'popup'
+  ) => {
+    let fee: string;
+    switch (feeType) {
+      case 'saved':
+        fee = await testContext.load('feeValue');
+        break;
+      case 'DApp transaction':
+        fee = await testContext.load('feeValueDAppTx');
+        break;
+      default:
+        break;
+    }
+    await tokensPageAssert.assertSeeValueSubtractedAda(tokenName, subtractedAmount, fee, mode);
+  }
+);
+
+Then(
+  /^the sent amount of: "([^"]*)" for token "([^"]*)" is subtracted from the total balance in (extended|popup) mode$/,
+  async (subtractedAmount: string, tokenName: string, mode: 'extended' | 'popup') => {
+    await tokensPageAssert.assertSeeValueSubtractedAsset(tokenName, subtractedAmount, mode);
   }
 );
 


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/230/5189100007/index.html) for [a73beb03](https://github.com/input-output-hk/lace/pull/40/commits/a73beb03f29f064c15e7f3541caf82c9ffe2f8f9)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->