### PR TITLE
test(extension): e2e - add support for Brave browser

### DIFF
--- a/.github/workflows/e2e-tests-linux.yml
+++ b/.github/workflows/e2e-tests-linux.yml
@@ -18,6 +18,7 @@ on:
         type: choice
         options:
           - chrome
+          - brave
           - edge
       network:
         type: choice
@@ -37,7 +38,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -46,6 +47,16 @@ jobs:
         run: ./decrypt_secret.sh
         env:
           WALLET_1_PASSWORD: ${{ secrets.WALLET_PASSWORD_TESTNET }}
+      - name: Install Brave
+        run: |
+           if [ ${BROWSER} == "brave" ]; then
+            sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+            echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg] https://brave-browser-apt-release.s3.brave.com/ stable main"|sudo tee /etc/apt/sources.list.d/brave-browser-release.list
+            sudo apt update
+            sudo apt install brave-browser
+           else
+             echo "Skipping Brave installation"
+           fi
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:
@@ -56,7 +67,7 @@ jobs:
       - name: Start Chrome driver
         working-directory: /usr/local/share/chrome_driver
         run: |
-          if [ ${BROWSER} == "chrome" ]; then
+          if [ ${BROWSER} == "chrome" ]  || [ ${BROWSER} == "brave" ]; then
             ./chromedriver -port=4444 &
           else
             echo "Skipping start of ChromeDriver"
@@ -76,6 +87,7 @@ jobs:
           WALLET_1_PASSWORD: ${{ secrets.WALLET_PASSWORD_TESTNET }}
           TEST_DAPP_URL: ${{ secrets.TEST_DAPP_URL }}
           ENV: ${{ env.NETWORK }}
+          BRAVE_LOCATION: '/usr/bin/brave-browser'
         run: |
           if [ "$TAGS" == "empty" ]; then
             TAGS_TO_RUN="";

--- a/packages/e2e-tests/wdio.conf.brave.ts
+++ b/packages/e2e-tests/wdio.conf.brave.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef */
+/* eslint-disable unicorn/prefer-module */
+
+import { config as baseConfig } from './wdio.conf.base';
+
+const drivers = {
+  // used only for local runs!
+  chrome: { version: 'latest' }
+};
+
+const braveConfig: WebdriverIO.Config = {
+  capabilities: [
+    {
+      maxInstances: 1,
+      browserName: 'chrome',
+      'goog:chromeOptions': {
+        binary: process.env.BRAVE_LOCATION,
+        args: [
+          '--no-sandbox',
+          '--disable-gpu',
+          '--disable-notifications',
+          '--enable-automation',
+          '--no-first-run',
+          '--no-default-browser-check',
+          `--load-extension=${__dirname}/../../apps/browser-extension-wallet/dist`,
+          '--disable-web-security',
+          '--allow-insecure-localhost',
+          '--window-size=1920,1080',
+          '--allow-file-access-from-files',
+          '--disable-dev-shm-usage',
+          '--remote-allow-origins=*'
+        ]
+      },
+      'wdio:devtoolsOptions': {
+        headless: false,
+        ignoreDefaultArgs: true
+      }
+    }
+  ],
+  services: ['devtools', 'intercept']
+};
+
+if (!process.env.CI) {
+  braveConfig.services = [
+    [
+      'selenium-standalone',
+      {
+        installArgs: { drivers },
+        args: { drivers }
+      }
+    ],
+    'devtools',
+    'intercept'
+  ];
+}
+
+export const config: WebdriverIO.Config = { ...baseConfig, ...braveConfig };


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/336/5220841709/index.html) for [ffe318ab](https://github.com/input-output-hk/lace/pull/91/commits/ffe318abecdbcd699a4121829cb5a2278cc44710)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->