### PR TITLE
ci(all): update labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,3 +13,6 @@ e2e:
 # Docs targets
 documentation:
   - any: ['docs/**/*', '**/*.md']
+# CI targets
+ci:
+  - any: ['.github/**/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,18 +1,18 @@
-# Browser extension target
+# Browser extension
 browser:
   - any: ['apps/browser-extension-wallet/**/*']
-# Staking & Multi-delegation
+# Staking
 staking:
   - any: ['packages/staking/**/*']
 # UI Toolkit
 ui-toolkit:
   - any: ['packages/ui/**/*']
-# E2E targets
+# E2E
 e2e:
   - any: ['features/**/*', 'packages/e2e-tests/**/*']
-# Docs targets
+# Docs
 documentation:
   - any: ['docs/**/*', '**/*.md']
-# CI targets
+# CI
 ci:
   - any: ['.github/**/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,5 @@
+# IMPORTANT: Please remember to add new labels to the `settings.yml`
+
 # Browser extension
 browser:
   - any: ['apps/browser-extension-wallet/**/*']

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -19,6 +19,7 @@ repository:
   enable_vulnerability_alerts: true
 
 # Labels: define labels for Issues and Pull Requests
+# IMPORTANT: Please remember to add new labels to the `labeler.yml`
 labels:
   - name: browser
     description: Changes to the browser application.

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -22,21 +22,27 @@ repository:
 labels:
   - name: browser
     description: Changes to the browser application.
+    color: '#FF6B35'
 
   - name: staking
     description: Changes to the staking package.
+    color: '#685369'
 
   - name: ui-toolkit
     description: Changes to the ui package.
+    color: '#FFBF00'
 
   - name: e2e
     description: Changes to the e2e testing instrumentation.
+    color: '#0B4F6C'
 
   - name: documentation
     description: Documentation related issues or pull requests.
+    color: '#81D2C7'
 
   - name: ci
     description: CI related issues or pull requests.
+    color: '#474747'
 
 # See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -35,6 +35,9 @@ labels:
   - name: documentation
     description: Documentation related issues or pull requests.
 
+  - name: ci
+    description: CI related issues or pull requests.
+
 # See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:
   # The permission to grant the team. Can be one of:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -26,6 +26,9 @@ labels:
   - name: staking
     description: Changes to the staking package.
 
+  - name: ui-toolkit
+    description: Changes to the ui package.
+
   - name: e2e
     description: Changes to the e2e testing instrumentation.
 


### PR DESCRIPTION
## Proposed solution

Update the labels list in `settings.yml` so the settings bot does not remove the `ui-toolkit` label assigned by `labeler.yml` and introduce a new `ci` label and colors.

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/332/5220437290/index.html) for [584b8f4e](https://github.com/input-output-hk/lace/pull/106/commits/584b8f4e0885dc35da219639c98a95d91d9ca0a2)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->