### PR TITLE
fix(extension): add description into the setup mnemonics for recovery flow

### DIFF
--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -1131,6 +1131,7 @@
     "walletSetupMnemonicStep": {
       "writePassphrase": "Write down your secret passphrase",
       "enterPassphrase": "Enter your secret passphrase",
+      "enterPassphraseDescription": "Please enter each word of your recovery phrase in the right order to verify it and recover your wallet.",
       "body": "Now let's check you've got the correct secret passphrase. Enter each word of your passphrase in the right order to verify it.",
       "passphraseInfo1": "Make sure you create an offline backup of your secret passphrase.",
       "passphraseInfo2": "Do not store your backup digitally.",

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -125,6 +125,7 @@ export const WalletSetupWizard = ({
     writePassphrase: t('core.walletSetupMnemonicStep.writePassphrase'),
     body: t('core.walletSetupMnemonicStep.body'),
     enterPassphrase: t('core.walletSetupMnemonicStep.enterPassphrase'),
+    enterPassphraseDescription: t('core.walletSetupMnemonicStep.enterPassphraseDescription'),
     passphraseInfo1: t('core.walletSetupMnemonicStep.passphraseInfo1'),
     passphraseInfo2: t('core.walletSetupMnemonicStep.passphraseInfo2'),
     passphraseInfo3: t('core.walletSetupMnemonicStep.passphraseInfo3'),

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupMnemonicVerificationStep.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupMnemonicVerificationStep.tsx
@@ -16,7 +16,7 @@ export interface WalletSetupMnemonicVerificationStepProps {
   onStepNext?: (currentStep: number) => void;
   isSubmitEnabled: boolean;
   mnemonicWordsInStep?: number;
-  translations: TranslationsFor<'enterPassphrase' | 'passphraseError'>;
+  translations: TranslationsFor<'enterPassphrase' | 'passphraseError' | 'enterPassphraseDescription'>;
   suggestionList?: Array<string>;
   isBackToMnemonic: boolean;
   setIsBackToMnemonic: (value: boolean) => void;
@@ -68,6 +68,7 @@ export const WalletSetupMnemonicVerificationStep = ({
   };
 
   const title = translations.enterPassphrase;
+  const description = translations.enterPassphraseDescription;
 
   const currentStepFirstWordIndex = mnemonicStep * mnemonicWordsInStep;
   const currentStepLastWordIndex = (mnemonicStep + 1) * mnemonicWordsInStep;
@@ -92,6 +93,7 @@ export const WalletSetupMnemonicVerificationStep = ({
   return (
     <WalletSetupStepLayout
       title={title}
+      description={description}
       stepInfoText={getStepInfoText()}
       onBack={handleBack}
       onNext={handleNext}

--- a/packages/core/src/ui/components/WalletSetup/__tests__/WalletSetupMnemonicVerificationStep.test.tsx
+++ b/packages/core/src/ui/components/WalletSetup/__tests__/WalletSetupMnemonicVerificationStep.test.tsx
@@ -36,7 +36,8 @@ const Test = () => {
       onSubmit={jest.fn()}
       translations={{
         enterPassphrase: 'Enter passphrase',
-        passphraseError: 'Passphrase error'
+        passphraseError: 'Passphrase error',
+        enterPassphraseDescription: 'Enter passphrase description'
       }}
       setIsBackToMnemonic={jest.fn()}
       isBackToMnemonic={false}
@@ -74,5 +75,12 @@ describe('<WalletSetupMnemonicVerificationStep>', () => {
 
     const input16th = await findInputByIndex(16);
     expect(input16th).toHaveValue('');
+  });
+
+  it('should render proper description', async () => {
+    render(<Test />);
+
+    const { getByText } = within(screen.getByTestId('wallet-setup-step-subtitle'));
+    expect(getByText('Enter passphrase description')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-6132
- [x] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Add missing description into the file with all the translations.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

<img width="1728" alt="Screenshot 2023-06-13 at 09 20 27" src="https://github.com/input-output-hk/lace/assets/7934077/3bdd8a1c-cd27-47d3-890f-92c160865a36">



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/365/5252048019/index.html) for [7433d618](https://github.com/input-output-hk/lace/pull/118/commits/7433d61855d0a58b9898225d50d79c21ee3a9944)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->