### PR TITLE
fix(extension): add navigation and title into the recieve drawer in the staking flow

### DIFF
--- a/apps/browser-extension-wallet/src/providers/ThemeProvider/context.tsx
+++ b/apps/browser-extension-wallet/src/providers/ThemeProvider/context.tsx
@@ -53,15 +53,15 @@ export const ThemeProvider = ({ children, customTheme, defaultThemeName }: Theme
   useEffect(() => {
     const preferedTheme = localStorage.getItem('mode') as themeTypes;
     let userAgentColorScheme: themeTypes = 'light';
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)')?.matches) {
       userAgentColorScheme = 'dark';
     }
 
     changeTheme(getThemeName(preferedTheme || userAgentColorScheme));
-    if (window.matchMedia('(prefers-color-scheme)').media !== 'not all') {
+    if (window.matchMedia('(prefers-color-scheme)')?.media !== 'not all') {
       const media = window.matchMedia('(prefers-color-scheme: dark)');
       const change = (e: MediaQueryListEvent) => changeTheme(e.matches ? 'dark' : 'light');
-      media.addEventListener('change', change);
+      media?.addEventListener('change', change);
 
       return () => media.removeEventListener('change', change);
     }

--- a/apps/browser-extension-wallet/src/views/browser-view/components/QRInfoWalletDrawer/QRInfoWalletDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/QRInfoWalletDrawer/QRInfoWalletDrawer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { InfoWallet } from '@lace/core';
 import { useTheme } from '@providers/ThemeProvider';
-import { useWalletStore } from '../../../../stores';
+import { useWalletStore } from '@src/stores';
 import styles from './QRInfoWalletDrawer.module.scss';
 import { useTranslation } from 'react-i18next';
 import { useDrawer } from '../../stores';
@@ -33,7 +33,7 @@ export const QRInfoWalletDrawer = (): React.ReactElement => {
     <div className={styles.infoContainer}>
       <InfoWallet
         getQRCodeOptions={() => getQRCodeOptions(theme)}
-        walletInfo={{ name: (handles?.length && handles[0]?.nftMetadata.name) || name, qrData: address.toString() }}
+        walletInfo={{ name: (handles?.length && handles[0]?.nftMetadata.name) || name, qrData: address?.toString() }}
         translations={infoWalletTranslations}
       />
     </div>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingModals/StakingModals.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingModals/StakingModals.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDrawer } from '@views/browser/stores';
@@ -11,6 +12,7 @@ import {
   AnalyticsEventNames
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { useAnalyticsContext } from '@providers';
+import { DrawerHeader, DrawerNavigation } from '@lace/common';
 
 type StakingModalsProps = {
   popupView?: boolean;
@@ -98,7 +100,7 @@ export const StakingModals = ({ popupView }: StakingModalsProps): React.ReactEle
         actions={[
           {
             body: t('browserView.staking.details.noFundsModal.buttons.cancel'),
-            dataTestId: 'no-funds-modal-confirm',
+            dataTestId: 'no-funds-modal-cancel',
             onClick: () => setNoFundsVisible(false),
             color: 'secondary'
           },
@@ -107,7 +109,15 @@ export const StakingModals = ({ popupView }: StakingModalsProps): React.ReactEle
             dataTestId: 'no-funds-modal-confirm',
             onClick: () => {
               setNoFundsVisible(false);
-              setDrawerConfig({ content: DrawerContent.RECEIVE_TRANSACTION });
+              setDrawerConfig({
+                content: DrawerContent.RECEIVE_TRANSACTION,
+                renderHeader: () => (
+                  <DrawerNavigation title={t('qrInfo.receive')} onCloseIconClick={() => setDrawerConfig()} />
+                ),
+                renderTitle: () => (
+                  <DrawerHeader title={t('qrInfo.title')} subtitle={t('qrInfo.scanQRCodeToConnectWallet')} />
+                )
+              });
               setIsDrawerVisible(false);
             }
           }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingModals/__tests__/StakingModals.test.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingModals/__tests__/StakingModals.test.tsx
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable import/imports-first */
+const mockUseStakePoolDetails = jest.fn();
+const mockUseWalletStore = jest.fn();
+/* eslint-disable sonarjs/no-duplicate-string */
+import * as React from 'react';
+import { render, fireEvent, waitFor, screen, within } from '@testing-library/react';
+import { StakingModals } from '../StakingModals';
+import '@testing-library/jest-dom';
+
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../../../../../../lib/i18n';
+import { AnalyticsProvider, AppSettingsProvider, ThemeProvider } from '@providers';
+import { StoreProvider } from '@src/stores';
+import { APP_MODE_BROWSER } from '@src/utils/constants';
+import { DrawerUIContainer } from '@src/views/browser-view/components/Drawer';
+import { BehaviorSubject } from 'rxjs';
+
+jest.mock('../../../store', () => ({
+  ...jest.requireActual<any>('../../../store'),
+  useStakePoolDetails: mockUseStakePoolDetails
+}));
+
+const handles$ = new BehaviorSubject(true);
+
+const inMemoryWallet = {
+  handles$
+};
+jest.mock('@src/stores', () => ({
+  ...jest.requireActual<any>('@src/stores'),
+  useWalletStore: mockUseWalletStore
+}));
+
+describe('Testing StakingModal component', () => {
+  test('should render no funds modal and open receive drawer with proper header, title and subtitle', async () => {
+    mockUseWalletStore.mockReturnValue({
+      inMemoryWallet
+    });
+    mockUseStakePoolDetails.mockReturnValue({
+      isNoFundsVisible: true,
+      setIsDrawerVisible: jest.fn(),
+      setNoFundsVisible: () => {
+        mockUseStakePoolDetails.mockReset();
+        mockUseStakePoolDetails.mockReturnValue({
+          isNoFundsVisible: false
+        });
+      }
+    });
+    render(
+      <AppSettingsProvider>
+        <StoreProvider appMode={APP_MODE_BROWSER}>
+          <I18nextProvider i18n={i18n}>
+            <AnalyticsProvider featureEnabled={false}>
+              <ThemeProvider>
+                <DrawerUIContainer />
+              </ThemeProvider>
+              <StakingModals />
+            </AnalyticsProvider>
+          </I18nextProvider>
+        </StoreProvider>
+      </AppSettingsProvider>
+    );
+
+    expect(within(screen.getByTestId('stake-modal-title')).getByText("You don't have enough funds to stake..."));
+
+    fireEvent.click(await screen.findByTestId('no-funds-modal-confirm'));
+
+    await waitFor(async () => {
+      expect(screen.queryByText("You don't have enough funds to stake...")).toBeNull();
+
+      const navigation = await within(await screen.getByTestId('drawer-navigation'));
+      await waitFor(async () => {
+        expect(navigation.getByText('Receive')).toBeInTheDocument();
+        expect(within(screen.getByTestId('drawer-header-title')).getByText('Your wallet address')).toBeInTheDocument();
+        expect(
+          within(screen.getByTestId('drawer-header-subtitle')).getByText('Scan QR code or copy address')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-6440
- [x] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Explain how does this PR solves the problem stated in JIRA ticket.
You can also enumerate different alternatives considered while approaching this task.

## Testing

pass proper values into the `setDrawerConfig` util.

## Screenshots

<img width="1054" alt="Screenshot 2023-06-13 at 11 28 44" src="https://github.com/input-output-hk/lace/assets/7934077/54f58835-0ea5-4b6e-ba28-ca1298d7baa7">



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/482/5312475880/index.html) for [a77f1951](https://github.com/input-output-hk/lace/pull/119/commits/a77f1951ac54d5e18d9bd9d1bc968ff456348be4)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->