### PR TITLE
chore: relax up-to-date PR requirement

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -77,7 +77,7 @@ branches:
       # Required. Require status checks to pass before merging. Set to null to disable
       required_status_checks:
         # Required. Require branches to be up to date before merging.
-        strict: true
+        strict: false
         # Required. The list of status checks to require in order to merge into this branch
         checks:
           - context: Build & Test


### PR DESCRIPTION
## Proposed solution

Branches no longer need to be up-to-date with `main` but will still fail PR checks if there are merge conflicts to resolve

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/231/5189291461/index.html) for [cb4e9f37](https://github.com/input-output-hk/lace/pull/77/commits/cb4e9f37fda1c8fe6d27b5d8c6f4c5947918dc9c)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->