### PR TITLE
Chore: adjust main branch merge settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,8 +1,8 @@
 # These settings are synced to GitHub by https://probot.github.io/apps/settings/
 
 repository:
-  allow_merge_commit: true
-  allow_rebase_merge: false
+  allow_merge_commit: false
+  allow_rebase_merge: true
   allow_squash_merge: true
   default_branch: main
   delete_branch_on_merge: true
@@ -79,12 +79,12 @@ branches:
         bypass_pull_request_allowances:
           apps: []
           users: []
-          teams: []
+          teams: ['lace-tech-leads']
         # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
         dismissal_restrictions:
           apps: []
           users: []
-          teams: []
+          teams: ['lace-tech-leads']
       # Required. Require status checks to pass before merging. Set to null to disable
       required_status_checks:
         # Required. Require branches to be up to date before merging.
@@ -95,7 +95,7 @@ branches:
           - context: block-fixup
           - context: Build Staking Center
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: true
+      enforce_admins:
       # Prevent merge commits from being pushed to matching branches
       required_linear_history: false
       # Permits force pushes to the protected branch by anyone with write access to the repository.


### PR DESCRIPTION
o Disable merge
o Enable rebase merge
o Allow lace-tech-leads to bypass reviews and checks

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/681/5404318659/index.html) for [73865c98](https://github.com/input-output-hk/lace/pull/195/commits/73865c98595bfa370bba82611827cf5d1a8d8ce6)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->