### PR TITLE
fix(extension): make remove option visible for non empty input

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/MetadataInput.module.scss
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/MetadataInput.module.scss
@@ -11,11 +11,19 @@
 
   &.visibleCounter {
     padding-bottom: size_unit(2.5);
+
+    :global(.ant-input-suffix) {
+      position: absolute;
+      right: size_unit(0.5);
+      top: size_unit(0.5);
+      width: size_unit(6.5);
+    }
   }
 
   input {
     @include text-bodyLarge-medium;
     color: var(--text-color-primary) !important;
+    transition: none;
     ::placeholder {
       color: var(--text-color-secondary) !important;
     }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/MetadataInput.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/MetadataInput.tsx
@@ -33,7 +33,10 @@ export const MetadataInput = (): React.ReactElement => {
         value={value}
         onChange={handleChange}
         suffix={
-          <div className={classnames(styles.suffixContent, { [styles.focus]: focused || value?.length > 0 })}>
+          <div
+            data-testid="metadata-input-suffix"
+            className={classnames(styles.suffixContent, { [styles.focus]: focused || value?.length > 0 })}
+          >
             <TextBoxItem iconClassName={styles.iconSize} onClick={handleClick} disabled={!value} />
           </div>
         }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/__tests__/MetadataInput.test.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/__tests__/MetadataInput.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MetadataInput } from '../MetadataInput';
+import i18n from '@lib/i18n';
+import { I18nextProvider } from 'react-i18next';
+
+const WrappedMetadataInput = () => (
+  <I18nextProvider i18n={i18n}>
+    <MetadataInput />
+  </I18nextProvider>
+);
+
+describe('MetadataInput', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+  describe('renders', () => {
+    test('suffix that is not hidden behind the input content', async () => {
+      render(<WrappedMetadataInput />);
+      const input = screen.queryByTestId('metadata-input') as HTMLInputElement;
+
+      fireEvent.change(input, {
+        target: { value: 'asdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasdasd' }
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-input-suffix')).toBeVisible();
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-6468
- [x] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Apply proper css stylings.

## Testing

Check the description in the ticket.

## Screenshots

<img width="645" alt="Screenshot 2023-06-09 at 12 35 13" src="https://github.com/input-output-hk/lace/assets/7934077/5b6a3b62-ba98-4f11-960c-43533a564773">



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/334/5220481365/index.html) for [90a5cfda](https://github.com/input-output-hk/lace/pull/107/commits/90a5cfdaff18dfccb31c8d1057b5c696274b88d0)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->