### PR TITLE
fix(extension): remove brave support from 1.2.0 release note

### DIFF
--- a/apps/browser-extension-wallet/src/release-notes/1_1_1.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_1_1.tsx
@@ -1,0 +1,10 @@
+/* eslint-disable camelcase */
+import React from 'react';
+
+const ReleaseNote_1_1_1 = (): React.ReactElement => (
+  <>
+    <p>Introducing Lace 1.1.1 now supporting the Brave browser!</p>
+  </>
+);
+
+export default ReleaseNote_1_1_1;

--- a/apps/browser-extension-wallet/src/release-notes/1_2_0.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_2_0.tsx
@@ -5,7 +5,6 @@ const ReleaseNote_1_2_0 = (): React.ReactElement => (
   <>
     <p>Introducing Lace 1.2.0 This version supports the following features:</p>
     <ul style={{ listStyleType: 'disc', margin: 0 }}>
-      <li>Brave browser support</li>
       <li>Organizing NFTs in folders</li>
       <li>Hide/unhide the wallet balance</li>
       <li>Improved wallet balance calculation</li>


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/421/5279789225/index.html) for [7d3617d5](https://github.com/input-output-hk/lace/pull/131/commits/7d3617d50f72c0760f86126ee9641ee97c2dcb5d)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 18     | 1      | 0       | 0     | 19    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->