### PR TITLE
feat(staking): add zustand store

### DIFF
--- a/packages/staking/src/features/store/index.ts
+++ b/packages/staking/src/features/store/index.ts
@@ -1,0 +1,2 @@
+export * from './stakingStore';
+export * from './types';

--- a/packages/staking/src/features/store/stakingStore.ts
+++ b/packages/staking/src/features/store/stakingStore.ts
@@ -1,0 +1,66 @@
+import create from 'zustand';
+import { SectionConfig, Sections, StakePoolDetails, StakingError } from './types';
+
+export const sectionsConfig: Record<Sections, SectionConfig> = {
+  [Sections.DETAIL]: {
+    currentSection: Sections.DETAIL,
+    nextSection: Sections.CONFIRMATION,
+  },
+  [Sections.CONFIRMATION]: {
+    currentSection: Sections.CONFIRMATION,
+    nextSection: Sections.SIGN,
+    prevSection: Sections.DETAIL,
+  },
+  [Sections.SIGN]: {
+    currentSection: Sections.SIGN,
+    prevSection: Sections.CONFIRMATION,
+  },
+  [Sections.SUCCESS_TX]: {
+    currentSection: Sections.SUCCESS_TX,
+    prevSection: Sections.SIGN,
+  },
+  [Sections.FAIL_TX]: {
+    currentSection: Sections.FAIL_TX,
+    prevSection: Sections.SIGN,
+  },
+};
+
+const storeDefaultState: Pick<StakePoolDetails, 'simpleSendConfig'> = {
+  simpleSendConfig: sectionsConfig[Sections.DETAIL],
+};
+
+/**
+ * returns a hook to access stake pool details store visibility states and setters
+ */
+export const useStakePoolDetails = create<StakePoolDetails>((set, get) => ({
+  ...storeDefaultState,
+  isBuildingTx: false,
+  isDrawerVisible: false,
+  isExitStakingVisible: false,
+  isNoFundsVisible: false,
+  isStakeConfirmationVisible: false,
+  resetStates: () => set((state: StakePoolDetails) => ({ ...state, ...storeDefaultState })),
+  setExitStakingVisible: (visibility: boolean) => set({ isExitStakingVisible: visibility }),
+  setIsBuildingTx: (visibility: boolean) => set({ isBuildingTx: visibility }),
+  setIsDrawerVisible: (visibility: boolean) => set({ isDrawerVisible: visibility }),
+  setNoFundsVisible: (visibility: boolean) => set({ isNoFundsVisible: visibility }),
+  setPrevSection: () => {
+    const { currentSection, prevSection } = get().simpleSendConfig;
+    if (!prevSection) {
+      console.error(`Tried to move to not existing section (previous of ${currentSection})`);
+      return;
+    }
+    set({ simpleSendConfig: sectionsConfig[prevSection] });
+  },
+  setSection: (section: SectionConfig) => {
+    const { currentSection, nextSection } = get().simpleSendConfig;
+    if (!nextSection) {
+      console.error(`Tried to move to not existing section (previous of ${currentSection})`);
+      return;
+    }
+    set({ simpleSendConfig: section ?? sectionsConfig[nextSection] });
+  },
+  setStakeConfirmationVisible: (visibility: boolean) => set({ isStakeConfirmationVisible: visibility }),
+  setStakingError: (error: StakingError | undefined) => set({ stakingError: error }),
+  stakingError: undefined,
+}));

--- a/packages/staking/src/features/store/types.ts
+++ b/packages/staking/src/features/store/types.ts
@@ -1,0 +1,37 @@
+export enum Sections {
+  DETAIL = 'detail',
+  CONFIRMATION = 'confirmation',
+  SIGN = 'sign',
+  SUCCESS_TX = 'success_tx',
+  FAIL_TX = 'fail_tx',
+}
+
+export enum StakingError {
+  UTXO_FULLY_DEPLETED = 'UTXO_FULLY_DEPLETED',
+  UTXO_BALANCE_INSUFFICIENT = 'UTXO_BALANCE_INSUFFICIENT',
+}
+
+export interface SectionConfig {
+  currentSection: Sections;
+  nextSection?: Sections;
+  prevSection?: Sections;
+}
+
+export interface StakePoolDetails {
+  simpleSendConfig: SectionConfig;
+  setSection: (section: SectionConfig) => void;
+  setPrevSection: () => void;
+  resetStates: () => void;
+  isDrawerVisible: boolean;
+  setIsDrawerVisible: (visibility: boolean) => void;
+  isStakeConfirmationVisible: boolean;
+  setStakeConfirmationVisible: (visibility: boolean) => void;
+  isExitStakingVisible: boolean;
+  setExitStakingVisible: (visibility: boolean) => void;
+  isNoFundsVisible: boolean;
+  setNoFundsVisible: (visibility: boolean) => void;
+  isBuildingTx: boolean;
+  setIsBuildingTx: (visibility: boolean) => void;
+  stakingError?: StakingError;
+  setStakingError: (error?: StakingError) => void;
+}


### PR DESCRIPTION
# Checklist

- [x] JIRA - [\<link>](https://input-output.atlassian.net/browse/LW-7060)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Staking store added to the staking package


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/566/5339607524/index.html) for [1b777fa6](https://github.com/input-output-hk/lace/pull/163/commits/1b777fa682fde559416ea8032b3e108d6a536d0f)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 19     | 0      | 0       | 0     | 19    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->