### PR TITLE
chore: relax merge restrictions

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -105,4 +105,4 @@ branches:
       restrictions:
         apps: []
         users: []
-        teams: ['lace-tech-leads']
+        teams: ['lace-tech-leads', 'lace']


### PR DESCRIPTION
## Proposed solution

Relax permissions to allow lace memebers to merge PRs

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/210/5188399999/index.html) for [7aa1219e](https://github.com/input-output-hk/lace/pull/74/commits/7aa1219eca18cb05dc7ab595424b5758471cf150)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->