### PR TITLE
test(extension): e2e - add dapp connector tests

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/NoWallet.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/NoWallet.tsx
@@ -18,11 +18,15 @@ export const NoWallet = (): React.ReactElement => {
     <div data-testid="no-wallet-container" className={styles.noWalletContainer}>
       <div className={styles.noWalletContent}>
         <Image data-testid="no-wallet-image" preview={false} width={112} src={Empty} />
-        <div className={styles.heading}>{t('dapp.noWallet.heading')}</div>
-        <div className={styles.description}>{t('dapp.noWallet.description')}</div>
+        <div className={styles.heading} data-testid="no-wallet-heading">
+          {t('dapp.noWallet.heading')}
+        </div>
+        <div className={styles.description} data-testid="no-wallet-description">
+          {t('dapp.noWallet.description')}
+        </div>
       </div>
       <div className={styles.footer}>
-        <Button data-test-id="create-or-restore-wallet-btn" className={styles.footerBtn} onClick={openCreatePage}>
+        <Button data-testid="create-or-restore-wallet-btn" className={styles.footerBtn} onClick={openCreatePage}>
           {t('dapp.nowallet.btn')}
         </Button>
       </div>

--- a/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
+++ b/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
@@ -11,6 +11,7 @@ import DAppTransactionAllDonePage from '../elements/dappConnector/dAppTransactio
 import { Logger } from '../support/logger';
 import testContext from '../utils/testContext';
 import RemoveDAppModal from '../elements/dappConnector/removeDAppModal';
+import NoWalletModal from '../elements/dappConnector/noWalletModal';
 
 export type ExpectedDAppDetails = {
   hasLogo: boolean;
@@ -92,6 +93,21 @@ class DAppConnectorAssert {
 
     await AuthorizeDAppModal.onceButton.waitForDisplayed();
     await expect(await AuthorizeDAppModal.onceButton.getText()).to.equal(await t('dapp.connect.modal.allowOnce'));
+  }
+
+  async assertSeeNoWalletModal() {
+    await this.assertSeeHeader();
+    await NoWalletModal.container.waitForDisplayed();
+    await NoWalletModal.image.waitForDisplayed();
+
+    await NoWalletModal.title.waitForDisplayed();
+    await expect(await NoWalletModal.title.getText()).to.equal(await t('dapp.noWallet.heading'));
+
+    await NoWalletModal.description.waitForDisplayed();
+    await expect(await NoWalletModal.description.getText()).to.equal(await t('dapp.noWallet.description'));
+
+    await NoWalletModal.createRestoreButton.waitForDisplayed();
+    await expect(await NoWalletModal.createRestoreButton.getText()).to.equal(await t('dapp.nowallet.btn'));
   }
 
   async assertSeeDAppRemovalConfirmationModal() {

--- a/packages/e2e-tests/src/elements/dappConnector/noWalletModal.ts
+++ b/packages/e2e-tests/src/elements/dappConnector/noWalletModal.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-undef */
+import { ChainablePromiseElement } from 'webdriverio';
+
+class NoWalletModal {
+  private CONTAINER = '[data-testid="no-wallet-container"]';
+  private IMAGE = '[data-testid="no-wallet-image"]';
+  private TITLE = '[data-testid="no-wallet-heading"]';
+  private DESCRIPTION = '[data-testid="no-wallet-description"]';
+  private CREATE_RESTORE_BUTTON = '[data-testid="create-or-restore-wallet-btn"]';
+
+  get container(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CONTAINER);
+  }
+
+  get image(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.IMAGE);
+  }
+
+  get title(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TITLE);
+  }
+
+  get description(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.DESCRIPTION);
+  }
+
+  get createRestoreButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CREATE_RESTORE_BUTTON);
+  }
+}
+
+export default new NoWalletModal();

--- a/packages/e2e-tests/src/features/DAppConnector.feature
+++ b/packages/e2e-tests/src/features/DAppConnector.feature
@@ -16,6 +16,18 @@ Feature: DAppConnector - Common
     When I click "Authorize" button in DApp authorization window
     Then I see DApp connection modal
 
+  @LW-3756 @Testnet @Mainnet
+  Scenario: Canceling DApp connection
+    When I open test DApp
+    Then I see DApp authorization window
+    When I click "Cancel" button in DApp authorization window
+    Then I don't see DApp window
+    And I see Lace wallet info in DApp when not connected
+    And I switch to window with Lace
+    And I close all remaining tabs except current one
+    When I open test DApp
+    Then I see DApp authorization window
+
   @LW-4062 @Testnet @Mainnet
   Scenario: Authorize app functions as expected when the user chooses 'Only once'
     When I open test DApp
@@ -37,3 +49,15 @@ Feature: DAppConnector - Common
     And I close all remaining tabs except current one
     And I open test DApp
     Then I don't see DApp window
+
+  @LW-3807 @Testnet @Mainnet
+  Scenario: "No wallet" modal displayed after trying to connect Dapp when there is no wallet
+    Given I remove wallet
+    And "Get started" page is displayed
+    When I open test DApp
+    And I close all remaining tabs except current one
+    Then I see DApp no wallet modal
+    When I click "Create or restore a wallet" button in DApp no wallet modal
+    And I switch to window with Lace
+    Then "Get started" page is displayed
+

--- a/packages/e2e-tests/src/features/DAppConnectorExtended.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorExtended.feature
@@ -57,3 +57,4 @@ Feature: DAppConnector - Extended view
     Then I see "Authorized DApps" section empty state in extended mode
     When I open test DApp
     Then I see DApp authorization window
+    And I see Lace wallet info in DApp when not connected

--- a/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
@@ -10,6 +10,7 @@ import ToastMessage from '../elements/toastMessage';
 import RemoveDAppModal from '../elements/dappConnector/removeDAppModal';
 import testContext from '../utils/testContext';
 import ConfirmTransactionPage from '../elements/dappConnector/confirmTransactionPage';
+import NoWalletModal from '../elements/dappConnector/noWalletModal';
 
 class DAppConnectorPageObject {
   TEST_DAPP_URL = this.getTestDAppUrl();
@@ -25,8 +26,8 @@ class DAppConnectorPageObject {
     await browser.newWindow(this.TEST_DAPP_URL);
   }
 
-  async waitAndSwitchToDAppConnectorWindow() {
-    await waitUntilExpectedNumberOfHandles(3);
+  async waitAndSwitchToDAppConnectorWindow(expectedNumberOfHandles: number) {
+    await waitUntilExpectedNumberOfHandles(expectedNumberOfHandles);
     await browser.switchWindow(this.DAPP_CONNECTOR_WINDOW_HANDLE);
   }
 
@@ -49,6 +50,11 @@ class DAppConnectorPageObject {
   async clickButtonInDAppRemovalConfirmationModal(button: 'Back' | 'Disconnect DApp') {
     await RemoveDAppModal.cancelButton.waitForDisplayed();
     button === 'Back' ? await RemoveDAppModal.cancelButton.click() : await RemoveDAppModal.confirmButton.click();
+  }
+
+  async clickCreateRestoreButtonInDAppNoWalletModal() {
+    await NoWalletModal.createRestoreButton.waitForDisplayed();
+    await NoWalletModal.createRestoreButton.click();
   }
 
   async deauthorizeAllDApps(mode: 'extended' | 'popup') {

--- a/packages/e2e-tests/src/pageobject/settingsExtendedPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/settingsExtendedPageObject.ts
@@ -4,6 +4,7 @@ import NetworkSettingsDrawer from '../elements/settings/extendedView/networkSett
 import menuHeaderPageObject from './menuHeaderPageObject';
 import simpleTxSideDrawerPageObject from './simpleTxSideDrawerPageObject';
 import localStorageManager from '../utils/localStorageManager';
+import Modal from '../elements/modal';
 
 class SettingsExtendedPageObject {
   clickOnAbout = async () => {
@@ -109,6 +110,12 @@ class SettingsExtendedPageObject {
     await (mode === 'extended'
       ? simpleTxSideDrawerPageObject.clickCloseDrawerButton()
       : simpleTxSideDrawerPageObject.clickBackDrawerButton());
+  };
+
+  removeWallet = async () => {
+    await menuHeaderPageObject.openSettings();
+    await this.clickOnRemoveWallet();
+    await Modal.confirmButton.click();
   };
 }
 

--- a/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
+++ b/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
@@ -20,14 +20,14 @@ When(/^I open test DApp$/, async () => {
 });
 
 Then(/^I see DApp authorization window$/, async () => {
-  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow(3);
   await DAppConnectorAssert.assertSeeAuthorizeDAppPage(testDAppDetails);
 });
 
 Then(
   /^I see DApp connector "Confirm transaction" page with: "([^"]*)" and: "([^"]*)" assets$/,
   async (adaValue: string, assetValue: string) => {
-    await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+    await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow(3);
 
     const expectedTransactionData: ExpectedTransactionData = {
       typeOfTransaction: 'Send',
@@ -40,12 +40,12 @@ Then(
 );
 
 Then(/^I see DApp connector "Sign transaction" page$/, async () => {
-  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow(3);
   await DAppConnectorAssert.assertSeeSignTransactionPage();
 });
 
 Then(/^I see DApp connector "All done" page$/, async () => {
-  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow(3);
   await DAppConnectorAssert.assertSeeAllDonePage();
 });
 
@@ -56,6 +56,11 @@ Then(/^I don't see DApp window$/, async () => {
 
 Then(/^I see DApp connection modal$/, async () => {
   await DAppConnectorAssert.assertSeeDAppConnectionModal();
+});
+
+Then(/^I see DApp no wallet modal$/, async () => {
+  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow(2);
+  await DAppConnectorAssert.assertSeeNoWalletModal();
 });
 
 Then(/^I see DApp removal confirmation modal$/, async () => {
@@ -70,6 +75,10 @@ Then(/^I click "(Always|Only once)" button in DApp authorization modal$/, async 
   await DAppConnectorPageObject.clickButtonInDAppAuthorizationModal(button);
 });
 
+When(/^I click "Create or restore a wallet" button in DApp no wallet modal$/, async () => {
+  await DAppConnectorPageObject.clickCreateRestoreButtonInDAppNoWalletModal();
+});
+
 Then(
   /^I click "(Back|Disconnect DApp)" button in DApp removal confirmation modal$/,
   async (button: 'Back' | 'Disconnect DApp') => {
@@ -78,6 +87,7 @@ Then(
 );
 
 Then(/^I see Lace wallet info in DApp when not connected$/, async () => {
+  await DAppConnectorPageObject.switchToTestDAppWindow();
   await DAppConnectorAssert.assertWalletFoundButNotConnectedInTestDApp();
 });
 
@@ -97,7 +107,7 @@ Then(/^I see test DApp on the Authorized DApps list$/, async () => {
 When(/^I open and authorize test DApp with "(Always|Only once)" setting$/, async (mode: 'Always' | 'Only once') => {
   await DAppConnectorPageObject.openTestDApp();
 
-  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow();
+  await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow(3);
   await DAppConnectorAssert.assertSeeAuthorizeDAppPage(testDAppDetails);
   await DAppConnectorPageObject.clickButtonInDAppAuthorizationWindow('Authorize');
   await DAppConnectorPageObject.clickButtonInDAppAuthorizationModal(mode);

--- a/packages/e2e-tests/src/steps/settingsSteps.ts
+++ b/packages/e2e-tests/src/steps/settingsSteps.ts
@@ -24,6 +24,7 @@ import { browser } from '@wdio/globals';
 import CollateralSettingsDrawer from '../elements/settings/extendedView/collateralSettingsDrawer';
 import HelpSettingsDrawer from '../elements/settings/extendedView/helpSettingsDrawer';
 import ModalAssert from '../assert/modalAssert';
+import menuHeaderPageObject from '../pageobject/menuHeaderPageObject';
 
 Given(
   /^I click on "(About|Your keys|Network|Authorized DApps|Show recovery phrase|Passphrase verification|FAQs|Help|Terms and conditions|Privacy policy|Cookie policy|Collateral)" setting$/,
@@ -252,6 +253,12 @@ When(/^I click "(Back|Remove wallet)" button on "Remove wallet" modal$/, async (
     default:
       throw new Error(`Unsupported button name: ${button}`);
   }
+});
+
+When(/^I remove wallet$/, async () => {
+  await menuHeaderPageObject.openSettings();
+  await settingsExtendedPageObject.clickOnRemoveWallet();
+  await Modal.confirmButton.click();
 });
 
 Then(/^I see "Show public key" page in (extended|popup) mode$/, async (mode: 'extended' | 'popup') => {


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/479/5312027730/index.html) for [2341611a](https://github.com/input-output-hk/lace/pull/143/commits/2341611ad141016a4c00e561f515c8237ee06fb6)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->