### PR TITLE
chore(ui): add existing convention to README.md

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -15,3 +15,39 @@ Storybook is used for development
 ```bash
 yarn storybook
 ```
+
+### Stories format
+
+| Type         |                                  PURPOSE                                  |
+| ------------ | :-----------------------------------------------------------------------: |
+| Overview     |          Dumb components presented as 1:1 parity from Figma file          |
+| Interactions |            Used for testing and to simulate user interactions             |
+| Controls     | Interact with a component's arguments dynamically without needing to code |
+
+### Docs
+
+Make sure to export `components` and `subcomponents` so they are displayed in the `Docs` tab.
+
+```jsx
+export default {
+  title: 'List & tables/Assets table',
+  component: AssetsTable,
+  subcomponents: {
+    TokenProfile,
+    TokenAmount,
+    MarketPrice,
+  }
+} as Meta;
+```
+
+## File naming convention
+
+| FILES            |                                    PURPOSE                                     |
+| ---------------- | :----------------------------------------------------------------------------: |
+| \*.index.ts      |             Defines the public API to be imported by other modules             |
+| \*.component.tsx |                            Defines the UI component                            |
+| \*.css.ts        |                           Vanilla-extract CSS files                            |
+| \*.stories.ts    |                                Storybook files                                 |
+| \*.data.ts       | Defines the data/types representation of the UI component or application logic |
+| \*.context.ts    |    Defines the UI component's inner state to be consumed by nested children    |
+| \*.hooks.ts      |                Defines methods to manipulate the context state                 |


### PR DESCRIPTION
## Proposed solution

We are missing information about how to structure storybook or file naming convention.


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/532/5324084393/index.html) for [098c9beb](https://github.com/input-output-hk/lace/pull/152/commits/098c9beb3859fcb5cb498d19e4412605e344a349)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->