### PR TITLE
fix(extension): make the address book sorting case insensitive

### DIFF
--- a/apps/browser-extension-wallet/src/features/address-book/hooks/__tests__/useGetFilteredAddressBook.test.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/hooks/__tests__/useGetFilteredAddressBook.test.tsx
@@ -12,12 +12,12 @@ import { AppSettingsProvider } from '@providers';
 import { Cardano } from '@cardano-sdk/core';
 
 const makeDbContextWrapper =
-  (dbIntance: WalletDatabase): FunctionComponent =>
+  (dbInstance: WalletDatabase): FunctionComponent =>
   ({ children }: { children?: React.ReactNode }) =>
     (
       <AppSettingsProvider>
         <StoreProvider appMode="browser" store={create(() => ({ environmentName: 'Preprod' } as any))}>
-          <DatabaseProvider dbCustomInstance={dbIntance}>{children}</DatabaseProvider>
+          <DatabaseProvider dbCustomInstance={dbInstance}>{children}</DatabaseProvider>
         </StoreProvider>
       </AppSettingsProvider>
     );

--- a/apps/browser-extension-wallet/src/features/nfts/context/__test__/context.test.tsx
+++ b/apps/browser-extension-wallet/src/features/nfts/context/__test__/context.test.tsx
@@ -19,12 +19,12 @@ jest.mock('../NftsFoldersProvider', () => ({
 }));
 
 const makeDbContextWrapper =
-  (dbIntance: WalletDatabase): FunctionComponent =>
+  (dbInstance: WalletDatabase): FunctionComponent =>
   ({ children }: { children?: React.ReactNode }) =>
     (
       <AppSettingsProvider>
         <StoreProvider appMode="browser" store={create(() => ({ environmentName: 'Preprod' } as any))}>
-          <DatabaseProvider dbCustomInstance={dbIntance}>
+          <DatabaseProvider dbCustomInstance={dbInstance}>
             <NftsFoldersProvider>{children}</NftsFoldersProvider>
           </DatabaseProvider>
         </StoreProvider>

--- a/apps/browser-extension-wallet/src/lib/storage/helpers/index.ts
+++ b/apps/browser-extension-wallet/src/lib/storage/helpers/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable complexity */
+/* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import Dexie from 'dexie';
@@ -18,10 +20,52 @@ export const getErrorMessage = (error: Error): string => {
   return 'general.errors.somethingWentWrong';
 };
 
-export const sortTabletByName = (item: any[]) => {
-  const idxLetterStarts = item.findIndex((value: any) => new RegExp(/^[A-Za-z]/).test(value.name));
-  const alphabeticSide = item.slice(idxLetterStarts);
-  const numericSide = item.slice(0, idxLetterStarts);
+const numericRegExp = /^\d+$/;
+const alphanumericRegExp = /^(?=.*[A-Za-z])(?=.*\d)/;
+const startsWithNumberRegExp = /^\d/;
+const startsWithUppercaseRegExp = /^[A-Z]/;
+const startsWithLowercaseRegExp = /^[a-z]/;
 
-  return [...alphabeticSide, ...numericSide];
+const caseInsensitiveSortByCb = ({ name: nameA }: { name: string }, { name: nameB }: { name: string }) =>
+  nameA.localeCompare(nameB, undefined, { sensitivity: 'base' });
+
+export const sortTabletByName = (item: any[]) => {
+  const numerical = [];
+  const alphanumericStartsWithNumber = [];
+  const uppercase = [];
+  const alphanumericStartsWithUppercase = [];
+  const lowercase = [];
+  const alphanumericStartsWithLowerCase = [];
+  const alphabetical = [];
+
+  for (const value of item) {
+    const name = value.name.split('').join('');
+    // Number
+    if (numericRegExp.test(name)) numerical.push(value);
+    // Alphanumeric that starts with a number
+    else if (alphanumericRegExp.test(name) && startsWithNumberRegExp.test(name))
+      alphanumericStartsWithNumber.push(value);
+    // Alphanumeric that starts with uppercase
+    else if (alphanumericRegExp.test(name) && startsWithUppercaseRegExp.test(name))
+      alphanumericStartsWithUppercase.push(value);
+    // Alphanumeric that starts with lowercase
+    else if (alphanumericRegExp.test(name) && startsWithLowercaseRegExp.test(name))
+      alphanumericStartsWithLowerCase.push(value);
+    // Uppercase
+    else if (name.toString().toUpperCase() === name.toString()) uppercase.push(value);
+    // Lowercase
+    else if (name.toString().toLowerCase() === name.toString()) lowercase.push(value);
+    // alphabetical
+    else alphabetical.push(value);
+  }
+
+  return [
+    ...numerical.sort(caseInsensitiveSortByCb),
+    ...alphanumericStartsWithNumber.sort(caseInsensitiveSortByCb),
+    ...uppercase.sort(caseInsensitiveSortByCb),
+    ...alphanumericStartsWithUppercase.sort(caseInsensitiveSortByCb),
+    ...lowercase.sort(caseInsensitiveSortByCb),
+    ...alphanumericStartsWithLowerCase.sort(caseInsensitiveSortByCb),
+    ...alphabetical.sort(caseInsensitiveSortByCb)
+  ];
 };


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-6092
- [x] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

sort the items using localCompare util in the storage helpers

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/749/5444052896/index.html) for [72dcafbd](https://github.com/input-output-hk/lace/pull/103/commits/72dcafbd6204a20f17bc2907cf0910f5c55fa9fc)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->