### PR TITLE
feat(extension): add corrupted data checks and error screen

### DIFF
--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -18,6 +18,7 @@ USE_NFT_FOLDERS=true
 USE_MULTI_CURRENCY=true
 USE_HIDE_MY_BALANCE=true
 USE_MULTI_DELEGATION_STAKING=false
+USE_DATA_CHECK=false
 
 # In App URLs
 CATALYST_GOOGLE_PLAY_URL=https://play.google.com/store/apps/details?id=io.iohk.vitvoting

--- a/apps/browser-extension-wallet/src/components/DataCheckContainer/CorruptedData.tsx
+++ b/apps/browser-extension-wallet/src/components/DataCheckContainer/CorruptedData.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { AppMode } from '@src/utils/constants';
+import { ResetDataError } from '@components/ResetDataError';
+
+export interface CorruptedDataProps {
+  appMode: AppMode;
+}
+
+export const CorruptedData = ({ appMode }: CorruptedDataProps): React.ReactElement => {
+  const { t } = useTranslation();
+
+  return (
+    <ResetDataError
+      appMode={appMode}
+      description={
+        <>
+          <div>{t('corruptedData.errorDescription')}</div>
+          <div>
+            <b>{t('corruptedData.actionDescription')}</b>
+          </div>
+        </>
+      }
+      title={<div>{t('corruptedData.title')}</div>}
+      buttonLabel={t('corruptedData.btn.confirm')}
+    />
+  );
+};

--- a/apps/browser-extension-wallet/src/components/DataCheckContainer/DataCheckContainer.tsx
+++ b/apps/browser-extension-wallet/src/components/DataCheckContainer/DataCheckContainer.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import { AppMode } from '@src/utils/constants';
+import { MainLoader } from '@components/MainLoader';
+import { CorruptedData } from './CorruptedData';
+import { DataCheckDispatcher, useDataCheck } from '@hooks/useDataCheck';
+
+const isFeatureEnabled = process.env.USE_DATA_CHECK === 'true';
+
+export interface DataCheckContainerProps {
+  children: React.ReactNode;
+  appMode: AppMode;
+  dataCheckDispatcher?: DataCheckDispatcher;
+}
+
+export const DataCheckContainer = ({
+  children,
+  appMode,
+  dataCheckDispatcher
+}: DataCheckContainerProps): React.ReactElement => {
+  const [dataCheckState, performDataCheck] = useDataCheck(dataCheckDispatcher);
+
+  useEffect(() => {
+    // Run only on mount
+    if (isFeatureEnabled) performDataCheck();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!isFeatureEnabled) return <>{children}</>;
+
+  if (dataCheckState.checkState !== 'checked') return <MainLoader />;
+  return dataCheckState.result.valid === false ? <CorruptedData appMode={appMode} /> : <>{children}</>;
+};

--- a/apps/browser-extension-wallet/src/components/DataCheckContainer/index.ts
+++ b/apps/browser-extension-wallet/src/components/DataCheckContainer/index.ts
@@ -1,0 +1,2 @@
+export * from './DataCheckContainer';
+export * from './CorruptedData';

--- a/apps/browser-extension-wallet/src/components/MigrationContainer/FailedMigration.tsx
+++ b/apps/browser-extension-wallet/src/components/MigrationContainer/FailedMigration.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@lace/common';
-import { ResultMessage } from '@components/ResultMessage';
-import styles from './FailedMigration.module.scss';
 import { AppMode } from '@src/utils/constants';
-import { WalletSetupLayout } from '@src/views/browser-view/components';
-import { useWalletManager } from '@hooks';
-import { useWalletStore } from '@src/stores';
-import { useBackgroundServiceAPIContext, useTheme } from '@providers';
+import { ResetDataError } from '@components/ResetDataError';
 
 export interface FailedMigrationProps {
   appMode: AppMode;
@@ -15,48 +9,25 @@ export interface FailedMigrationProps {
 
 export const FailedMigration = ({ appMode }: FailedMigrationProps): React.ReactElement => {
   const { t } = useTranslation();
-  const { deleteWallet } = useWalletManager();
-  const { walletManagerUi } = useWalletStore();
-  const { theme } = useTheme();
-  const backgroundService = useBackgroundServiceAPIContext();
-
-  const Layout = appMode === 'browser' ? WalletSetupLayout : React.Fragment;
-
-  const resetData = async () => {
-    if (walletManagerUi) await deleteWallet();
-    window.localStorage.clear();
-    window.localStorage.setItem('mode', theme.name);
-    await backgroundService.resetStorage();
-    // Reload app states with updated storage
-    window.location.reload();
-  };
 
   return (
-    <Layout>
-      <div className={styles.failedMigrationContainer} data-testid="failed-migration">
-        <ResultMessage
-          status="error"
-          title={
-            <>
-              <div>{t('migrations.failed.title')}</div>
-              <div>{t('migrations.failed.subtitle')}</div>
-            </>
-          }
-          description={
-            <>
-              <div>{t('migrations.failed.errorDescription')}</div>
-              <div>
-                <b>{t('migrations.failed.actionDescription')}</b>
-              </div>
-            </>
-          }
-        />
-        <div className={styles.failedMigrationButton}>
-          <Button onClick={resetData} className={styles.btn} size="large">
-            {t('migrations.failed.btn.confirm')}
-          </Button>
-        </div>
-      </div>
-    </Layout>
+    <ResetDataError
+      appMode={appMode}
+      title={
+        <>
+          <div>{t('migrations.failed.title')}</div>
+          <div>{t('migrations.failed.subtitle')}</div>
+        </>
+      }
+      description={
+        <>
+          <div>{t('migrations.failed.errorDescription')}</div>
+          <div>
+            <b>{t('migrations.failed.actionDescription')}</b>
+          </div>
+        </>
+      }
+      buttonLabel={t('migrations.failed.btn.confirm')}
+    />
   );
 };

--- a/apps/browser-extension-wallet/src/components/MigrationContainer/__tests__/MigrationContainer.test.tsx
+++ b/apps/browser-extension-wallet/src/components/MigrationContainer/__tests__/MigrationContainer.test.tsx
@@ -149,8 +149,9 @@ describe('MigrationContainer', () => {
 
         await waitFor(() => expect(queryByTestId('mock-child')).not.toBeInTheDocument());
         await waitFor(() => {
-          const failed = queryByTestId('failed-migration');
+          const failed = queryByTestId('reset-data-error');
           expect(failed).toBeInTheDocument();
+          expect(failed).toHaveTextContent('Data migration failed!');
         });
         expect(mockMigrations.applyMigrations).not.toHaveBeenCalled();
       });
@@ -160,27 +161,17 @@ describe('MigrationContainer', () => {
       beforeEach(async () => {
         await storage.local.set({ MIGRATION_STATE: { state: 'not-applied', from: '1.0.0', to: '2.0.0' } });
       });
-      test('in popup mode, renders MainLoader screen with applying update message and applies migrations', async () => {
+      test('renders MainLoader screen with loading message and tries to apply migrations', async () => {
         const { queryByTestId } = render(<MigrationContainerTest />);
 
         await waitFor(() => expect(queryByTestId('mock-child')).not.toBeInTheDocument());
         await waitFor(() => {
           const mainLoader = queryByTestId('main-loader');
           expect(mainLoader).toBeInTheDocument();
-          expect(mainLoader).toHaveTextContent('Applying update...');
+          expect(mainLoader).toHaveTextContent('Loading...');
         });
         await waitFor(() => expect(mockMigrations.migrationsRequirePassword).toHaveBeenCalled());
         await waitFor(() => expect(mockMigrations.applyMigrations).toHaveBeenCalled());
-      });
-      test('in browser mode, renders migration in progress screen and does not apply migrations', async () => {
-        const { queryByTestId } = render(<MigrationContainerTest appMode={APP_MODE_BROWSER} />);
-
-        await waitFor(() => expect(queryByTestId('mock-child')).not.toBeInTheDocument());
-        await waitFor(() => {
-          const inProgress = queryByTestId('migration-in-progress');
-          expect(inProgress).toBeInTheDocument();
-        });
-        await waitFor(() => expect(mockMigrations.applyMigrations).not.toHaveBeenCalled());
       });
     });
   });

--- a/apps/browser-extension-wallet/src/components/ResetDataError/ResetDataError.module.scss
+++ b/apps/browser-extension-wallet/src/components/ResetDataError/ResetDataError.module.scss
@@ -1,12 +1,12 @@
 @import '../../../../../packages/common/src/ui/styles/theme.scss';
 
-.failedMigrationContainer {
+.resetDataErrorContainer {
   @include flex-center;
   height: 100%;
   flex-direction: column;
   gap: size_unit(2);
 }
 
-.failedMigrationButton {
+.resetDataErrorButton {
   margin-top: 20px;
 }

--- a/apps/browser-extension-wallet/src/components/ResetDataError/ResetDataError.tsx
+++ b/apps/browser-extension-wallet/src/components/ResetDataError/ResetDataError.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Button } from '@lace/common';
+import { ResultMessage } from '@components/ResultMessage';
+import styles from './ResetDataError.module.scss';
+import { AppMode } from '@src/utils/constants';
+import { WalletSetupLayout } from '@src/views/browser-view/components';
+import { useWalletManager } from '@hooks';
+import { useWalletStore } from '@src/stores';
+import { useBackgroundServiceAPIContext, useTheme } from '@providers';
+
+export interface ResetDataErrorProps {
+  appMode: AppMode;
+  title: React.ReactNode;
+  description: React.ReactNode;
+  buttonLabel: string;
+}
+
+export const ResetDataError = ({
+  appMode,
+  title,
+  description,
+  buttonLabel
+}: ResetDataErrorProps): React.ReactElement => {
+  const { deleteWallet } = useWalletManager();
+  const { walletManagerUi } = useWalletStore();
+  const { theme } = useTheme();
+  const backgroundService = useBackgroundServiceAPIContext();
+
+  const Layout = appMode === 'browser' ? WalletSetupLayout : React.Fragment;
+
+  const resetData = async () => {
+    if (walletManagerUi) await deleteWallet();
+    window.localStorage.clear();
+    window.localStorage.setItem('mode', theme.name);
+    await backgroundService.resetStorage();
+    // Reload app states with updated storage
+    window.location.reload();
+  };
+
+  return (
+    <Layout>
+      <div className={styles.resetDataErrorContainer} data-testid="reset-data-error">
+        <ResultMessage status="error" title={title} description={description} />
+        <div className={styles.resetDataErrorButton}>
+          <Button onClick={resetData} className={styles.btn} size="large">
+            {buttonLabel}
+          </Button>
+        </div>
+      </div>
+    </Layout>
+  );
+};

--- a/apps/browser-extension-wallet/src/components/ResetDataError/index.ts
+++ b/apps/browser-extension-wallet/src/components/ResetDataError/index.ts
@@ -1,0 +1,1 @@
+export * from './ResetDataError';

--- a/apps/browser-extension-wallet/src/features/unlock-wallet/components/UnlockWalletContainer.tsx
+++ b/apps/browser-extension-wallet/src/features/unlock-wallet/components/UnlockWalletContainer.tsx
@@ -13,6 +13,7 @@ export interface UnlockWalletContainerProps {
   validateMnemonic?: boolean;
 }
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export const UnlockWalletContainer = ({ validateMnemonic }: UnlockWalletContainerProps): React.ReactElement => {
   const { unlockWallet, lockWallet, deleteWallet } = useWalletManager();
   const { environmentName, setKeyAgentData } = useWalletStore();
@@ -27,7 +28,8 @@ export const UnlockWalletContainer = ({ validateMnemonic }: UnlockWalletContaine
   const loadWallet = useCallback(async () => {
     if (unlocked) {
       const keyAgentData = unlocked[environmentName]?.keyAgentData;
-      saveValueInLocalStorage({ key: 'keyAgentData', value: keyAgentData });
+      // eslint-disable-next-line unicorn/no-null
+      saveValueInLocalStorage({ key: 'keyAgentData', value: keyAgentData ?? null });
       await backgroundService.setBackgroundStorage({ keyAgentsByChain: unlocked });
       setKeyAgentData(keyAgentData);
     }
@@ -59,7 +61,6 @@ export const UnlockWalletContainer = ({ validateMnemonic }: UnlockWalletContaine
     try {
       const decrypted = await unlockWallet(password);
       setIsValidPassword(true);
-      // TODO: check comment in `useWalletManager` > `unlockWallet` [LW-5449]
       if (decrypted) setUnlocked(decrypted);
     } catch {
       setIsValidPassword(false);

--- a/apps/browser-extension-wallet/src/hooks/__tests__/useDataCheck.test.ts
+++ b/apps/browser-extension-wallet/src/hooks/__tests__/useDataCheck.test.ts
@@ -1,0 +1,375 @@
+/* eslint-disable unicorn/no-null */
+/* eslint-disable sonarjs/no-duplicate-string */
+import { storage } from 'webextension-polyfill';
+import { Wallet } from '@lace/cardano';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useDataCheck } from '@hooks/useDataCheck';
+import { WalletStorage } from '@src/types';
+import { getValueFromLocalStorage, saveValueInLocalStorage } from '@src/utils/local-storage';
+import { buildMockProviders, IMockProviders } from '@src/utils/mocks/context-providers';
+import * as DataValidators from '@utils/data-validators';
+import { mockKeyAgentDataTestnet, mockKeyAgentsByChain } from '@src/utils/mocks/test-helpers';
+
+const setStorageHelper = async ({
+  withLock,
+  withKeyAgentData,
+  isHardwareWallet,
+  withWalletStorage,
+  withAppSettings,
+  withKeyAgentsByChain
+}: {
+  withLock?: boolean;
+  withKeyAgentData?: boolean;
+  isHardwareWallet?: boolean;
+  withWalletStorage?: boolean;
+  withAppSettings?: boolean;
+  withKeyAgentsByChain?: boolean;
+}) => {
+  if (withLock) saveValueInLocalStorage({ key: 'lock', value: !isHardwareWallet ? Buffer.from('test') : null });
+  if (withKeyAgentData) {
+    saveValueInLocalStorage({
+      key: 'keyAgentData',
+      value: !isHardwareWallet
+        ? mockKeyAgentDataTestnet
+        : {
+            ...mockKeyAgentDataTestnet,
+            __typename: Wallet.KeyManagement.KeyAgentType.Ledger,
+            communicationType: Wallet.KeyManagement.CommunicationType.Web
+          }
+    });
+  }
+  if (withWalletStorage) saveValueInLocalStorage({ key: 'wallet', value: { name: 'test wallet' } });
+  if (withAppSettings) saveValueInLocalStorage({ key: 'appSettings', value: { chainName: 'Preview' } });
+  if (withKeyAgentsByChain) {
+    await storage.local.set({ BACKGROUND_STORAGE: { keyAgentsByChain: mockKeyAgentsByChain } });
+  }
+};
+
+describe('useDataCheck', () => {
+  let MockProviders: IMockProviders;
+
+  beforeAll(async () => {
+    ({ MockProviders } = await buildMockProviders({ walletStore: { environmentName: 'Preview' } }));
+  });
+
+  it('returns initial state as not-checked and data check function', () => {
+    const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+    const [dataCheckState, checker] = result.current;
+
+    expect(dataCheckState).toEqual({ checkState: 'not-checked' });
+    expect(typeof checker).toEqual('function');
+  });
+
+  it('overrides the data check function', async () => {
+    const fakeChecker = jest.fn();
+    const { result } = renderHook(() => useDataCheck(fakeChecker), { wrapper: MockProviders });
+    const [, checker] = result.current;
+    await checker();
+
+    expect(fakeChecker).toHaveBeenCalled();
+  });
+
+  describe('state dispatcher', () => {
+    it('transitions to "checking" state', async () => {
+      const fakeChecker = jest.fn().mockImplementation(async (dispatch) => {
+        dispatch({ type: 'checking' });
+      });
+      const { result } = renderHook(() => useDataCheck(fakeChecker), { wrapper: MockProviders });
+      expect(result.current[0]).toEqual({ checkState: 'not-checked' });
+
+      act(() => {
+        result.current[1]();
+      });
+      expect(result.current[0]).toEqual({ checkState: 'checking' });
+    });
+
+    it('transitions to "checked" state with a valid result', async () => {
+      const fakeChecker = jest.fn().mockImplementation(async (dispatch) => {
+        dispatch({ type: 'valid' });
+      });
+      const { result } = renderHook(() => useDataCheck(fakeChecker), { wrapper: MockProviders });
+      expect(result.current[0]).toEqual({ checkState: 'not-checked' });
+
+      act(() => {
+        result.current[1]();
+      });
+      expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+    });
+
+    it('transitions to "error" state with an invalid result', async () => {
+      const fakeChecker = jest.fn().mockImplementation(async (dispatch) => {
+        dispatch({ type: 'error', error: 'Invalid data check' });
+      });
+      const { result } = renderHook(() => useDataCheck(fakeChecker), { wrapper: MockProviders });
+      expect(result.current[0]).toEqual({ checkState: 'not-checked' });
+
+      act(() => {
+        result.current[1]();
+      });
+      expect(result.current[0]).toEqual({
+        checkState: 'checked',
+        result: { valid: false, error: 'Invalid data check' }
+      });
+    });
+  });
+
+  describe('browser data checks', () => {
+    afterEach(async () => {
+      jest.restoreAllMocks();
+      window.localStorage.clear();
+      await storage.local.clear();
+    });
+
+    describe('return a valid state', () => {
+      it('when no wallet created (empty storage)', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        await act(async () => {
+          await result.current[1]();
+        });
+
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+      });
+
+      it('when no wallet created, background storage is cleared', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({ withKeyAgentsByChain: true });
+        await act(async () => {
+          await result.current[1]();
+        });
+
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+        expect(await storage.local.get('BACKGROUND_STORAGE')).toEqual({});
+      });
+
+      it('for an unlocked wallet', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: true,
+          withKeyAgentData: true,
+          withKeyAgentsByChain: true,
+          withWalletStorage: true,
+          withAppSettings: true
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+      });
+
+      it('for an unlocked wallet, if keyAgentsByChain is missing, delete keyAgentData', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: true,
+          withKeyAgentData: true,
+          withKeyAgentsByChain: false,
+          withWalletStorage: true,
+          withAppSettings: true
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+        expect(getValueFromLocalStorage('keyAgentData')).toBeUndefined();
+      });
+
+      it('for a locked wallet', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: true,
+          withKeyAgentData: false,
+          withKeyAgentsByChain: false,
+          withWalletStorage: true,
+          withAppSettings: true
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+      });
+
+      it('for a hardware wallet', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: false,
+          withKeyAgentData: true,
+          isHardwareWallet: true,
+          withKeyAgentsByChain: true,
+          withWalletStorage: true,
+          withAppSettings: true
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+      });
+
+      it('when no wallet info available, name is set to Lace', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: true,
+          withKeyAgentData: true,
+          withKeyAgentsByChain: true,
+          withAppSettings: true,
+          withWalletStorage: false
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+        expect(getValueFromLocalStorage('wallet')).toEqual({ name: 'Lace' });
+      });
+
+      it('when invalid wallet info, name is set to Lace', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: true,
+          withKeyAgentData: true,
+          withKeyAgentsByChain: true,
+          withAppSettings: true,
+          withWalletStorage: false
+        });
+        saveValueInLocalStorage({ key: 'wallet', value: { invalidProperty: 'test' } as unknown as WalletStorage });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+        expect(getValueFromLocalStorage('wallet')).toEqual({ name: 'Lace' });
+      });
+
+      it('when no appSettings, chainName is set to the current one', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: true,
+          withKeyAgentData: true,
+          withKeyAgentsByChain: true,
+          withAppSettings: false,
+          withWalletStorage: true
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: true } });
+        // environmentName set when mocking providers
+        expect(getValueFromLocalStorage('appSettings')).toEqual({ chainName: 'Preview' });
+      });
+    });
+
+    describe('return an error state', () => {
+      it('for an unlocked in-memory wallet without lock', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: false,
+          withKeyAgentData: true,
+          withKeyAgentsByChain: true,
+          withWalletStorage: true,
+          withAppSettings: true
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({
+          checkState: 'checked',
+          result: { valid: false, error: 'Missing lock for InMemory wallet' }
+        });
+      });
+
+      it('when keyAgentDate is not valid', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: true,
+          withKeyAgentData: false,
+          withKeyAgentsByChain: true,
+          withWalletStorage: true,
+          withAppSettings: true
+        });
+        saveValueInLocalStorage({
+          key: 'keyAgentData',
+          value: { notValid: 'test' } as unknown as Wallet.KeyManagement.SerializableKeyAgentData
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({
+          checkState: 'checked',
+          result: { valid: false, error: 'Invalid key agent data' }
+        });
+      });
+
+      it('when keyAgentsByChain is missing a chain', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: true,
+          withKeyAgentData: true,
+          withKeyAgentsByChain: false,
+          withWalletStorage: true,
+          withAppSettings: true
+        });
+        await storage.local.set({
+          BACKGROUND_STORAGE: {
+            keyAgentsByChain: { Preview: mockKeyAgentsByChain.Preview, Preprod: mockKeyAgentsByChain.Mainnet }
+          }
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({
+          checkState: 'checked',
+          result: { valid: false, error: 'Invalid key agents by chain' }
+        });
+      });
+
+      it('when it is a hardware wallet and keyAgentsByChain is missing', async () => {
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: false,
+          withKeyAgentData: true,
+          isHardwareWallet: true,
+          withKeyAgentsByChain: false,
+          withWalletStorage: true,
+          withAppSettings: true
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({
+          checkState: 'checked',
+          result: { valid: false, error: 'Missing key agents by chain' }
+        });
+      });
+
+      it('when an unexpected error occurs while checking the data', async () => {
+        jest.spyOn(DataValidators, 'isKeyAgentDataValid').mockImplementation(() => {
+          throw new Error('Some exception');
+        });
+        const { result } = renderHook(() => useDataCheck(), { wrapper: MockProviders });
+        setStorageHelper({
+          withLock: true,
+          withKeyAgentData: false,
+          withKeyAgentsByChain: true,
+          withWalletStorage: true,
+          withAppSettings: true
+        });
+        saveValueInLocalStorage({
+          key: 'keyAgentData',
+          value: { notValid: 'test' } as unknown as Wallet.KeyManagement.SerializableKeyAgentData
+        });
+
+        await act(async () => {
+          await result.current[1]();
+        });
+        expect(result.current[0]).toEqual({ checkState: 'checked', result: { valid: false, error: 'Some exception' } });
+      });
+    });
+  });
+});

--- a/apps/browser-extension-wallet/src/hooks/useDataCheck.ts
+++ b/apps/browser-extension-wallet/src/hooks/useDataCheck.ts
@@ -1,0 +1,116 @@
+/* eslint-disable max-depth */
+/* eslint-disable sonarjs/no-duplicate-string */
+import { useCallback, useReducer } from 'react';
+import { storage } from 'webextension-polyfill';
+import isNil from 'lodash/isNil';
+import { Wallet } from '@lace/cardano';
+import { ExtensionStorage } from '@lib/scripts/types';
+import { ILocalStorage } from '@src/types';
+import { deleteFromLocalStorage, getValueFromLocalStorage, saveValueInLocalStorage } from '@src/utils/local-storage';
+import { useWalletStore, WalletStore } from '@src/stores';
+import { isWalletStorageValid, isKeyAgentsByChainValid, isKeyAgentDataValid } from '@src/utils/data-validators';
+import { config } from '@src/config';
+
+const { CHAIN } = config();
+
+export type DataCheckState =
+  | { checkState: 'not-checked' | 'checking' }
+  | { checkState: 'checked'; result: { valid: true } | { valid: false; error: string } };
+export type DataCheckAction = { type: 'not-checked' | 'checking' | 'valid' } | { type: 'error'; error: string };
+
+export type DataCheckDispatcher = (dispatcher: React.Dispatch<DataCheckAction>, store: WalletStore) => Promise<void>;
+export type UseDataCheck = [DataCheckState, () => Promise<void>];
+
+const dataCheckReducer = (state: DataCheckState, action: DataCheckAction): DataCheckState => {
+  switch (action.type) {
+    case 'not-checked':
+      return { checkState: 'not-checked' };
+    case 'checking':
+      return { checkState: 'checking' };
+    case 'valid':
+      return { checkState: 'checked', result: { valid: true } };
+    case 'error':
+      return { checkState: 'checked', result: { valid: false, error: action.error } };
+    default:
+      return state;
+  }
+};
+
+// eslint-disable-next-line complexity, sonarjs/cognitive-complexity
+export const dataCheckDispatcher: DataCheckDispatcher = async (dispatcher, walletStore) => {
+  dispatcher({ type: 'checking' });
+  try {
+    const lock = getValueFromLocalStorage<ILocalStorage, 'lock'>('lock'); // Not in HW
+    const keyAgentData = getValueFromLocalStorage<ILocalStorage, 'keyAgentData'>('keyAgentData');
+    const walletStorage = getValueFromLocalStorage<ILocalStorage, 'wallet'>('wallet');
+    const appSettings = getValueFromLocalStorage<ILocalStorage, 'appSettings'>('appSettings');
+    const extensionStorage = (await storage.local.get('BACKGROUND_STORAGE')) as Pick<
+      ExtensionStorage,
+      'BACKGROUND_STORAGE'
+    >;
+
+    const keyAgentsByChain = extensionStorage.BACKGROUND_STORAGE?.keyAgentsByChain;
+
+    // No key agent data and no lock means no wallet so BACKGROUND_STORAGE should not exist, delete and don't fail
+    if (isNil(keyAgentData) && isNil(lock) && !isNil(extensionStorage.BACKGROUND_STORAGE)) {
+      await storage.local.remove('BACKGROUND_STORAGE');
+    }
+    // We have a wallet if:
+    //   - there is a keyAgentData present (unlocked wallet), regardless of lock (HW wallets have no lock)
+    //   - or there's no keyAgentData but there is a lock (locked InMemory wallet)
+    const isWalletCreated = !isNil(keyAgentData) || !isNil(lock);
+    if (isWalletCreated) {
+      // If there is no wallet name stored or is invalid, fallback to "Lace" without failing the data check
+      if (isNil(walletStorage) || !isWalletStorageValid(walletStorage)) {
+        saveValueInLocalStorage({ key: 'wallet', value: { name: 'Lace' } });
+      }
+      // If we have keyAgentsByChain, we should validate it
+      if (!isNil(keyAgentsByChain) && !isKeyAgentsByChainValid(keyAgentsByChain)) {
+        return dispatcher({ type: 'error', error: 'Invalid key agents by chain' });
+      }
+
+      // If wallet is not locked or is a HW wallet
+      if (!isNil(keyAgentData)) {
+        // We should validate the keyAgentData
+        if (!isKeyAgentDataValid(keyAgentData)) return dispatcher({ type: 'error', error: 'Invalid key agent data' });
+
+        const isInMemoryWallet = keyAgentData.__typename === Wallet.KeyManagement.KeyAgentType.InMemory;
+        if (isInMemoryWallet) {
+          // InMemory wallets should always have a lock
+          if (isNil(lock)) return dispatcher({ type: 'error', error: 'Missing lock for InMemory wallet' });
+          // If there is lock, but there is no keyAgentsByChain network switching won't work
+          if (isNil(keyAgentsByChain)) {
+            // Force-lock the wallet to restore keyAgentsByChain on unlock, but don't fail the data check
+            deleteFromLocalStorage('keyAgentData');
+          }
+        } else {
+          // With no keyAgentsByChain network switching won't work and with no lock keyAgentsByChain can't be recovered
+          // eslint-disable-next-line no-lonely-if
+          if (isNil(keyAgentsByChain)) return dispatcher({ type: 'error', error: 'Missing key agents by chain' });
+        }
+      }
+
+      if (isNil(appSettings?.chainName)) {
+        // If there is no appSettings or no chainName when there is a wallet save current network or the default one
+        saveValueInLocalStorage({ key: 'appSettings', value: { chainName: walletStore?.environmentName || CHAIN } });
+      }
+    }
+
+    return dispatcher({ type: 'valid' });
+  } catch (error) {
+    return dispatcher({ type: 'error', error: error?.message ?? 'Something went wrong' });
+  }
+};
+
+const INITIAL_STATE: DataCheckState = { checkState: 'not-checked' };
+
+export const useDataCheck = (checkData = dataCheckDispatcher): UseDataCheck => {
+  const store = useWalletStore();
+  const [dataCheckState, dispatch] = useReducer(dataCheckReducer, INITIAL_STATE);
+
+  const performDataCheck = useCallback(async () => {
+    await checkData(dispatch, store);
+  }, [checkData, store]);
+
+  return [dataCheckState, performDataCheck];
+};

--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -126,8 +126,6 @@ export const useWalletManager = (): UseWalletManager => {
    * Deletes wallet info in storage, which should be stored encrypted with the wallet password as lock
    */
   const lockWallet = useCallback(async (): Promise<void> => {
-    // TODO: if !walletLock then browser storage is corrupted and won't be able to unlock later.
-    // what should we do in this case? should we display an error screen to the user with a CTA to delete all data?
     if (!walletLock) return;
     // Deletes key agent data from storage and clears states
     await backgroundService.clearBackgroundStorage(['keyAgentsByChain']);
@@ -142,8 +140,6 @@ export const useWalletManager = (): UseWalletManager => {
    */
   const unlockWallet = useCallback(
     async (password: string): Promise<Wallet.KeyAgentsByChain | void> => {
-      // TODO: if !walletLock then browser storage is corrupted and won't be able to unlock later.
-      // what should we do in this case? should we display an error screen to the user with a CTA to delete all data?
       if (!walletLock) return;
       const walletDecrypted = await Wallet.KeyManagement.emip3decrypt(walletLock, Buffer.from(password));
 

--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -931,6 +931,12 @@
       "btn.confirm": "Got it"
     }
   },
+  "corruptedData": {
+    "title": "Data Corrupted",
+    "errorDescription": "Looks like some of your data is missing or invalid. Don't worry your funds are safe.",
+    "actionDescription": "You will need to restore your wallet again with your recovery phrase.",
+    "btn.confirm": "Restore your wallet"
+  },
   "cardano": {
     "general": {
       "confirmButton": "Confirm",

--- a/apps/browser-extension-wallet/src/popup.tsx
+++ b/apps/browser-extension-wallet/src/popup.tsx
@@ -20,6 +20,7 @@ import { BackgroundServiceAPIProvider } from '@providers/BackgroundServiceAPI';
 import { ExternalLinkOpenerProvider } from '@providers/ExternalLinkOpenerProvider';
 import { APP_MODE_POPUP } from './utils/constants';
 import { MigrationContainer } from '@components/MigrationContainer';
+import { DataCheckContainer } from '@components/DataCheckContainer';
 
 const App = (): React.ReactElement => (
   <BackgroundServiceAPIProvider>
@@ -34,7 +35,9 @@ const App = (): React.ReactElement => (
                     <ThemeProvider>
                       <ExternalLinkOpenerProvider>
                         <MigrationContainer appMode={APP_MODE_POPUP}>
-                          <PopupView />
+                          <DataCheckContainer appMode={APP_MODE_POPUP}>
+                            <PopupView />
+                          </DataCheckContainer>
                         </MigrationContainer>
                       </ExternalLinkOpenerProvider>
                     </ThemeProvider>

--- a/apps/browser-extension-wallet/src/utils/data-validators.ts
+++ b/apps/browser-extension-wallet/src/utils/data-validators.ts
@@ -1,0 +1,14 @@
+import { Wallet } from '@lace/cardano';
+import { WalletStorage } from '@src/types/local-storage';
+
+export const isKeyAgentDataValid = (keyAgentData: Wallet.KeyManagement.SerializableKeyAgentData): boolean =>
+  '__typename' in keyAgentData &&
+  'chainId' in keyAgentData &&
+  'accountIndex' in keyAgentData &&
+  'knownAddresses' in keyAgentData &&
+  'extendedAccountPublicKey' in keyAgentData;
+
+export const isKeyAgentsByChainValid = (keyAgentsByChain: Wallet.KeyAgentsByChain): boolean =>
+  'Preprod' in keyAgentsByChain && 'Preview' in keyAgentsByChain && 'Mainnet' in keyAgentsByChain;
+
+export const isWalletStorageValid = (walletStorage: WalletStorage): boolean => 'name' in walletStorage;

--- a/apps/browser-extension-wallet/src/utils/local-storage.ts
+++ b/apps/browser-extension-wallet/src/utils/local-storage.ts
@@ -41,13 +41,13 @@ export const saveValueInLocalStorage = <T = ILocalStorage, K extends keyof T = k
 export const deleteFromLocalStorage = (key: keyof ILocalStorage): void => window.localStorage.removeItem(key);
 
 export const onStorageChangeEvent = (
-  keys: (keyof ILocalStorage)[],
+  keys: (keyof ILocalStorage)[] | 'all',
   callback: StorageEventPresetAction | ((ev?: StorageEvent) => unknown),
   eventType: StorageEventType = 'any'
-): void => {
-  // eslint-disable-next-line consistent-return, complexity
-  window.addEventListener('storage', (ev) => {
-    let extraCondition;
+): (() => void) => {
+  // eslint-disable-next-line complexity, consistent-return
+  const listener = (ev: StorageEvent) => {
+    let extraCondition = true;
 
     switch (eventType) {
       case 'create':
@@ -61,17 +61,20 @@ export const onStorageChangeEvent = (
         break;
       case 'any':
       default:
-        true;
         extraCondition = true;
     }
 
-    if (keys.includes(ev.key as keyof ILocalStorage) && extraCondition) {
-      if (typeof callback === 'string' && (callback as StorageEventPresetAction) === 'reload')
+    const shouldRun = typeof keys === 'string' ? keys === 'all' : keys.includes(ev.key as keyof ILocalStorage);
+    if (shouldRun && extraCondition) {
+      if (typeof callback === 'string' && (callback as StorageEventPresetAction) === 'reload') {
         return window.location.reload();
-
+      }
       if (typeof callback === 'function') return callback(ev);
     }
-  });
+  };
+  window.addEventListener('storage', listener);
+
+  return () => window.removeEventListener('storage', listener);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types

--- a/apps/browser-extension-wallet/src/utils/mocks/test-helpers.tsx
+++ b/apps/browser-extension-wallet/src/utils/mocks/test-helpers.tsx
@@ -33,10 +33,10 @@ export const mockKeyAgentDataTestnet: Wallet.KeyManagement.SerializableKeyAgentD
 };
 
 export const mockKeyAgentsByChain: Wallet.KeyAgentsByChain = {
-  Preprod: { keyAgentData: mockKeyAgentDataTestnet },
   LegacyTestnet: { keyAgentData: { ...mockKeyAgentDataTestnet, chainId: Wallet.Cardano.ChainIds.LegacyTestnet } },
-  Preview: { keyAgentData: { ...mockKeyAgentDataTestnet, chainId: Wallet.Cardano.ChainIds.Preview } },
-  Mainnet: { keyAgentData: { ...mockKeyAgentDataTestnet, chainId: Wallet.Cardano.ChainIds.Mainnet } }
+  Mainnet: { keyAgentData: { ...mockKeyAgentDataTestnet, chainId: Wallet.Cardano.ChainIds.Mainnet } },
+  Preprod: { keyAgentData: { ...mockKeyAgentDataTestnet, chainId: Wallet.Cardano.ChainIds.Preprod } },
+  Preview: { keyAgentData: { ...mockKeyAgentDataTestnet, chainId: Wallet.Cardano.ChainIds.Preview } }
 };
 
 export const mockInMemoryWallet = {

--- a/apps/browser-extension-wallet/src/views/browser-view/index.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/index.tsx
@@ -20,6 +20,7 @@ import { BackgroundServiceAPIProvider } from '@providers/BackgroundServiceAPI';
 import { ExternalLinkOpenerProvider } from '@providers/ExternalLinkOpenerProvider';
 import { APP_MODE_BROWSER } from '@src/utils/constants';
 import { MigrationContainer } from '@components/MigrationContainer';
+import { DataCheckContainer } from '@components/DataCheckContainer';
 import '../../lib/scripts/keep-alive-ui';
 
 const App = (): React.ReactElement => (
@@ -35,7 +36,9 @@ const App = (): React.ReactElement => (
                     <ThemeProvider>
                       <ExternalLinkOpenerProvider>
                         <MigrationContainer appMode={APP_MODE_BROWSER}>
-                          <BrowserViewRoutes />
+                          <DataCheckContainer appMode={APP_MODE_BROWSER}>
+                            <BrowserViewRoutes />
+                          </DataCheckContainer>
                         </MigrationContainer>
                       </ExternalLinkOpenerProvider>
                     </ThemeProvider>


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-5449
- [x] Proper tests implemented

---

## Proposed solution

- Adds a hook and a component to perform data checks on storage
- Shows an error with a CTA to reset the wallet if data is corrupted

## Testing

- Enable feature in local `.env` file to test
- Load the extension, delete different things from the storage, and reload the extension. Not every case will display the error, only the things needed for the wallet to work such as `lock`, `keyAgentsByChain`, and `keyAgentData`. Some may be re-created with a default like the wallet's name and some may disable features like show recovery passphrase.