### PR TITLE
test(extension): e2e - add test to create folder button

### DIFF
--- a/packages/e2e-tests/src/assert/nftAssert.ts
+++ b/packages/e2e-tests/src/assert/nftAssert.ts
@@ -76,6 +76,13 @@ class NftAssert {
       await expect(await new NftDetails().sendNFTButton.getText()).to.equal(await t('core.nftDetail.sendNFT'));
     }
   }
+
+  async assertSeeCreateFolderButton(shouldSee: boolean, mode: 'extended' | 'popup') {
+    await NftsPage.createFolderButton.waitForDisplayed({ reverse: !shouldSee });
+    if (mode === 'extended' && shouldSee === true) {
+      await expect(await NftsPage.createFolderButton.getText()).to.equal(await t('browserView.nfts.createFolder'));
+    }
+  }
 }
 
 export default new NftAssert();

--- a/packages/e2e-tests/src/elements/NFTs/nftsPage.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftsPage.ts
@@ -14,7 +14,7 @@ class NftsPage {
   }
 
   get createFolderButton(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(`${this.CREATE_FOLDER_BUTTON}`);
+    return $(this.CREATE_FOLDER_BUTTON);
   }
 }
 

--- a/packages/e2e-tests/src/elements/NFTs/nftsPage.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftsPage.ts
@@ -1,12 +1,20 @@
+/* eslint-disable no-undef */
 import SectionTitle from '../sectionTitle';
+import { ChainablePromiseElement } from 'webdriverio';
 
 class NftsPage {
+  private CREATE_FOLDER_BUTTON = '[data-testid="create-folder-button"]';
+
   get title() {
     return SectionTitle.sectionTitle;
   }
 
   get counter() {
     return SectionTitle.sectionCounter;
+  }
+
+  get createFolderButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(`${this.CREATE_FOLDER_BUTTON}`);
   }
 }
 

--- a/packages/e2e-tests/src/features/EmptyStatesExtended.feature
+++ b/packages/e2e-tests/src/features/EmptyStatesExtended.feature
@@ -12,10 +12,11 @@ Feature: Empty states
     When I click "Copy" button on empty state banner
     Then I see a toast with message: "general.clipboard.copiedToClipboard"
 
-  @LW-2516
+  @LW-2516 @LW-7236
   Scenario: Extended View - NFTs empty state
     When I navigate to NFTs extended page
     Then I see empty state banner for NFTs page in extended mode
+    And I do not see "Create folder" button on NFTs page in extended mode
     When I click "Copy" button on empty state banner
     Then I see a toast with message: "general.clipboard.copiedToClipboard"
 

--- a/packages/e2e-tests/src/features/EmptyStatesPopup.feature
+++ b/packages/e2e-tests/src/features/EmptyStatesPopup.feature
@@ -11,10 +11,11 @@ Feature: Empty states
     When I click "Copy" button on empty state banner
     Then I see a toast with message: "general.clipboard.copiedToClipboard"
 
-  @LW-2517
+  @LW-2517 @LW-7239
   Scenario: Popup View - NFTs empty state
     When I navigate to NFTs popup page
     Then I see empty state banner for NFTs page in popup mode
+    And I do not see "Create folder" button on NFTs page in popup mode
     When I click "Copy" button on empty state banner
     Then I see a toast with message: "general.clipboard.copiedToClipboard"
 

--- a/packages/e2e-tests/src/features/NFTsExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsExtended.feature
@@ -10,10 +10,11 @@ Feature: LW-423: NFTs - Extended view
     When I see NFTs counter with total number of NFTs displayed
     Then NFTs counter matches the number of wallet NFTs
 
-  @LW-2497 @Mainnet
+  @LW-2497 @LW-7237 @Mainnet
   Scenario: Extended-view - Owning NFTs
     Given I am on NFTs extended page
     Then A gallery view showing my NFTs is displayed
+    And I see "Create folder" button on NFTs page in extended mode
 
   @LW-2498 @Mainnet
   Scenario: Extended-view - Information displayed

--- a/packages/e2e-tests/src/features/NFTsPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsPopup.feature
@@ -14,10 +14,11 @@ Feature: LW-411 Ext.PopUp - Collectibles/NFTs
     When I see NFTs counter with total number of NFTs displayed
     Then NFTs counter matches the number of wallet NFTs
 
-  @LW-2509 @Mainnet
+  @LW-2509 @LW-7238 @Mainnet
   Scenario: Popup-view - Owning NFTs
     Given I am on NFTs popup page
     Then A gallery view showing my NFTs is displayed
+    And I see "Create folder" button on NFTs page in popup mode
 
   @LW-2510 @Mainnet
   Scenario: Popup-view - Information displayed

--- a/packages/e2e-tests/src/steps/nftsCommonSteps.ts
+++ b/packages/e2e-tests/src/steps/nftsCommonSteps.ts
@@ -81,6 +81,13 @@ Given(
   }
 );
 
+Given(
+  /^I (see|do not see) "Create folder" button on NFTs page in (popup|extended) mode$/,
+  async (shouldSee: 'see' | 'do not see', mode: 'extended' | 'popup') => {
+    await nftAssert.assertSeeCreateFolderButton(shouldSee === 'see', mode);
+  }
+);
+
 Then(/^A gallery view showing my NFTs is displayed$/, async () => {
   await $(new NftItem().container().toJSLocator()).waitForDisplayed({ timeout: 15_000 });
   await nftAssert.assertSeeNftList(1);


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/690/5411080900/index.html) for [d5668485](https://github.com/input-output-hk/lace/pull/191/commits/d5668485268967ae52d8f4c26ff13f158fe775aa)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->