### PR TITLE
feat(extension): implement downgrade migrations

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/migrations/__tests__/versions/v0_6_0.test.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/migrations/__tests__/versions/v0_6_0.test.ts
@@ -128,7 +128,7 @@ describe('v0.6.0 migration', () => {
         test('throws an error when there is temporary wallet data', async () => {
           localStorage.setItem('keyAgentData_tmp', JSON.stringify(mockKeyAgentDataTestnet));
           await expect(migrationPersistance.assert()).rejects.toThrow(
-            new InvalidMigrationData('0.6.0', 'Wallet data should not exist')
+            new InvalidMigrationData('0.6.0', 'upgrade', 'Wallet data should not exist')
           );
         });
         test('resolves to true if there is no temporary data', async () => {
@@ -190,31 +190,31 @@ describe('v0.6.0 migration', () => {
         test('throws an error when there is no chainName in appSettings_tmp', async () => {
           localStorage.setItem('appSettings_tmp', JSON.stringify({ chainId: 'Preprod' }));
           await expect(migrationPersistance.assert()).rejects.toThrow(
-            new InvalidMigrationData('0.6.0', 'Missing chain name in app settings')
+            new InvalidMigrationData('0.6.0', 'upgrade', 'Missing chain name in app settings')
           );
         });
         test('throws an error when keyAgentData_tmp is missing', async () => {
           localStorage.removeItem('keyAgentData_tmp');
           await expect(migrationPersistance.assert()).rejects.toThrow(
-            new InvalidMigrationData('0.6.0', 'Wallet data missing')
+            new InvalidMigrationData('0.6.0', 'upgrade', 'Wallet data missing')
           );
         });
         test('throws an error when wallet_tmp is missing', async () => {
           localStorage.removeItem('wallet_tmp');
           await expect(migrationPersistance.assert()).rejects.toThrow(
-            new InvalidMigrationData('0.6.0', 'Wallet data missing')
+            new InvalidMigrationData('0.6.0', 'upgrade', 'Wallet data missing')
           );
         });
         test('throws an error when keyAgentsByChain_tmp is missing', async () => {
           await storage.local.set({ BACKGROUND_STORAGE: {} });
           await expect(migrationPersistance.assert()).rejects.toThrow(
-            new InvalidMigrationData('0.6.0', 'Wallet data missing')
+            new InvalidMigrationData('0.6.0', 'upgrade', 'Wallet data missing')
           );
         });
         test('throws an error when there is no name in wallet_tmp', async () => {
           localStorage.setItem('wallet_tmp', JSON.stringify({}));
           await expect(migrationPersistance.assert()).rejects.toThrow(
-            new InvalidMigrationData('0.6.0', 'Missing name in wallet info')
+            new InvalidMigrationData('0.6.0', 'upgrade', 'Missing name in wallet info')
           );
         });
         test('throws an error when keyAgentData_tmp is missing a field', async () => {
@@ -222,7 +222,7 @@ describe('v0.6.0 migration', () => {
           delete keyAgentData_tmp.__typename;
           localStorage.setItem('keyAgentData_tmp', JSON.stringify(keyAgentData_tmp));
           await expect(migrationPersistance.assert()).rejects.toThrow(
-            new InvalidMigrationData('0.6.0', 'Missing field in key agent data')
+            new InvalidMigrationData('0.6.0', 'upgrade', 'Missing field in key agent data')
           );
         });
         test('throws an error when keyAgentDataByChain_tmp is missing a chain', async () => {
@@ -230,14 +230,14 @@ describe('v0.6.0 migration', () => {
             BACKGROUND_STORAGE: { keyAgentsByChain_tmp: { Preprod: mockKeyAgentDataTestnet } }
           });
           await expect(migrationPersistance.assert()).rejects.toThrow(
-            new InvalidMigrationData('0.6.0', 'Missing key agent for one or more chains')
+            new InvalidMigrationData('0.6.0', 'upgrade', 'Missing key agent for one or more chains')
           );
         });
         test('throws an error when decrypted lock_tmp is not the same as keyAgentsByChain_tmp', async () => {
           const wrongLock = await encryptData(mockWalletInfoTestnet, initialStorage.walletPassword);
           localStorage.setItem('lock_tmp', JSON.stringify(wrongLock));
           await expect(migrationPersistance.assert()).rejects.toThrow(
-            new InvalidMigrationData('0.6.0', 'Decrypted lock is not valid')
+            new InvalidMigrationData('0.6.0', 'upgrade', 'Decrypted lock is not valid')
           );
         });
       });
@@ -417,4 +417,5 @@ describe('v0.6.0 migration', () => {
       });
     });
   });
+  test.todo('add downgrade tests');
 });

--- a/apps/browser-extension-wallet/src/lib/scripts/migrations/__tests__/versions/v1_0_0.test.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/migrations/__tests__/versions/v1_0_0.test.ts
@@ -97,7 +97,7 @@ describe('v1.0.0 migration', () => {
         test('throws an error when chainName in temporary appSettings is not Mainnet', () => {
           localStorage.setItem('appSettings_tmp', JSON.stringify({ chainName: 'Preprod' }));
           expect(migrationPersistance.assert).toThrow(
-            new InvalidMigrationData('1.0.0', 'Chain name in app settings is not Mainnet')
+            new InvalidMigrationData('1.0.0', 'upgrade', 'Chain name in app settings is not Mainnet')
           );
         });
       });
@@ -168,13 +168,13 @@ describe('v1.0.0 migration', () => {
         test('throws an error when chainName in temporary appSettings is not Mainnet', () => {
           localStorage.setItem('appSettings_tmp', JSON.stringify({ chainName: 'Preprod' }));
           expect(migrationPersistance.assert).toThrow(
-            new InvalidMigrationData('1.0.0', 'Chain name in app settings is not Mainnet')
+            new InvalidMigrationData('1.0.0', 'upgrade', 'Chain name in app settings is not Mainnet')
           );
         });
         test('throws an error when keyAgentData_tmp does not match mainnet key agent', () => {
           localStorage.setItem('keyAgentData_tmp', JSON.stringify(initialStorage.keyAgentsByChain.Preprod));
           expect(migrationPersistance.assert).toThrow(
-            new InvalidMigrationData('1.0.0', 'Key agent data does not match Mainnet key agent')
+            new InvalidMigrationData('1.0.0', 'upgrade', 'Key agent data does not match Mainnet key agent')
           );
         });
       });

--- a/apps/browser-extension-wallet/src/lib/scripts/migrations/errors.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/migrations/errors.ts
@@ -1,5 +1,5 @@
 export class InvalidMigrationData extends Error {
-  constructor(version: string, reason?: string) {
-    super(`Invalid migrated data for version ${version}${reason ? '. Reason: '.concat(reason) : '.'}`);
+  constructor(version: string, type: 'upgrade' | 'downgrade', reason?: string) {
+    super(`Invalid migrated data for version ${version} ${type}${reason ? '. Reason: '.concat(reason) : '.'}`);
   }
 }

--- a/apps/browser-extension-wallet/src/lib/scripts/migrations/versions/v1_0_0.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/migrations/versions/v1_0_0.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-null */
 /* eslint-disable camelcase */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import isEqual from 'lodash/isEqual';
@@ -7,10 +8,6 @@ import { Migration } from '../migrations';
 import { getItemFromLocalStorage, removeItemFromLocalStorage, setItemInLocalStorage } from '../util';
 
 const MIGRATION_VERSION = '1.0.0';
-const throwInvalidDataError = (reason?: string) => {
-  throw new InvalidMigrationData(MIGRATION_VERSION, reason);
-};
-
 export const v_1_0_0: Migration = {
   version: MIGRATION_VERSION,
   // No password required for this migration
@@ -55,6 +52,11 @@ export const v_1_0_0: Migration = {
         }
       },
       assert: () => {
+        // eslint-disable-next-line unicorn/consistent-function-scoping
+        const throwInvalidDataError = (reason?: string) => {
+          throw new InvalidMigrationData(MIGRATION_VERSION, 'upgrade', reason);
+        };
+
         const tmpAppSettings = getItemFromLocalStorage<any>('appSettings_tmp');
         const tmpKeyAgentData = getItemFromLocalStorage<any>('keyAgentData_tmp');
 
@@ -88,5 +90,6 @@ export const v_1_0_0: Migration = {
         removeItemFromLocalStorage('keyAgentData_tmp');
       }
     };
-  }
+  },
+  downgrade: null
 };


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-5595
- [x] Proper tests implemented

---

## Proposed solution

- Adds a `downgrade` function for the migrations with the same interface as the `upgrade` one.
- The downgrade function for a particular version should revert the changes made by the upgrade function from the next version. The newest version won't have a downgrade function implemented as it's not possible to downgrade to it
- Modify functions in `migrations.ts` to identify and run the downgrades.
- Improved errors for invalid data in assert functions.

## Testing

- Make two builds with different manifest versions from this same branch, one with 0.6.0 and another one with 1.0.0 (cannot use older builds)
- Load the 1.0.0 app and create a wallet; should be in Mainnet by default. Close it.
- Update to the 0.6.0 app and open it; should have the same wallet but in Preprod.

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/258/5191771537/index.html) for [475b2be9](https://github.com/input-output-hk/lace/pull/84/commits/475b2be98a8949df5a3fc5e95d5e15ee75ddb32b)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->