### PR TITLE
feat(extension): add blog link to 1.2.0 release notes

### DIFF
--- a/apps/browser-extension-wallet/src/release-notes/1_2_0.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_2_0.tsx
@@ -12,6 +12,12 @@ const ReleaseNote_1_2_0 = (): React.ReactElement => (
       <li>Improved DApp connector</li>
       <li>Added performance improvements for token information requests</li>
     </ul>
+    <p>
+      Check out the details in the{' '}
+      <a href="https://www.lace.io/blog/join-us-on-a-tour-of-lace-1-2" target="_blank">
+        blog
+      </a>
+    </p>
   </>
 );
 


### PR DESCRIPTION
## Proposed solution

Added blog link to the 1.2.0 release notes
