### PR TITLE
feat(extension) add onboarding events to PostHog

### DIFF
--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/events.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/events.ts
@@ -34,7 +34,8 @@ export const postHogOnboardingActions: PostHogOnboardingActionsType = {
     WRITE_PASSPHRASE_17_NEXT_CLICK: PostHogAction.OnboardingCreateWritePassphrase17NextClick,
     ENTER_PASSPHRASE_01_NEXT_CLICK: PostHogAction.OnboardingCreateEnterPassphrase01NextClick,
     ENTER_PASSPHRASE_09_NEXT_CLICK: PostHogAction.OnboardingCreateEnterPassphrase09NextClick,
-    ENTER_PASSPHRASE_17_NEXT_CLICK: PostHogAction.OnboardingCreateEnterPassphrase17NextClick
+    ENTER_PASSPHRASE_17_NEXT_CLICK: PostHogAction.OnboardingCreateEnterPassphrase17NextClick,
+    DONE_GO_TO_WALLET: PostHogAction.OnboardingCreateDoneGoToWallet
   },
   restore: {
     ANALYTICS_AGREE_CLICK: PostHogAction.OnboardingRestoreAnalyticsAgreeClick,
@@ -48,7 +49,8 @@ export const postHogOnboardingActions: PostHogOnboardingActionsType = {
     RESTORE_MULTI_ADDR_OK_CLICK: PostHogAction.OnboardingRestoreWarningMultiAddressWalletOkClick,
     ENTER_PASSPHRASE_01_NEXT_CLICK: PostHogAction.OnboardingRestoreEnterPassphrase01NextClick,
     ENTER_PASSPHRASE_09_NEXT_CLICK: PostHogAction.OnboardingRestoreEnterPassphrase09NextClick,
-    ENTER_PASSPHRASE_17_NEXT_CLICK: PostHogAction.OnboardingRestoreEnterPassphrase17NextClick
+    ENTER_PASSPHRASE_17_NEXT_CLICK: PostHogAction.OnboardingRestoreEnterPassphrase17NextClick,
+    DONE_GO_TO_WALLET: PostHogAction.OnboardingRestoreDoneGoToWallet
   },
   hw: {
     ANALYTICS_AGREE_CLICK: PostHogAction.OnboardingHWAnalyticsAgreeClick,
@@ -57,7 +59,8 @@ export const postHogOnboardingActions: PostHogOnboardingActionsType = {
     LACE_TERMS_OF_USE_NEXT_CLICK: PostHogAction.OnboardinHWLaceTermsOfUseNextClick,
     CONNECT_HW_NEXT_CLICK: PostHogAction.OnboardingHWConnectNextClick,
     SELECT_HW_ACCOUNT_NEXT_CLICK: PostHogAction.OnboardingHWSelectAccountNextClick,
-    SETUP_OPTION_CLICK: PostHogAction.OnboardingHWClick
+    SETUP_OPTION_CLICK: PostHogAction.OnboardingHWClick,
+    DONE_GO_TO_WALLET: PostHogAction.OnboardingHWDoneGoToWallet
   }
 };
 

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -67,6 +67,7 @@ export enum PostHogAction {
   OnboardingCreateEnterPassphrase01NextClick = 'onboarding | new wallet | enter passphrase #01 | next | click',
   OnboardingCreateEnterPassphrase09NextClick = 'onboarding | new wallet | enter passphrase #09 | next | click',
   OnboardingCreateEnterPassphrase17NextClick = 'onboarding | new wallet | enter passphrase #17 | next | click',
+  WalletChangeActivePage = 'wallet | change active page | view',
   OnboardingCreateDoneGoToWallet = 'onboarding | new wallet | all done | go to my wallet | click',
   OnboardingRestoreDoneGoToWallet = 'onboarding | restore wallet | all done | go to my wallet | click',
   OnboardingHWDoneGoToWallet = 'onboarding | hardware wallet | all done | go to my wallet | click'

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -32,6 +32,7 @@ export type Metadata = {
 };
 
 export enum PostHogAction {
+  WalletChangeActivePage = 'wallet | change active page | view',
   // Hardware wallet connect
   OnboardingHWAnalyticsAgreeClick = 'onboarding | hardware wallet | analytics | agree | click',
   OnboardingHWAnalyticsSkipClick = 'onboarding | hardware wallet | analytics | skip | click',
@@ -40,7 +41,9 @@ export enum PostHogAction {
   OnboardingHWConnectNextClick = 'onboarding | hardware wallet | connect hw | next | click',
   OnboardingHWSelectAccountNextClick = 'onboarding | hardware wallet | select hw account | next | click',
   OnboardingHWNameNextClick = 'onboarding | hardware wallet | name hw wallet | next | click',
+  OnboardingHWDoneGoToWallet = 'onboarding | hardware wallet | all done | go to my wallet | click',
   // Restore wallet
+  OnboardingRestoreDoneGoToWallet = 'onboarding | restore wallet | all done | go to my wallet | click',
   OnboardingRestoreAnalyticsAgreeClick = 'onboarding | restore wallet | analytics | agree | click',
   OnboardingRestoreAnalyticsSkipClick = 'onboarding | restore wallet | analytics | skip | click',
   OnboardingRestoreClick = 'onboarding | restore wallet | restore | click',
@@ -54,6 +57,7 @@ export enum PostHogAction {
   OnboardingRestoreEnterPassphrase09NextClick = 'onboarding | restore wallet | enter passphrase #09 | next | click',
   OnboardingRestoreEnterPassphrase17NextClick = 'onboarding | restore wallet | enter passphrase #17 | next | click',
   // Create new wallet
+  OnboardingCreateDoneGoToWallet = 'onboarding | new wallet | all done | go to my wallet | click',
   OnboardingCreateAnalyticsAgreeClick = 'onboarding | new wallet | analytics | agree | click',
   OnboardingCreateAnalyticsSkipClick = 'onboarding | new wallet | analytics | skip | click',
   OnboardingCreateClick = 'onboarding | new wallet | create | click',
@@ -66,11 +70,7 @@ export enum PostHogAction {
   OnboardingCreateWritePassphrase17NextClick = 'onboarding | new wallet | write passphrase #17 | next | click',
   OnboardingCreateEnterPassphrase01NextClick = 'onboarding | new wallet | enter passphrase #01 | next | click',
   OnboardingCreateEnterPassphrase09NextClick = 'onboarding | new wallet | enter passphrase #09 | next | click',
-  OnboardingCreateEnterPassphrase17NextClick = 'onboarding | new wallet | enter passphrase #17 | next | click',
-  WalletChangeActivePage = 'wallet | change active page | view',
-  OnboardingCreateDoneGoToWallet = 'onboarding | new wallet | all done | go to my wallet | click',
-  OnboardingRestoreDoneGoToWallet = 'onboarding | restore wallet | all done | go to my wallet | click',
-  OnboardingHWDoneGoToWallet = 'onboarding | hardware wallet | all done | go to my wallet | click'
+  OnboardingCreateEnterPassphrase17NextClick = 'onboarding | new wallet | enter passphrase #17 | next | click'
 }
 
 export enum EnhancedAnalyticsOptInStatus {
@@ -102,7 +102,8 @@ export type PostHogActionsKeys =
   | 'RESTORE_MULTI_ADDR_CANCEL_CLICK'
   | 'RECOVERY_PASSPHRASE_LENGTH_NEXT_CLICK'
   | 'CONNECT_HW_NEXT_CLICK'
-  | 'SELECT_HW_ACCOUNT_NEXT_CLICK';
+  | 'SELECT_HW_ACCOUNT_NEXT_CLICK'
+  | 'DONE_GO_TO_WALLET';
 export type PostHogOnboardingActionsValueType = Partial<Record<PostHogActionsKeys, PostHogAction>>;
 export type PostHogOnboardingActionsType = Partial<Record<OnboardingFlows, PostHogOnboardingActionsValueType>>;
 export type PostHogMetadata = {

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -66,7 +66,10 @@ export enum PostHogAction {
   OnboardingCreateWritePassphrase17NextClick = 'onboarding | new wallet | write passphrase #17 | next | click',
   OnboardingCreateEnterPassphrase01NextClick = 'onboarding | new wallet | enter passphrase #01 | next | click',
   OnboardingCreateEnterPassphrase09NextClick = 'onboarding | new wallet | enter passphrase #09 | next | click',
-  OnboardingCreateEnterPassphrase17NextClick = 'onboarding | new wallet | enter passphrase #17 | next | click'
+  OnboardingCreateEnterPassphrase17NextClick = 'onboarding | new wallet | enter passphrase #17 | next | click',
+  OnboardingCreateDoneGoToWallet = 'onboarding | new wallet | all done | go to my wallet | click',
+  OnboardingRestoreDoneGoToWallet = 'onboarding | restore wallet | all done | go to my wallet | click',
+  OnboardingHWDoneGoToWallet = 'onboarding | hardware wallet | all done | go to my wallet | click'
 }
 
 export enum EnhancedAnalyticsOptInStatus {

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
@@ -1,9 +1,9 @@
+import { useLocalStorage } from '@src/hooks/useLocalStorage';
+import { useWalletStore } from '@src/stores';
 import React, { createContext, useContext, useEffect, useMemo } from 'react';
-import { AnalyticsTracker } from './analyticsTracker';
+import { AnalyticsTracker, PostHogAction } from './analyticsTracker';
 import { EnhancedAnalyticsOptInStatus } from './analyticsTracker/types';
 import { ENHANCED_ANALYTICS_OPT_IN_STATUS_LS_KEY } from './matomo/config';
-import { useWalletStore } from '@src/stores';
-import { useLocalStorage } from '@src/hooks/useLocalStorage';
 
 interface AnalyticsProviderProps {
   children: React.ReactNode;
@@ -49,6 +49,14 @@ export const AnalyticsProvider = ({
   useEffect(() => {
     analyticsTracker.setChain(currentChain);
   }, [currentChain, analyticsTracker]);
+
+  useEffect(() => {
+    const trackActivePageChange = () => analyticsTracker.sendEventToPostHog(PostHogAction.WalletChangeActivePage);
+    window.addEventListener('popstate', trackActivePageChange);
+    return () => {
+      window.removeEventListener('popstate', trackActivePageChange);
+    };
+  }, [analyticsTracker]);
 
   return <AnalyticsContext.Provider value={analyticsTracker}>{children}</AnalyticsContext.Provider>;
 };

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
@@ -1,5 +1,6 @@
 import { useLocalStorage } from '@src/hooks/useLocalStorage';
 import { useWalletStore } from '@src/stores';
+import debounce from 'lodash/debounce';
 import React, { createContext, useContext, useEffect, useMemo } from 'react';
 import { AnalyticsTracker, PostHogAction } from './analyticsTracker';
 import { EnhancedAnalyticsOptInStatus } from './analyticsTracker/types';
@@ -13,6 +14,8 @@ interface AnalyticsProviderProps {
    */
   analyticsDisabled?: boolean;
 }
+
+const PAGE_VIEW_DEBOUNCE_DELAY = 100;
 
 type AnalyticsTrackerInstance = AnalyticsTracker;
 
@@ -52,7 +55,10 @@ export const AnalyticsProvider = ({
 
   // Track page changes with PostHog in order to keep the user session alive
   useEffect(() => {
-    const trackActivePageChange = () => analyticsTracker.sendPageNavigationEvent(PostHogAction.WalletChangeActivePage);
+    const trackActivePageChange = debounce(
+      () => analyticsTracker.sendPageNavigationEvent(PostHogAction.WalletChangeActivePage),
+      PAGE_VIEW_DEBOUNCE_DELAY
+    );
     window.addEventListener('popstate', trackActivePageChange);
     return () => {
       window.removeEventListener('popstate', trackActivePageChange);

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
@@ -52,7 +52,7 @@ export const AnalyticsProvider = ({
 
   // Track page changes with PostHog in order to keep the user session alive
   useEffect(() => {
-    const trackActivePageChange = () => analyticsTracker.sendEventToPostHog(PostHogAction.WalletChangeActivePage);
+    const trackActivePageChange = () => analyticsTracker.sendPageNavigationEvent(PostHogAction.WalletChangeActivePage);
     window.addEventListener('popstate', trackActivePageChange);
     return () => {
       window.removeEventListener('popstate', trackActivePageChange);

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
@@ -50,6 +50,7 @@ export const AnalyticsProvider = ({
     analyticsTracker.setChain(currentChain);
   }, [currentChain, analyticsTracker]);
 
+  // Track page changes with PostHog in order to keep the user session alive
   useEffect(() => {
     const trackActivePageChange = () => analyticsTracker.sendEventToPostHog(PostHogAction.WalletChangeActivePage);
     window.addEventListener('popstate', trackActivePageChange);

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -39,16 +39,16 @@ export class PostHogClient {
     });
   }
 
-  sendPageNavigationEvent = async (pageTitle: string): Promise<void> => {
+  sendPageNavigationEvent = async (eventName: string): Promise<void> => {
     if (!this.initialized) {
       await this.init();
     }
 
-    console.debug('[ANALYTICS] Logging page navigation event to PostHog', pageTitle);
+    console.debug('[ANALYTICS] Logging page navigation event to PostHog', eventName);
 
     posthog.capture('pageview', {
       ...(await this.getEventMetadata()),
-      action_name: pageTitle
+      event: eventName
     });
   };
 

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -46,7 +46,7 @@ export class PostHogClient {
 
     console.debug('[ANALYTICS] Logging page navigation event to PostHog', eventName);
 
-    posthog.capture('pageview', {
+    posthog.capture('$pageview', {
       ...(await this.getEventMetadata()),
       event: eventName
     });

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -22,8 +22,7 @@ import { useTranslation } from 'react-i18next';
 import {
   AnalyticsEventNames,
   EnhancedAnalyticsOptInStatus,
-  postHogOnboardingActions,
-  PostHogAction
+  postHogOnboardingActions
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { config } from '@src/config';
 import { walletRoutePaths } from '@routes/wallet-paths';
@@ -277,7 +276,7 @@ export const HardwareWalletFlow = ({
     finish: () => (
       <WalletSetupFinalStep
         onFinish={async () => {
-          await sendAnalytics(Events.SETUP_FINISHED_NEXT, PostHogAction.OnboardingHWDoneGoToWallet);
+          await sendAnalytics(Events.SETUP_FINISHED_NEXT, postHogOnboardingActions.hw?.DONE_GO_TO_WALLET);
           await handleFinishCreation();
           // Workaround to enable staking with Ledger right after the onboarding LW-5564
           window.location.reload();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -22,7 +22,8 @@ import { useTranslation } from 'react-i18next';
 import {
   AnalyticsEventNames,
   EnhancedAnalyticsOptInStatus,
-  postHogOnboardingActions
+  postHogOnboardingActions,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { config } from '@src/config';
 import { walletRoutePaths } from '@routes/wallet-paths';
@@ -276,7 +277,7 @@ export const HardwareWalletFlow = ({
     finish: () => (
       <WalletSetupFinalStep
         onFinish={async () => {
-          sendAnalytics(Events.SETUP_FINISHED_NEXT);
+          sendAnalytics(Events.SETUP_FINISHED_NEXT, PostHogAction.OnboardingHWDoneGoToWallet);
           await handleFinishCreation();
           // Workaround to enable staking with Ledger right after the onboarding LW-5564
           window.location.reload();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -277,7 +277,7 @@ export const HardwareWalletFlow = ({
     finish: () => (
       <WalletSetupFinalStep
         onFinish={async () => {
-          sendAnalytics(Events.SETUP_FINISHED_NEXT, PostHogAction.OnboardingHWDoneGoToWallet);
+          await sendAnalytics(Events.SETUP_FINISHED_NEXT, PostHogAction.OnboardingHWDoneGoToWallet);
           await handleFinishCreation();
           // Workaround to enable staking with Ledger right after the onboarding LW-5564
           window.location.reload();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
@@ -1,12 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { WalletSetupOptionsStep, WalletSetupSteps, useTranslate } from '@lace/core';
-import { HardwareWalletFlow } from './HardwareWalletFlow';
-import { WalletSetupLayout } from '@src/views/browser-view/components/Layout';
-import { WarningModal } from '@src/views/browser-view/components/WarningModal';
-import styles from './WalletSetup.module.scss';
-import { Route, Switch, useHistory, useRouteMatch } from 'react-router-dom';
-import { walletRoutePaths } from '@routes/wallet-paths';
-import { WalletSetupWizard } from './WalletSetupWizard';
+import { useTranslate, WalletSetupOptionsStep, WalletSetupSteps } from '@lace/core';
 import { useAnalyticsContext } from '@providers/AnalyticsProvider';
 import {
   AnalyticsEventActions,
@@ -15,10 +7,18 @@ import {
   PostHogAction,
   postHogOnboardingActions
 } from '@providers/AnalyticsProvider/analyticsTracker';
+import { walletRoutePaths } from '@routes/wallet-paths';
 import { ILocalStorage } from '@src/types';
 import { deleteFromLocalStorage, getValueFromLocalStorage } from '@src/utils/local-storage';
+import { WalletSetupLayout } from '@src/views/browser-view/components/Layout';
+import { WarningModal } from '@src/views/browser-view/components/WarningModal';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Route, Switch, useHistory, useRouteMatch } from 'react-router-dom';
+import { HardwareWalletFlow } from './HardwareWalletFlow';
 import { Portal } from './Portal';
 import { SendOboardingAnalyticsEvent } from '../types';
+import styles from './WalletSetup.module.scss';
+import { WalletSetupWizard } from './WalletSetupWizard';
 
 const { WalletSetup: Events } = AnalyticsEventNames;
 
@@ -103,21 +103,20 @@ export const WalletSetup = ({ initialStep = WalletSetupSteps.Legal }: WalletSetu
     analytics.sendEventToPostHog(postHogOnboardingActions.hw?.SETUP_OPTION_CLICK);
   };
 
-  const sendAnalytics = (
+  const sendAnalytics = async (
     category: SetupAnalyticsCategories,
     eventName: string,
     value = 1,
     postHogAction?: PostHogAction
   ) => {
-    const event = {
+    await analytics.sendEvent({
       action: AnalyticsEventActions.CLICK_EVENT,
       category,
       name: eventName,
       value
-    };
-    analytics.sendEvent(event);
+    });
     if (postHogAction) {
-      analytics.sendEventToPostHog(postHogAction);
+      await analytics.sendEventToPostHog(postHogAction);
     }
   };
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
@@ -121,8 +121,8 @@ export const WalletSetup = ({ initialStep = WalletSetupSteps.Legal }: WalletSetu
   };
 
   const getSendAnalyticsHandler: (eventCategory: SetupAnalyticsCategories) => SendOboardingAnalyticsEvent =
-    (eventCategory) => (event, postHogAction, value) =>
-      sendAnalytics(eventCategory, event, value, postHogAction);
+    (eventCategory) => async (event, postHogAction, value) =>
+      await sendAnalytics(eventCategory, event, value, postHogAction);
 
   const handleRestoreWallet = () => {
     setIsConfirmRestoreOpen(true);

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -22,7 +22,8 @@ import { WarningModal } from '@src/views/browser-view/components/WarningModal';
 import {
   AnalyticsEventNames,
   EnhancedAnalyticsOptInStatus,
-  postHogOnboardingActions
+  postHogOnboardingActions,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { config } from '@src/config';
 
@@ -482,7 +483,12 @@ export const WalletSetupWizard = ({
       {currentStep === WalletSetupSteps.Finish && (
         <WalletSetupFinalStep
           onFinish={() => {
-            sendAnalytics(Events.SETUP_FINISHED_NEXT);
+            sendAnalytics(
+              Events.SETUP_FINISHED_NEXT,
+              setupType === 'restore'
+                ? PostHogAction.OnboardingRestoreDoneGoToWallet
+                : PostHogAction.OnboardingCreateDoneGoToWallet
+            );
             goToMyWallet();
           }}
           translations={walletSetupFinalStepTranslations}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -22,8 +22,7 @@ import { WarningModal } from '@src/views/browser-view/components/WarningModal';
 import {
   AnalyticsEventNames,
   EnhancedAnalyticsOptInStatus,
-  postHogOnboardingActions,
-  PostHogAction
+  postHogOnboardingActions
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { config } from '@src/config';
 
@@ -483,12 +482,7 @@ export const WalletSetupWizard = ({
       {currentStep === WalletSetupSteps.Finish && (
         <WalletSetupFinalStep
           onFinish={() => {
-            sendAnalytics(
-              Events.SETUP_FINISHED_NEXT,
-              setupType === 'restore'
-                ? PostHogAction.OnboardingRestoreDoneGoToWallet
-                : PostHogAction.OnboardingCreateDoneGoToWallet
-            );
+            sendAnalytics(Events.SETUP_FINISHED_NEXT, postHogOnboardingActions[setupType]?.DONE_GO_TO_WALLET);
             goToMyWallet();
           }}
           translations={walletSetupFinalStepTranslations}


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-6768)

---

## Proposed solution

This PR adds tracking for the following PostHog events:

- wallet | change active page | view
- onboarding | new wallet | all done | go to my wallet | click
- onboarding | hardware wallet | all done | go to my wallet | click
- onboarding | restore wallet | all done | go to my wallet | click

## Testing

You need access to our PostHog service and go through the steps required to trigger those events + check them in PostHog
