### PR TITLE
refactor(extension): use get-assets instead of get-asset as fallback

### DIFF
--- a/apps/browser-extension-wallet/src/utils/__tests__/get-assets-information.test.ts
+++ b/apps/browser-extension-wallet/src/utils/__tests__/get-assets-information.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 /* eslint-disable @typescript-eslint/no-shadow */
 import '@testing-library/jest-dom';
 import { Wallet } from '@lace/cardano';
@@ -13,6 +14,10 @@ describe('Testing getAssetsInformation function', () => {
   const assetsInfo: TokenInfo = new Map([[assetsIdList[0], mockAssetMetadata]]);
   const assetProvider = Wallet.mockUtils.assetsProviderStub();
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('should get asset information by id when existing in assets info map', async () => {
     const assets = await getAssetsInformation([assetsIdList[0]], assetsInfo, {
       assetProvider,
@@ -24,7 +29,7 @@ describe('Testing getAssetsInformation function', () => {
 
     expect(assets.size).toEqual(1);
     expect(assets.get(assetsIdList[0])).toEqual(mockAssetMetadata);
-    expect(assetProvider.getAsset).not.toHaveBeenCalled();
+    expect(assetProvider.getAssets).not.toHaveBeenCalled();
   });
 
   test('should fetch asset information from provider when not existing in assets info map', async () => {
@@ -38,16 +43,21 @@ describe('Testing getAssetsInformation function', () => {
 
     expect(assets.size).toEqual(1);
     expect(assets.get(assetsIdList[1])).toEqual(Wallet.mockUtils.mockedAssets[0]);
-    expect(assetProvider.getAsset).toHaveBeenCalled();
+    expect(assetProvider.getAssets).toHaveBeenCalledWith({
+      assetIds: [assetsIdList[1]],
+      extraData: {
+        nftMetadata: true,
+        tokenMetadata: true
+      }
+    });
   });
 
   test('should skip an asset in case provider throws', async () => {
-    const consoleSpy = jest.spyOn(console, 'log');
     const error = 'error';
     const assetProvider = {
-      getAsset: async () => {
+      getAssets: jest.fn(() => {
         throw new Error(error);
-      }
+      })
     } as unknown as AssetProvider;
     const assets = await getAssetsInformation([assetsIdList[1]], assetsInfo, {
       assetProvider,
@@ -58,6 +68,31 @@ describe('Testing getAssetsInformation function', () => {
     });
 
     expect(assets.size).toEqual(0);
-    expect(consoleSpy).toHaveBeenCalledWith('Error fetching asset info', { assetId: assetsIdList[1], error });
+    expect(assetProvider.getAssets).toHaveBeenCalled();
+    expect(assetProvider.getAssets).not.toHaveReturned();
+  });
+
+  describe('chunks', () => {
+    test('should call getAssets once if amount of assets is less than or equal 100', async () => {
+      const hundredAssets = Array.from<Wallet.Cardano.AssetId>({ length: 100 }).fill(assetsIdList[1]);
+      await getAssetsInformation(hundredAssets, assetsInfo, { assetProvider });
+      expect(assetProvider.getAssets).toHaveBeenCalledTimes(1);
+      expect(assetProvider.getAssets).toHaveBeenCalledWith({ assetIds: hundredAssets });
+    });
+
+    test('should call getAssets in chunks of 100 or less if the amount of assets is greater than 100', async () => {
+      const lotsOfAssets = Array.from<Wallet.Cardano.AssetId>({ length: 250 }).fill(assetsIdList[1]);
+      await getAssetsInformation(lotsOfAssets, assetsInfo, { assetProvider });
+      expect(assetProvider.getAssets).toHaveBeenCalledTimes(3);
+      expect(assetProvider.getAssets).toHaveBeenNthCalledWith(1, {
+        assetIds: Array.from<Wallet.Cardano.AssetId>({ length: 100 }).fill(assetsIdList[1])
+      });
+      expect(assetProvider.getAssets).toHaveBeenNthCalledWith(2, {
+        assetIds: Array.from<Wallet.Cardano.AssetId>({ length: 100 }).fill(assetsIdList[1])
+      });
+      expect(assetProvider.getAssets).toHaveBeenNthCalledWith(3, {
+        assetIds: Array.from<Wallet.Cardano.AssetId>({ length: 50 }).fill(assetsIdList[1])
+      });
+    });
   });
 });

--- a/packages/cardano/src/wallet/test/mocks/AssetsProviderStub.ts
+++ b/packages/cardano/src/wallet/test/mocks/AssetsProviderStub.ts
@@ -41,7 +41,7 @@ export const assetsProviderStub = (assets: Asset.AssetInfo[] = mockedAssets): As
   getAssets: jest.fn().mockImplementation(
     ({ assetIds }) =>
       // eslint-disable-next-line promise/avoid-new
-      new Promise((resolve) => resolve(assets.find((asset) => assetIds.includes(asset.assetId)) || assets[0]))
+      new Promise((resolve) => resolve(assets.filter((asset) => assetIds.includes(asset.assetId)) || assets[0]))
   ),
   healthCheck: jest.fn().mockResolvedValue({ ok: true })
 });


### PR DESCRIPTION
# Checklist

- [x] Proper tests implemented

---

## Proposed solution

- Replace calls to `assetProvider.getAsset` for each asset and instead call `assetProvider.getAssets` in chunks of 100 assets max in case the assets info wasn't found in the wallet's `assetInfo$`

## Testing

Asset information should still be displayed properly everywhere, including dapp transactions

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/425/5280751044/index.html) for [7416df86](https://github.com/input-output-hk/lace/pull/116/commits/7416df86d1bb061891a4ee2aa0eea1eb973d53d1)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->