### PR TITLE
chore: allow squash and merge

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,7 +3,7 @@
 repository:
   allow_merge_commit: true
   allow_rebase_merge: false
-  allow_squash_merge: false
+  allow_squash_merge: true
   default_branch: main
   delete_branch_on_merge: true
   has_downloads: false


### PR DESCRIPTION
## Proposed solution

Allow squash + merge as PR option for merging to `main` branch

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/262/5197108848/index.html) for [fff92283](https://github.com/input-output-hk/lace/pull/86/commits/fff922832155fbd297270bb5b7f017ec597e9472)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->