### PR TITLE
feat(extension): persist balance visibility

### DIFF
--- a/apps/browser-extension-wallet/src/stores/StoreProvider.tsx
+++ b/apps/browser-extension-wallet/src/stores/StoreProvider.tsx
@@ -3,7 +3,6 @@ import createContext from 'zustand/context';
 import { UseStore } from 'zustand';
 import { WalletStore } from './types';
 import { createWalletStore } from './createWalletStore';
-import { bufferReviver, getValueFromLocalStorage } from '@src/utils/local-storage';
 import { useAppSettingsContext } from '@providers';
 import { config } from '@src/config';
 import { AppMode } from '@src/utils/constants';
@@ -35,9 +34,7 @@ export const StoreProvider = ({
   sliceProvider = createWalletStore
 }: StoreProviderProps): React.ReactElement => {
   const [{ chainName = CHAIN }] = useAppSettingsContext();
-  const walletLock = getValueFromLocalStorage('lock', undefined, bufferReviver);
-
-  const createStore = () => store ?? sliceProvider(walletLock, chainName, appMode);
+  const createStore = () => store ?? sliceProvider(chainName, appMode);
 
   return <Provider createStore={createStore}>{children}</Provider>;
 };

--- a/apps/browser-extension-wallet/src/stores/createWalletStore.ts
+++ b/apps/browser-extension-wallet/src/stores/createWalletStore.ts
@@ -1,7 +1,6 @@
 import create, { UseStore } from 'zustand';
 import { Wallet } from '@lace/cardano';
 import { WalletStore } from './types';
-import { WalletLocked } from '../types';
 import {
   BlockchainProviderFactory,
   walletActivitiesSlice,
@@ -20,7 +19,6 @@ import { config } from '@src/config';
 const { CHAIN } = config();
 
 export const createWalletStore = (
-  walletLock: WalletLocked,
   currentChainName: Wallet.ChainName,
   appMode: AppMode,
   blockchainProviderFactory?: BlockchainProviderFactory
@@ -35,7 +33,7 @@ export const createWalletStore = (
     ...walletActivitiesSlice({ set, get }),
     ...networkSlice({ set, get }),
     ...stakePoolSearchSlice({ set, get }),
-    ...lockSlice({ set, get }, walletLock),
+    ...lockSlice({ set, get }),
     ...transactionDetailSlice({ set, get }),
     ...assetDetailsSlice({ set, get })
   }));

--- a/apps/browser-extension-wallet/src/stores/slices/__tests__/lock-slice.test.ts
+++ b/apps/browser-extension-wallet/src/stores/slices/__tests__/lock-slice.test.ts
@@ -5,22 +5,30 @@ import '@testing-library/jest-dom';
 import { lockSlice } from '../lock-slice';
 import create, { GetState, SetState } from 'zustand';
 import { mockKeyAgentDataTestnet } from '@src/utils/mocks/test-helpers';
+import { saveValueInLocalStorage } from '@src/utils/local-storage';
 
 const mockWalletLock = Buffer.from('test');
 const mockLockSlice = (
   set: SetState<LockSlice>,
   get: GetState<LockSlice>,
-  mocks?: { keyAgentData?: Wallet.KeyManagement.SerializableKeyAgentData; walletLock?: Uint8Array }
+  mocks?: { keyAgentData?: Wallet.KeyManagement.SerializableKeyAgentData }
 ): LockSlice => {
   const getState: GetState<LockSlice & WalletInfoSlice> = () =>
     ({ ...get(), keyAgentData: mocks?.keyAgentData } as LockSlice & WalletInfoSlice);
-  return lockSlice({ set, get: getState }, mocks?.walletLock);
+  return lockSlice({ set, get: getState });
 };
 
 describe('Testing lock slice', () => {
+  beforeAll(() => {
+    saveValueInLocalStorage({ key: 'lock', value: mockWalletLock });
+  });
+  afterAll(() => {
+    window.localStorage.clear();
+  });
+
   test('should create store hook with lock slice', () => {
     const useLockHook = create<LockSlice>((set, get) =>
-      mockLockSlice(set, get, { walletLock: mockWalletLock, keyAgentData: mockKeyAgentDataTestnet })
+      mockLockSlice(set, get, { keyAgentData: mockKeyAgentDataTestnet })
     );
     const { result } = renderHook(() => useLockHook());
 
@@ -31,7 +39,7 @@ describe('Testing lock slice', () => {
 
   test('should set wallet locked info', async () => {
     const useLockHook = create<LockSlice>((set, get) =>
-      mockLockSlice(set, get, { walletLock: mockWalletLock, keyAgentData: mockKeyAgentDataTestnet })
+      mockLockSlice(set, get, { keyAgentData: mockKeyAgentDataTestnet })
     );
     const { result, waitForNextUpdate } = renderHook(() => useLockHook());
 
@@ -45,7 +53,7 @@ describe('Testing lock slice', () => {
   });
 
   test('should return true/false when wallet is locked/not locked', async () => {
-    const useLockHook = create<LockSlice>((set, get) => mockLockSlice(set, get, { walletLock: mockWalletLock }));
+    const useLockHook = create<LockSlice>((set, get) => mockLockSlice(set, get));
     const { result, waitForNextUpdate } = renderHook(() => useLockHook());
 
     await act(async () => {

--- a/apps/browser-extension-wallet/src/stores/slices/lock-slice.ts
+++ b/apps/browser-extension-wallet/src/stores/slices/lock-slice.ts
@@ -1,5 +1,10 @@
 import { WalletLocked } from '@src/types';
-import { saveValueInLocalStorage, deleteFromLocalStorage } from '@src/utils/local-storage';
+import {
+  saveValueInLocalStorage,
+  deleteFromLocalStorage,
+  getValueFromLocalStorage,
+  bufferReviver
+} from '@src/utils/local-storage';
 import { LockSlice, SliceCreator, WalletInfoSlice, ZustandHandlers } from '../types';
 
 const isWalletLocked = ({ get }: ZustandHandlers<LockSlice & WalletInfoSlice>): boolean =>
@@ -21,12 +26,12 @@ const resetWalletLock = (_: WalletLocked, { set }: ZustandHandlers<LockSlice>): 
   set({ walletLock: undefined });
 };
 
-export const lockSlice: SliceCreator<LockSlice & WalletInfoSlice, LockSlice, WalletLocked, LockSlice> = (
-  { get, set },
-  walletLock
-) => ({
-  isWalletLocked: () => isWalletLocked({ get }),
-  walletLock,
-  setWalletLock: (lock: WalletLocked) => setWalletLock(lock, { set }),
-  resetWalletLock: () => resetWalletLock(undefined, { set })
-});
+export const lockSlice: SliceCreator<LockSlice & WalletInfoSlice, LockSlice, void, LockSlice> = ({ get, set }) => {
+  const walletLock = getValueFromLocalStorage('lock', undefined, bufferReviver);
+  return {
+    isWalletLocked: () => isWalletLocked({ get }),
+    walletLock,
+    setWalletLock: (lock: WalletLocked) => setWalletLock(lock, { set }),
+    resetWalletLock: () => resetWalletLock(undefined, { set })
+  };
+};

--- a/apps/browser-extension-wallet/src/types/local-storage.ts
+++ b/apps/browser-extension-wallet/src/types/local-storage.ts
@@ -37,6 +37,7 @@ export interface ILocalStorage {
   lock?: WalletLocked;
   lastStaking?: LastStakingInfo;
   mode?: 'light' | 'dark';
+  hideBalance?: boolean;
   showDappBetaModal?: boolean;
   analyticsAccepted?: AnalyticsConsentStatus;
   isForgotPasswordFlow?: boolean;

--- a/apps/browser-extension-wallet/src/utils/local-storage.ts
+++ b/apps/browser-extension-wallet/src/utils/local-storage.ts
@@ -42,7 +42,7 @@ export const deleteFromLocalStorage = (key: keyof ILocalStorage): void => window
 
 export const onStorageChangeEvent = (
   keys: (keyof ILocalStorage)[],
-  callback: StorageEventPresetAction | (() => unknown),
+  callback: StorageEventPresetAction | ((ev?: StorageEvent) => unknown),
   eventType: StorageEventType = 'any'
 ): void => {
   // eslint-disable-next-line consistent-return, complexity
@@ -69,7 +69,7 @@ export const onStorageChangeEvent = (
       if (typeof callback === 'string' && (callback as StorageEventPresetAction) === 'reload')
         return window.location.reload();
 
-      if (typeof callback === 'function') return callback();
+      if (typeof callback === 'function') return callback(ev);
     }
   });
 };

--- a/apps/browser-extension-wallet/test/__mocks__/set-env-vars.js
+++ b/apps/browser-extension-wallet/test/__mocks__/set-env-vars.js
@@ -6,3 +6,4 @@ process.env.CEXPLORER_URL_MAINNET = 'https://cexplorer.io';
 process.env.CEXPLORER_URL_PREVIEW = 'https://preview.cexplorer.io';
 process.env.CEXPLORER_URL_PREPROD = 'https://preprod.cexplorer.io';
 process.env.CEXPLORER_URL_TESTNET = 'https://testnet.cexplorer.io';
+process.env.USE_HIDE_MY_BALANCE = 'true';


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-6456
- [x] Proper tests implemented

---

## Proposed solution

- Adds a new `hideBalance` field to the local storage to persist the balance visibility preference
- `getWalletUI` in `ui-slice` gets the value for the balance visibility from storage on load
- `setBalancesVisibility` in `ui-slice` now also saves the visibility state to the store
- Added a listener to update the visibility state on storage change in `ui-slice`

## Testing

- Hiding/showing the balance from the popup should also do it in all open browser tabs
- Hiding/showing the balance from a browser tab should also do it in all other open browser tabs
- When re-opening the popup or opening/refreshing a tab the visibility state should be the same as the last time 


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/161/5181246704/index.html) for [0ab6cd99](https://github.com/input-output-hk/lace/pull/70/commits/0ab6cd99cd3794698e8a2ed79af2bfd9d9e63058)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->