### PR TITLE
chore: update codeowners to not require review from leads for yarn.lock changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Root Level
 *                       @input-output-hk/lace-tech-leads
-
+yarn.lock               @input-output-hk/lace-core
 # Packages Teams
 /packages/ui/           @input-output-hk/lace-ui
 /packages/staking/      @input-output-hk/lace-staking


### PR DESCRIPTION
Update would exclude review from lace-tech-leads for yarn.lock changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/399/5267196526/index.html) for [60b93f0e](https://github.com/input-output-hk/lace/pull/125/commits/60b93f0e6d77b451993ad5e0e56264825be3a6cf)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 13     | 6      | 0       | 0     | 19    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->