### PR TITLE
fix(extension): handle tab keypress functionality for the asset input

### DIFF
--- a/packages/core/src/ui/components/AssetInput/AssetInputRow.tsx
+++ b/packages/core/src/ui/components/AssetInput/AssetInputRow.tsx
@@ -41,6 +41,14 @@ export const AssetInputRow = ({
     [coin?.id, maxDecimals, onBlur, value]
   );
 
+  const onFocus = useCallback(
+    (props) => {
+      setIsFocused(true);
+      row?.onFocus(props);
+    },
+    [row]
+  );
+
   useOnClickOutside(
     containerRef,
     () => {
@@ -57,7 +65,13 @@ export const AssetInputRow = ({
   return (
     <>
       <div id={`input-${idx}`} className={styles.assetRow} ref={containerRef} onClick={onClick}>
-        <AssetInput {...row} focused={isFocused} setFocus={(focusState) => setIsFocused(focusState)} onBlur={onBlur} />
+        <AssetInput
+          {...row}
+          focused={isFocused}
+          setFocus={(focusState) => setIsFocused(focusState)}
+          onBlur={onBlur}
+          onFocus={onFocus}
+        />
         {rowsLength > 1 && (
           <div
             onClick={onDelete}

--- a/packages/core/src/ui/components/AssetInput/__tests__/AssetInputRow.test.tsx
+++ b/packages/core/src/ui/components/AssetInput/__tests__/AssetInputRow.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AssetInputRow } from '../AssetInputRow';
+import { AssetInputProps } from '../AssetInput';
+
+describe('AssetInputRow', () => {
+  const props = {
+    getErrorMessage: jest.fn(),
+    coin: {},
+    setFocusInput: jest.fn(),
+    onFocus: jest.fn(),
+    onBlur: jest.fn(),
+    onChange: jest.fn(),
+    maxDecimals: 3,
+    focused: true,
+    displayValue: '123,456,78.901',
+    compactValue: '12.34M'
+  } as unknown as AssetInputProps;
+  beforeEach(async () => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+  describe('renders', () => {
+    test('correct display value in case it was focused using tab key event', async () => {
+      render(<AssetInputRow rowsLength={0} idx={0} {...props} />);
+      const input = screen.queryByTestId('coin-configure-input') as HTMLInputElement;
+
+      await userEvent.tab();
+      await userEvent.tab();
+      await userEvent.tab();
+
+      expect(input).toHaveFocus();
+
+      fireEvent.change(input, { target: { value: '12345678.901' } });
+
+      await waitFor(() => {
+        expect(input.value).toBe(props.displayValue);
+      });
+    });
+  });
+});

--- a/packages/core/test/__mocks__/svgMock.js
+++ b/packages/core/test/__mocks__/svgMock.js
@@ -1,0 +1,1 @@
+module.exports = { ReactComponent: 'div' };

--- a/packages/core/test/jest.config.js
+++ b/packages/core/test/jest.config.js
@@ -11,7 +11,8 @@ module.exports = {
   rootDir,
   moduleNameMapper: {
     '.*\\.(scss|sass|css|less)$': '<rootDir>/test/__mocks__/styleMock.js',
-    '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$': '<rootDir>/test/__mocks__/fileMock.js',
+    '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2)$': '<rootDir>/test/__mocks__/fileMock.js',
+    '\\.svg': '<rootDir>/test/__mocks__/svgMock.js',
     ...pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/src' })
   },
   preset: 'ts-jest',


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-6470
- [x] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Inner state that handles focused state was out of sync in case we are using on tab functionality (instead of clicking).

## Testing

Check all the steps described in the ticket.

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/317/5209730498/index.html) for [d4f50c9f](https://github.com/input-output-hk/lace/pull/100/commits/d4f50c9f7832c60381a3d585ae0f0477897cf561)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->