### PR TITLE
fix(extension): filter out NFTs for `hasTokens` check in Asset list

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/Assets.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/Assets.tsx
@@ -199,7 +199,17 @@ export const Assets = ({ topSection }: AssetsProps): React.ReactElement => {
   /**
    * Means it has more than 1 asset (ADA) in portfolio for Assets list.
    */
-  const hasTokens = useMemo(() => !isNil(total?.assets) && total?.assets?.size > 0, [total?.assets]);
+  const hasTokens = useMemo(() => {
+    if (isNil(total?.assets) || total?.assets?.size === 0) return false;
+    // Look for at least one asset that is not an NFT
+    for (const [assetId] of total.assets) {
+      const assetInfo = assetsInfo?.get(assetId);
+      // If no assetInfo, assume it's not an NFT until the info is loaded
+      if (!assetInfo || !isNFT(assetInfo)) return true;
+    }
+    // Return false if all assets are NFTs as we are not displaying them in this component
+    return false;
+  }, [assetsInfo, total?.assets]);
   /**
    * Assets are loading if only ADA was populated in the list and there are more assets to load and append to the UI.
    */


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-6938

---

## Proposed solution

Balance stays in a loading state when the wallet has one or more NFTs and no fungible tokens besides ADA.
- Do not take into account NFTs when checking if the user has tokens in `Assets.tsx` component as we are not showing them on this screen

## Testing

Use a wallet with only NFTs and no other assets than ADA to test.


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/345/5223610597/index.html) for [a415f415](https://github.com/input-output-hk/lace/pull/111/commits/a415f415619c0257691b3886f5fd124efa80d0dc)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->