### PR TITLE
fix(extension): reflect network change on stake poool page (popup)

### DIFF
--- a/apps/browser-extension-wallet/src/features/delegation/components/DelegationContainer.tsx
+++ b/apps/browser-extension-wallet/src/features/delegation/components/DelegationContainer.tsx
@@ -48,7 +48,8 @@ export const DelegationContainer = (): React.ReactElement => {
   const { t } = useTranslation();
   const {
     getKeyAgentType,
-    walletUI: { cardanoCoin }
+    walletUI: { cardanoCoin },
+    blockchainProvider
   } = useWalletStore();
   const isInMemory = useMemo(() => getKeyAgentType() === Wallet.KeyManagement.KeyAgentType.InMemory, [getKeyAgentType]);
   const [searchValue, setSearchValue] = useState<string | undefined>();
@@ -102,7 +103,7 @@ export const DelegationContainer = (): React.ReactElement => {
     if (isHardwareWalletPopupTransition) return;
     if (searchValue?.length !== 0 && searchValue?.length < MIN_CHARS_TO_SEARCH) return;
     fetchStakePools({ searchString: searchValue || '', limit: MAX_ITEMS_TO_SHOW });
-  }, [searchValue, fetchStakePools, isInMemory]);
+  }, [searchValue, fetchStakePools, isInMemory, blockchainProvider]);
 
   const openDelagationConfirmation = useCallback(() => {
     setSection();


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-6458
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Add the blockchainProvider as a dependency into the useEffect that triggers the fetching.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/302/5204438587/index.html) for [96ad5beb](https://github.com/input-output-hk/lace/pull/94/commits/96ad5bebbe8a02170015a11826086842cfc9eb88)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->