### PR TITLE
chore: adjust github settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -59,9 +59,9 @@ branches:
         # The number of approvals required. (1-6)
         required_approving_review_count: 1
         # Dismiss approved reviews automatically when a new commit is pushed.
-        dismiss_stale_reviews: true
+        dismiss_stale_reviews: false
         # Whether the most recent push must be approved by someone other than the person who pushed it.
-        require_last_push_approval: true
+        require_last_push_approval: false
         # Blocks merge until code owners have reviewed.
         require_code_owner_reviews: true
         # Allow specific users, teams, or apps to bypass pull request requirements.
@@ -105,4 +105,4 @@ branches:
       restrictions:
         apps: []
         users: []
-        teams: []
+        teams: ['lace-tech-leads']


### PR DESCRIPTION
## Proposed solution

Make Github settings more permissible


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/154/5178752728/index.html) for [7972c588](https://github.com/input-output-hk/lace/pull/69/commits/7972c588a0ac94f639fa6d1295ec9edbebee23ca)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->