### PR TITLE
test(extension): e2e - add tests for removing DApp from the list of authorized DApps

### DIFF
--- a/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
+++ b/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
@@ -10,6 +10,7 @@ import SignTransactionPage from '../elements/dappConnector/signTransactionPage';
 import DAppTransactionAllDonePage from '../elements/dappConnector/dAppTransactionAllDonePage';
 import { Logger } from '../support/logger';
 import testContext from '../utils/testContext';
+import RemoveDAppModal from '../elements/dappConnector/removeDAppModal';
 
 export type ExpectedDAppDetails = {
   hasLogo: boolean;
@@ -91,6 +92,21 @@ class DAppConnectorAssert {
 
     await AuthorizeDAppModal.onceButton.waitForDisplayed();
     await expect(await AuthorizeDAppModal.onceButton.getText()).to.equal(await t('dapp.connect.modal.allowOnce'));
+  }
+
+  async assertSeeDAppRemovalConfirmationModal() {
+    await RemoveDAppModal.container.waitForDisplayed();
+    await RemoveDAppModal.title.waitForDisplayed();
+    await expect(await RemoveDAppModal.title.getText()).to.equal(await t('dapp.delete.title'));
+
+    await RemoveDAppModal.description.waitForDisplayed();
+    await expect(await RemoveDAppModal.description.getText()).to.equal(await t('dapp.delete.description'));
+
+    await RemoveDAppModal.confirmButton.waitForDisplayed();
+    await expect(await RemoveDAppModal.confirmButton.getText()).to.equal(await t('dapp.delete.confirm'));
+
+    await RemoveDAppModal.cancelButton.waitForDisplayed();
+    await expect(await RemoveDAppModal.cancelButton.getText()).to.equal(await t('dapp.delete.cancel'));
   }
 
   async assertWalletFoundButNotConnectedInTestDApp() {

--- a/packages/e2e-tests/src/features/DAppConnectorExtended.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorExtended.feature
@@ -26,3 +26,33 @@ Feature: DAppConnector - Extended view
     And I open settings from header menu
     When I click on "Authorized DApps" setting
     Then I see "Authorized DApps" section empty state in extended mode
+
+  @LW-6879 @Testnet @Mainnet
+  Scenario: Extended view - Remove authorized DApp and cancel, DApp remains authorized
+    Given I open and authorize test DApp with "Always" setting
+    And I switch to window with Lace
+    And I close all remaining tabs except current one
+    And I open settings from header menu
+    And I click on "Authorized DApps" setting
+    And I see test DApp on the Authorized DApps list
+    When I de-authorize test DApp in extended mode
+    Then I see DApp removal confirmation modal
+    When I click "Back" button in DApp removal confirmation modal
+    Then I see test DApp on the Authorized DApps list
+    When I open test DApp
+    Then I don't see DApp window
+
+  @LW-6880 @Testnet @Mainnet
+  Scenario: Extended view - Remove authorized DApp, DApp requires authorization
+    Given I open and authorize test DApp with "Always" setting
+    And I switch to window with Lace
+    And I close all remaining tabs except current one
+    And I open settings from header menu
+    And I click on "Authorized DApps" setting
+    And I see test DApp on the Authorized DApps list
+    When I de-authorize test DApp in extended mode
+    Then I see DApp removal confirmation modal
+    When I click "Disconnect DApp" button in DApp removal confirmation modal
+    Then I see "Authorized DApps" section empty state in extended mode
+    When I open test DApp
+    Then I see DApp authorization window

--- a/packages/e2e-tests/src/features/DAppConnectorPopup.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorPopup.feature
@@ -26,3 +26,33 @@ Feature: DAppConnector - Popup view
     And I open settings from header menu
     When I click on "Authorized DApps" setting
     Then I see "Authorized DApps" section empty state in popup mode
+
+  @LW-6881 @Testnet @Mainnet
+  Scenario: Popup view - Remove authorized DApp and cancel, DApp remains authorized
+    Given I open and authorize test DApp with "Always" setting
+    And I switch to window with Lace
+    And I close all remaining tabs except current one
+    And I open settings from header menu
+    And I click on "Authorized DApps" setting
+    And I see test DApp on the Authorized DApps list
+    When I de-authorize test DApp in popup mode
+    Then I see DApp removal confirmation modal
+    When I click "Back" button in DApp removal confirmation modal
+    Then I see test DApp on the Authorized DApps list
+    When I open test DApp
+    Then I don't see DApp window
+
+  @LW-6882 @Testnet @Mainnet
+  Scenario: Popup view - Remove authorized DApp, DApp requires authorization
+    Given I open and authorize test DApp with "Always" setting
+    And I switch to window with Lace
+    And I close all remaining tabs except current one
+    And I open settings from header menu
+    And I click on "Authorized DApps" setting
+    And I see test DApp on the Authorized DApps list
+    When I de-authorize test DApp in popup mode
+    Then I see DApp removal confirmation modal
+    When I click "Disconnect DApp" button in DApp removal confirmation modal
+    Then I see "Authorized DApps" section empty state in popup mode
+    When I open test DApp
+    Then I see DApp authorization window

--- a/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
@@ -46,6 +46,11 @@ class DAppConnectorPageObject {
     button === 'Always' ? await AuthorizeDappModal.alwaysButton.click() : await AuthorizeDappModal.onceButton.click();
   }
 
+  async clickButtonInDAppRemovalConfirmationModal(button: 'Back' | 'Disconnect DApp') {
+    await RemoveDAppModal.cancelButton.waitForDisplayed();
+    button === 'Back' ? await RemoveDAppModal.cancelButton.click() : await RemoveDAppModal.confirmButton.click();
+  }
+
   async deauthorizeAllDApps(mode: 'extended' | 'popup') {
     mode === 'extended' ? await extendedView.visitSettings() : await popupView.visitSettings();
     await settingsExtendedPageObject.clickSettingsItem('Authorized DApps');
@@ -57,6 +62,19 @@ class DAppConnectorPageObject {
       await RemoveDAppModal.confirmButton.click();
 
       await ToastMessage.container.waitForDisplayed();
+    }
+  }
+
+  async deauthorizeDApp(expectedDappName: string, mode: 'extended' | 'popup') {
+    mode === 'extended' ? await extendedView.visitSettings() : await popupView.visitSettings();
+    await settingsExtendedPageObject.clickSettingsItem('Authorized DApps');
+    await AuthorizedDappsPage.drawerHeaderTitle.waitForDisplayed();
+
+    for (const dAppName of await AuthorizedDappsPage.dAppNames) {
+      if ((await dAppName.getText()) === expectedDappName) {
+        await AuthorizedDappsPage.dAppRemoveButtons[dAppName.index].waitForClickable();
+        await AuthorizedDappsPage.dAppRemoveButtons[dAppName.index].click();
+      }
     }
   }
 

--- a/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
+++ b/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
@@ -58,6 +58,10 @@ Then(/^I see DApp connection modal$/, async () => {
   await DAppConnectorAssert.assertSeeDAppConnectionModal();
 });
 
+Then(/^I see DApp removal confirmation modal$/, async () => {
+  await DAppConnectorAssert.assertSeeDAppRemovalConfirmationModal();
+});
+
 Then(/^I click "(Authorize|Cancel)" button in DApp authorization window$/, async (button: 'Authorize' | 'Cancel') => {
   await DAppConnectorPageObject.clickButtonInDAppAuthorizationWindow(button);
 });
@@ -65,6 +69,13 @@ Then(/^I click "(Authorize|Cancel)" button in DApp authorization window$/, async
 Then(/^I click "(Always|Only once)" button in DApp authorization modal$/, async (button: 'Always' | 'Only once') => {
   await DAppConnectorPageObject.clickButtonInDAppAuthorizationModal(button);
 });
+
+Then(
+  /^I click "(Back|Disconnect DApp)" button in DApp removal confirmation modal$/,
+  async (button: 'Back' | 'Disconnect DApp') => {
+    await DAppConnectorPageObject.clickButtonInDAppRemovalConfirmationModal(button);
+  }
+);
 
 Then(/^I see Lace wallet info in DApp when not connected$/, async () => {
   await DAppConnectorAssert.assertWalletFoundButNotConnectedInTestDApp();
@@ -94,6 +105,10 @@ When(/^I open and authorize test DApp with "(Always|Only once)" setting$/, async
 
 Then(/^I de-authorize all DApps in (extended|popup) mode$/, async (mode: 'extended' | 'popup') => {
   await DAppConnectorPageObject.deauthorizeAllDApps(mode);
+});
+
+Then(/^I de-authorize test DApp in (extended|popup) mode$/, async (mode: 'extended' | 'popup') => {
+  await DAppConnectorPageObject.deauthorizeDApp(DAppConnectorPageObject.TEST_DAPP_NAME, mode);
 });
 
 Then(/^I click "(Send ADA|Send Token)" "Run" button in test DApp$/, async (runButton: 'Send ADA' | 'Send Token') => {


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/271/5198405016/index.html) for [8902d942](https://github.com/input-output-hk/lace/pull/80/commits/8902d94255bb5ac7d1a70db163f76ed7a2bb3ddb)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->