### PR TITLE
feat: isolate network addresses between testnet

### DIFF
--- a/apps/browser-extension-wallet/src/features/address-book/context/AddressBookProvider.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/context/AddressBookProvider.tsx
@@ -13,15 +13,16 @@ interface AddressBookProviderProps {
 
 export type AddressRecordParams = Pick<AddressBookSchema, 'address' | 'name'>;
 
+export const cardanoNetworkMap = {
+  Mainnet: Wallet.Cardano.NetworkMagics.Mainnet,
+  Preprod: Wallet.Cardano.NetworkMagics.Preprod,
+  Preview: Wallet.Cardano.NetworkMagics.Preview,
+  LegacyTestnet: Wallet.Cardano.NetworkMagics.Testnet
+};
+
 export const AddressBookProvider = ({ children, initialState }: AddressBookProviderProps): React.ReactElement => {
   const { environmentName } = useWalletStore();
-  const queries = useMemo(
-    () =>
-      addressBookQueries(
-        environmentName === 'Mainnet' ? Wallet.Cardano.NetworkId.Mainnet : Wallet.Cardano.NetworkId.Testnet
-      ),
-    [environmentName]
-  );
+  const queries = useMemo(() => addressBookQueries(cardanoNetworkMap[environmentName]), [environmentName]);
 
   return (
     <AddressBookContext.Provider

--- a/apps/browser-extension-wallet/src/features/address-book/hooks/useGetFilteredAddressBook.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/hooks/useGetFilteredAddressBook.tsx
@@ -3,7 +3,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { AddressBookSchema, addressBookSchema } from '@src/lib/storage';
 import { useActionExecution } from '@src/hooks/useActionExecution';
 import { useWalletStore } from '@src/stores';
-import { Wallet } from '@lace/cardano';
+import { cardanoNetworkMap } from '@src/features/address-book/context';
 
 const DEFAULT_QUERY_LIMIT = 5;
 
@@ -46,8 +46,7 @@ export const useGetFilteredAddressBook = (): {
 
   const getAddressBookByNameOrAddress = useCallback(
     async ({ value, limit = DEFAULT_QUERY_LIMIT }: GetAddressByNameOrAddressArgs) => {
-      const network =
-        environmentName === 'Mainnet' ? Wallet.Cardano.NetworkId.Mainnet : Wallet.Cardano.NetworkId.Testnet;
+      const network = cardanoNetworkMap[environmentName];
 
       if (value.length <= 0) {
         setFilteredAddresses([]);

--- a/apps/browser-extension-wallet/src/lib/storage/database/build.ts
+++ b/apps/browser-extension-wallet/src/lib/storage/database/build.ts
@@ -29,7 +29,7 @@ export const migrateAddressBookSchema = (transaction: Transaction): PromiseExten
   transaction
     .table('addressBook')
     .toCollection()
-    .modify((addressBook: AddressBookSchema) => {
+    .modify((addressBook: Omit<AddressBookSchema, 'network'> & { network: Wallet.Cardano.NetworkId }) => {
       addressBook.network = startWithRegExp(addressBook.address).test('addr_test1')
         ? Wallet.Cardano.NetworkId.Testnet
         : Wallet.Cardano.NetworkId.Mainnet;

--- a/apps/browser-extension-wallet/src/lib/storage/models/address-book.ts
+++ b/apps/browser-extension-wallet/src/lib/storage/models/address-book.ts
@@ -9,7 +9,7 @@ export interface AddressBookSchema {
   id: number;
   name: string;
   address: string;
-  network: Wallet.Cardano.NetworkId;
+  network: Wallet.Cardano.NetworkMagics;
 }
 
 export const addressBookSchema: VersionedSchema = {
@@ -21,7 +21,7 @@ export const addressBookSchema: VersionedSchema = {
 };
 
 export const addressBookQueries = (
-  currentChain: Wallet.Cardano.NetworkId
+  currentChain: Wallet.Cardano.NetworkMagics
 ): DbQueries<AddressBookSchema, AddressRecordParams> => ({
   listQuery: (collection) =>
     collection.filter(({ network }) => network === currentChain).sortBy('name', sortTabletByName),

--- a/apps/browser-extension-wallet/src/views/browser-view/features/adress-book/components/AddressBook/AddressBook.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/adress-book/components/AddressBook/AddressBook.tsx
@@ -84,6 +84,7 @@ export const AddressBook = withAddressBookContext((): React.ReactElement => {
       action: AnalyticsEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.AddressBook.ADD_ADDRESS_BROWSER
     });
+
     return 'id' in addressToEdit
       ? updateAddress(addressToEdit.id, address, {
           text: translate('browserView.addressBook.toast.editAddress'),


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-6813
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Previously, the address book content is shared between preview and preprod. This PR isolates the address book content based on the network. It uses `Cardano.NetworkMagics` instead of `Cardano.NetworkId`


## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-6813]: https://input-output.atlassian.net/browse/LW-6813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ