### PR TITLE
fix: transaction builder signing

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useInitializeTx.ts
+++ b/apps/browser-extension-wallet/src/hooks/useInitializeTx.ts
@@ -62,7 +62,7 @@ export const useInitializeTx = (
     if (hasInvalidOutputs || reachedMaxAmountList.length > 0) {
       setBuiltTxData({
         uiTx: undefined,
-        txBuilder: undefined,
+        tx: undefined,
         totalMinimumCoins: undefined,
         error: undefined,
         reachedMaxAmountList
@@ -78,15 +78,15 @@ export const useInitializeTx = (
 
         outputsWithMissingCoins.outputs.forEach((output) => txBuilder.addOutput(output));
         txBuilder.metadata(partialTxProps?.auxiliaryData?.blob || new Map());
-        const tx = await txBuilder.build().inspect();
-
+        const tx = txBuilder.build();
+        const inspection = await tx.inspect();
         setBuiltTxData({
           uiTx: {
-            fee: tx.inputSelection.fee,
-            hash: tx.hash,
-            outputs: tx.inputSelection.outputs
+            fee: inspection.inputSelection.fee,
+            hash: inspection.hash,
+            outputs: inspection.inputSelection.outputs
           },
-          txBuilder,
+          tx,
           totalMinimumCoins,
           error: undefined,
           reachedMaxAmountList: []
@@ -95,7 +95,7 @@ export const useInitializeTx = (
         console.error('error initializing transaction:', { error });
         setBuiltTxData({
           uiTx: undefined,
-          txBuilder: undefined,
+          tx: undefined,
           error: error.message,
           reachedMaxAmountList: []
         });

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -111,7 +111,7 @@ export const Footer = ({ isPopupView, openContinueDialog }: FooterProps): React.
   const isHwSummary = useMemo(() => isSummaryStep && !isInMemory, [isSummaryStep, isInMemory]);
 
   const signAndSubmitTransaction = useCallback(async () => {
-    const { tx } = await builtTxData.txBuilder.build().sign();
+    const { tx } = await builtTxData.tx.sign();
     await inMemoryWallet.submitTx(tx);
   }, [builtTxData, inMemoryWallet]);
 
@@ -191,8 +191,8 @@ export const Footer = ({ isPopupView, openContinueDialog }: FooterProps): React.
   ]);
 
   const confirmDisable = useMemo(
-    () => !builtTxData.txBuilder || hasInvalidOutputs || metadata?.length > METADATA_MAX_LENGTH,
-    [builtTxData.txBuilder, hasInvalidOutputs, metadata]
+    () => !builtTxData.tx || hasInvalidOutputs || metadata?.length > METADATA_MAX_LENGTH,
+    [builtTxData.tx, hasInvalidOutputs, metadata]
   );
   const isSubmitDisabled = useMemo(
     () =>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
@@ -1,6 +1,5 @@
 import { CardanoTxOut, TxMinimumCoinQuantity } from '../../../../types';
 import { Wallet } from '@lace/cardano';
-import { TxBuilder } from '@cardano-sdk/tx-construction';
 
 export enum Sections {
   FORM = 'form',
@@ -28,7 +27,7 @@ export type OutputsMap = Map<string, CardanoOutput>;
 
 export interface BuiltTxData {
   totalMinimumCoins?: TxMinimumCoinQuantity;
-  txBuilder?: TxBuilder;
+  tx?: Wallet.UnsignedTx;
   uiTx?: {
     hash: Wallet.Cardano.TransactionId;
     outputs: Set<Wallet.Cardano.TxOut>;

--- a/packages/cardano/src/wallet/index.ts
+++ b/packages/cardano/src/wallet/index.ts
@@ -39,7 +39,8 @@ export {
   InitializeTxProps,
   InitializeTxResult,
   InitializeTxPropsValidationResult,
-  MinimumCoinQuantityPerOutput
+  MinimumCoinQuantityPerOutput,
+  UnsignedTx
 } from '@cardano-sdk/tx-construction';
 
 export * as KeyManagement from '../../../../node_modules/@cardano-sdk/key-management/dist/cjs';


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-6991](https://input-output.atlassian.net/browse/LW-6991)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Utilises only building the transaction once with `txBuilder`, and signing only at point of submit

## Testing

1. Open Lace with restored wallet
2. Click send
3. Use Ada
4. Proceed with sending transaction until the success screen
5. Copy the transaction hash
6. Go to activity section
7. Assert the transaction hash from step 5 matches the one display after the transaction has settled and links to correct cexplorer link

## Screenshots

![Screenshot 2023-06-14 at 13 02 23](https://github.com/input-output-hk/lace/assets/7581002/c1b6b203-cbc5-468e-aacd-015c383fde80)
![Screenshot 2023-06-14 at 13 02 34](https://github.com/input-output-hk/lace/assets/7581002/a6d6dee1-1ec5-40bf-aa2a-293d84d5b327)
![Screenshot 2023-06-14 at 13 06 16](https://github.com/input-output-hk/lace/assets/7581002/2e4d11d0-77d0-438f-a7b5-b6c05938da80)


[LW-6991]: https://input-output.atlassian.net/browse/LW-6991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/396/5266923223/index.html) for [a71da8f2](https://github.com/input-output-hk/lace/pull/123/commits/a71da8f2cd54a09c4597ed5bbca9388659d3d7ba)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 14     | 5      | 0       | 0     | 19    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->