### PR TITLE
fix(extension): change small breakpoint size

### DIFF
--- a/apps/browser-extension-wallet/src/styles/constants/breakpoints.ts
+++ b/apps/browser-extension-wallet/src/styles/constants/breakpoints.ts
@@ -1,2 +1,2 @@
 export const BREAKPOINT_XSMALL = 1024;
-export const BREAKPOINT_SMALL = 1280;
+export const BREAKPOINT_SMALL = 1281;

--- a/packages/common/src/ui/styles/theme.scss
+++ b/packages/common/src/ui/styles/theme.scss
@@ -10,7 +10,7 @@ $theme-light-grey-border-opacity: #efefef8f;
 
 $breakpoint-minimum: 668px;
 $breakpoint-xsmall: 1024px;
-$breakpoint-small: 1280px;
+$breakpoint-small: 1281px;
 $breakpoint-medium: 1440px;
 $breakpoint-xmedium: 1550px;
 $breakpoint-large: 1660px;


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-7115](https://input-output.atlassian.net/browse/LW-7115)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Adds 1px to `breakpoint-small`


[LW-7115]: https://input-output.atlassian.net/browse/LW-7115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/590/5349615377/index.html) for [a5fed4da](https://github.com/input-output-hk/lace/pull/169/commits/a5fed4da63c0d36d13ddc7ee37e871f51d6d6323)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->