### PR TITLE
test(extension): e2e - add missing cleanup step for DApp tests

### DIFF
--- a/packages/e2e-tests/src/features/DAppConnectorExtended.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorExtended.feature
@@ -41,6 +41,7 @@ Feature: DAppConnector - Extended view
     Then I see test DApp on the Authorized DApps list
     When I open test DApp
     Then I don't see DApp window
+    And I de-authorize all DApps in extended mode
 
   @LW-6880 @Testnet @Mainnet
   Scenario: Extended view - Remove authorized DApp, DApp requires authorization

--- a/packages/e2e-tests/src/features/DAppConnectorPopup.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorPopup.feature
@@ -41,6 +41,7 @@ Feature: DAppConnector - Popup view
     Then I see test DApp on the Authorized DApps list
     When I open test DApp
     Then I don't see DApp window
+    And I de-authorize all DApps in extended mode
 
   @LW-6882 @Testnet @Mainnet
   Scenario: Popup view - Remove authorized DApp, DApp requires authorization


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/331/5219626941/index.html) for [f8267ff7](https://github.com/input-output-hk/lace/pull/105/commits/f8267ff73f190092cf962bae663c532c65b3e1a0)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->