### PR TITLE
feat(extension): release v1.2.0

### DIFF
--- a/apps/browser-extension-wallet/manifest.json
+++ b/apps/browser-extension-wallet/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Lace",
   "description": "One fast, accessible, and secure platform for digital assets, DApps, NFTs, and DeFi.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "manifest_version": 3,
   "key": "$LACE_EXTENSION_KEY",
   "icons": {

--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lace/browser-extension-wallet",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A fully capable wallet packaged as browser extensions for Chrome, Firefox, and Edge",
   "homepage": "https://github.com/input-output-hk/lace/blob/master/apps/browser-extension-wallet/README.md",
   "bugs": {

--- a/apps/browser-extension-wallet/src/release-notes/1_2_0.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_2_0.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable camelcase */
+import React from 'react';
+
+const ReleaseNote_1_2_0 = (): React.ReactElement => (
+  <>
+    <p>Introducing Lace 1.2.0 This version supports the following features:</p>
+    <ul style={{ listStyleType: 'disc', margin: 0 }}>
+      <li>Brave browser support</li>
+      <li>Organizing NFTs in folders</li>
+      <li>Hide/unhide the wallet balance</li>
+      <li>Improved wallet balance calculation</li>
+      <li>Improved DApp connector</li>
+      <li>Added performance improvements for token information requests</li>
+    </ul>
+  </>
+);
+
+export default ReleaseNote_1_2_0;


### PR DESCRIPTION
## Proposed solution

- Version increment for v1.2.0
- Release notes added

## Testing

With Lace 1.1.0 installed, upgrade to 1.2.0 and:
- assert release notes are viewable
- assert version is updates in `settings -> about`


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/310/5209282881/index.html) for [7acc266b](https://github.com/input-output-hk/lace/pull/97/commits/7acc266bc25160a448ac486ff23e7745fa5ce782)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->