### PR TITLE
feat(staking): add search and sort for stake pools browser

### DIFF
--- a/packages/cardano/src/wallet/util/__tests__/stake-pool-transformer.test.ts
+++ b/packages/cardano/src/wallet/util/__tests__/stake-pool-transformer.test.ts
@@ -1,21 +1,22 @@
 /* eslint-disable new-cap, no-magic-numbers */
 import { Percent } from '@cardano-sdk/util';
-import { Wallet } from '../../..';
+import { Cardano } from '@cardano-sdk/core';
+import { StakePoolSearchResults, CoinId } from '@src/wallet';
 import { stakePoolTransformer } from '../stake-pool-transformer';
 
-const cardanoCoin: Wallet.CoinId = {
+const cardanoCoin: CoinId = {
   id: '1',
   name: 'Cardano',
   decimals: 6,
   symbol: 'ADA'
 };
 
-const cardanoStakePoolMock: Wallet.StakePoolSearchResults = {
+const cardanoStakePoolMock: StakePoolSearchResults = {
   pageResults: [
     {
       cost: BigInt('6040000'),
-      hexId: Wallet.Cardano.PoolIdHex('a76e3a1104a9d816a67d5826a155c9e2979a839d0d944346d47e33ab'),
-      id: Wallet.Cardano.PoolId('pool1syqhydhdzcuqhwtt6q4m63f9g8e7262wzsvk7e0r0njsyjyd0yn'),
+      hexId: Cardano.PoolIdHex('a76e3a1104a9d816a67d5826a155c9e2979a839d0d944346d47e33ab'),
+      id: Cardano.PoolId('pool1syqhydhdzcuqhwtt6q4m63f9g8e7262wzsvk7e0r0njsyjyd0yn'),
       margin: {
         denominator: 50,
         numerator: 1
@@ -28,7 +29,7 @@ const cardanoStakePoolMock: Wallet.StakePoolSearchResults = {
         ext: {
           serial: 1,
           pool: {
-            id: Wallet.Cardano.PoolIdHex('a76e3a1104a9d816a67d5826a155c9e2979a839d0d944346d47e33ab')
+            id: Cardano.PoolIdHex('a76e3a1104a9d816a67d5826a155c9e2979a839d0d944346d47e33ab')
           }
         }
       },
@@ -42,12 +43,12 @@ const cardanoStakePoolMock: Wallet.StakePoolSearchResults = {
         apy: Percent(0.013)
       },
       owners: [
-        Wallet.Cardano.RewardAccount('stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj'),
-        Wallet.Cardano.RewardAccount('stake_test1uq7g7kqeucnqfweqzgxk3dw34e8zg4swnc7nagysug2mm4cm77jrx')
+        Cardano.RewardAccount('stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj'),
+        Cardano.RewardAccount('stake_test1uq7g7kqeucnqfweqzgxk3dw34e8zg4swnc7nagysug2mm4cm77jrx')
       ],
       pledge: BigInt('2000000000'),
-      rewardAccount: Wallet.Cardano.RewardAccount('stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj'),
-      status: Wallet.Cardano.StakePoolStatus.Active,
+      rewardAccount: Cardano.RewardAccount('stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj'),
+      status: Cardano.StakePoolStatus.Active,
       vrf: undefined,
       relays: undefined
     }

--- a/packages/cardano/src/wallet/util/stake-pool-transformer.ts
+++ b/packages/cardano/src/wallet/util/stake-pool-transformer.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-magic-numbers */
 import { formatPercentages, getRandomIcon } from '@lace/common';
-import * as Wallet from '@wallet';
+import { Cardano } from '@cardano-sdk/core';
+import { CoinId } from '@src/wallet';
+import { lovelacesToAdaString } from './unit-converters';
 
 export interface StakePool {
   id: string;
@@ -22,9 +24,9 @@ export interface StakePool {
 }
 
 type StakePoolTransformerProp = {
-  stakePool: Wallet.Cardano.StakePool;
+  stakePool: Cardano.StakePool;
   delegatingPoolId?: string;
-  cardanoCoin: Wallet.CoinId;
+  cardanoCoin: CoinId;
 };
 
 export const stakePoolTransformer = ({
@@ -34,15 +36,15 @@ export const stakePoolTransformer = ({
 }: StakePoolTransformerProp): StakePool => {
   const { margin, cost, hexId, pledge, owners, status, metadata, id, metrics } = stakePool;
   const { size, apy, saturation } = metrics;
-  const calcCost = cost ? ` + ${Wallet.util.lovelacesToAdaString(cost.toString(), 0)}${cardanoCoin.symbol}` : '';
+  const calcCost = cost ? ` + ${lovelacesToAdaString(cost.toString(), 0)}${cardanoCoin.symbol}` : '';
   const calcMargin = margin ? `${formatPercentages(margin.numerator / margin.denominator)}` : '-';
 
   return {
     hexId: hexId.toString(),
     margin: calcMargin,
-    pledge: pledge ? `${Wallet.util.lovelacesToAdaString(pledge.toString())}${cardanoCoin.symbol}` : '-',
-    owners: owners ? owners.map((owner: Wallet.Cardano.RewardAccount) => owner.toString()) : [],
-    retired: status === Wallet.Cardano.StakePoolStatus.Retired,
+    pledge: pledge ? `${lovelacesToAdaString(pledge.toString())}${cardanoCoin.symbol}` : '-',
+    owners: owners ? owners.map((owner: Cardano.RewardAccount) => owner.toString()) : [],
+    retired: status === Cardano.StakePoolStatus.Retired,
     description: metadata?.description,
     size: `${size?.live ?? '-'} %`,
     id: id.toString(),
@@ -52,7 +54,7 @@ export const stakePoolTransformer = ({
     logo: metadata?.ext?.pool.media_assets?.icon_png_64x64 || getRandomIcon({ id: id.toString(), size: 30 }),
     apy: apy && formatPercentages(apy.valueOf()),
     saturation: saturation && formatPercentages(saturation.valueOf()),
-    fee: Wallet.util.lovelacesToAdaString(cost.toString()),
+    fee: lovelacesToAdaString(cost.toString()),
     isStakingPool: delegatingPoolId ? delegatingPoolId === id.toString() : undefined
   };
 };

--- a/packages/staking/src/features/browse-pools/BrowsePools.tsx
+++ b/packages/staking/src/features/browse-pools/BrowsePools.tsx
@@ -1,18 +1,21 @@
 import { Percent } from '@cardano-sdk/util';
-import { Wallet } from '@lace/cardano';
+import { StakePoolSortOptions, Wallet } from '@lace/cardano';
 import { Box, Flex } from '@lace/ui';
+import debounce from 'lodash/debounce';
+import { useEffect, useMemo, useState } from 'react';
 import { StakePoolDetails } from '../drawer';
-import { Sections } from '../store';
+import { Sections, useStakePoolDetails } from '../store';
 import stakePoolsRaw from './data.json';
 import { Search } from './search';
 import { StakePoolsTable } from './stake-pools-table';
 
-const stakePools = stakePoolsRaw.map<Wallet.Cardano.StakePool>((pool) => ({
+const stakePoolsMock = stakePoolsRaw.map<Wallet.Cardano.StakePool>((pool) => ({
   ...pool,
   cost: BigInt(pool.cost),
   hexId: Wallet.Cardano.PoolIdHex(pool.hexId),
   id: Wallet.Cardano.PoolId(pool.id),
-  metadataJson: undefined, // empty
+  // @ts-ignore
+  metadataJson: pool.metadataJson,
   metrics: {
     ...pool.metrics,
     livePledge: BigInt(pool.metrics.livePledge),
@@ -33,35 +36,121 @@ const stakePools = stakePoolsRaw.map<Wallet.Cardano.StakePool>((pool) => ({
   },
   owners: pool.owners.map((owner) => Wallet.Cardano.RewardAccount(owner)),
   pledge: BigInt(pool.pledge),
-  relays: [], // empty
+  // @ts-ignore
+  relays: pool.relays,
   rewardAccount: Wallet.Cardano.RewardAccount(pool.rewardAccount),
   status: pool.status as Wallet.Cardano.StakePoolStatus,
   vrf: Wallet.Cardano.VrfVkHex(pool.vrf),
 }));
+
+const DEFAULT_SORT_OPTIONS: StakePoolSortOptions = {
+  field: 'name',
+  order: 'asc',
+};
+const searchDebounce = 300;
+const mockFetchDelay = 500;
+
+const fetchStakePools = async ({
+  searchString,
+  sort,
+}: {
+  searchString: string;
+  skip?: number;
+  limit?: number;
+  sort?: StakePoolSortOptions;
+}) =>
+  new Promise<Wallet.Cardano.StakePool[]>((resolve) => {
+    setTimeout(() => {
+      const data = stakePoolsMock.filter((pool) => pool.metadata?.name.includes(searchString));
+
+      if (!sort) return resolve(data);
+
+      const dataSorted =
+        sort.field === 'name'
+          ? // mock data is already sorted
+            data
+          : sort.field === 'saturation'
+          ? // @ts-ignore
+            data.sort((poolA, poolB) => poolA.metrics.saturation - poolB.metrics.saturation)
+          : // @ts-ignore
+            data.sort((poolA, poolB) => poolA[sort.field] - poolB[sort.field]);
+
+      return sort.order === 'asc' ? resolve(dataSorted) : resolve(dataSorted.reverse());
+    }, mockFetchDelay);
+  });
 
 const stepsWithBackBtn = new Set([Sections.CONFIRMATION, Sections.SIGN]);
 
 const stepsWithExitConfirmation = new Set([Sections.CONFIRMATION, Sections.SIGN, Sections.FAIL_TX]);
 
 export const BrowsePools = () => {
+  const [isSearching, setIsSearching] = useState<boolean>(true);
+  const [isLoadingList, setIsLoadingList] = useState<boolean>(true);
+  const [sort, setSort] = useState<StakePoolSortOptions>(DEFAULT_SORT_OPTIONS);
+  const [searchValue, setSearchValue] = useState<string>('');
+  const { setIsDrawerVisible } = useStakePoolDetails();
+
+  const [stakePools, setStakePools] = useState<Wallet.StakePoolSearchResults['pageResults']>([]);
+  const [{ pageResults, totalResultCount }, setStakePoolSearchResults] = useState<Wallet.StakePoolSearchResults>({
+    pageResults: [],
+    totalResultCount: 0,
+  });
+
+  const onSearch = (searchString: string) => {
+    setIsSearching(true);
+    setSearchValue(searchString);
+  };
+  const [fetchingPools, setFetchingPools] = useState(false);
   // TODO: compute real value
   const hasNoFunds = false;
   // eslint-disable-next-line unicorn/consistent-function-scoping,@typescript-eslint/no-empty-function
   const onStake = () => {};
+  const debouncedSearch = useMemo(
+    () =>
+      debounce((...args: Parameters<typeof fetchStakePools>) => {
+        setFetchingPools(true);
+        // eslint-disable-next-line promise/catch-or-return
+        fetchStakePools(...args).then((pools) => {
+          setStakePoolSearchResults({
+            pageResults: pools,
+            totalResultCount: pools.length,
+          });
+          setFetchingPools(false);
+          setIsSearching(false);
+        });
+      }, searchDebounce),
+    []
+  );
+
+  useEffect(() => {
+    // Close pool details drawer & fetch pools on mount, network switching, searchValue change and sort change
+    setIsLoadingList(true);
+    setIsDrawerVisible(false);
+    // @ts-ignore
+    debouncedSearch({ searchString: searchValue, sort });
+  }, [searchValue, sort, debouncedSearch, setIsDrawerVisible]);
+
+  useEffect(() => {
+    // Update stake pool list and new offset position
+    setStakePools(pageResults);
+    setIsLoadingList(false);
+  }, [pageResults]);
 
   return (
     <Flex flexDirection={'column'} alignItems={'stretch'}>
-      <Search />
+      <Search onChange={onSearch} loading={fetchingPools} />
       <Box mt={'$32'}>
         <StakePoolsTable
           stakePools={stakePools}
           // eslint-disable-next-line @typescript-eslint/no-empty-function
           loadMoreData={() => {}}
-          totalResultCount={stakePoolsRaw.length}
-          isSearching={false}
-          fetchingPools={false}
-          isLoadingList={false}
+          totalResultCount={totalResultCount}
+          isSearching={isSearching}
+          fetchingPools={fetchingPools}
+          isLoadingList={isLoadingList}
           scrollableTargetId={'lace-app'}
+          sort={sort}
+          setSort={setSort}
         />
       </Box>
       <StakePoolDetails

--- a/packages/staking/src/features/browse-pools/search/Search.tsx
+++ b/packages/staking/src/features/browse-pools/search/Search.tsx
@@ -1,13 +1,20 @@
-import { Search as SearchBase } from '@lace/common';
+import { Search as SearchBase, SearchProps as SearchBaseProps } from '@lace/common';
+import { useTranslation } from 'react-i18next';
 import * as styles from './Search.module.scss';
 
-export const Search = () => (
-  <SearchBase
-    className={styles.search}
-    withSearchIcon
-    inputPlaceholder={'Search by type, token name or ID'}
-    onChange={() => console.info('on change')}
-    data-testid="search-input"
-    loading={false}
-  />
-);
+type SearchProps = Pick<SearchBaseProps, 'onChange' | 'loading'>;
+
+export const Search = ({ onChange, loading }: SearchProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <SearchBase
+      className={styles.search}
+      withSearchIcon
+      inputPlaceholder={t('browsePools.stakePoolTableBrowser.searchInputPlaceholder')}
+      onChange={onChange}
+      data-testid="search-input"
+      loading={loading}
+    />
+  );
+};

--- a/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolsTable.tsx
+++ b/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolsTable.tsx
@@ -1,16 +1,11 @@
 import { Wallet } from '@lace/cardano';
 import { getRandomIcon } from '@lace/common';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOutsideHandles } from '../../outside-handles-provider';
 import { useStakePoolDetails } from '../../store';
 import { StakePoolsTableEmpty } from './StakePoolsTableEmpty';
 import { StakePoolSortOptions, StakePoolTableBrowser, StakePoolTableBrowserProps } from './StakePoolTableBrowser';
-
-const DEFAULT_SORT_OPTIONS: StakePoolSortOptions = {
-  field: 'apy',
-  order: 'desc',
-};
 
 type StakePoolsTableProps = {
   stakePools: Wallet.Cardano.StakePool[];
@@ -20,6 +15,8 @@ type StakePoolsTableProps = {
   fetchingPools: boolean;
   isLoadingList: boolean;
   scrollableTargetId: string;
+  sort: StakePoolSortOptions;
+  setSort: (options: StakePoolSortOptions) => void;
 };
 
 export const StakePoolsTable = ({
@@ -30,10 +27,11 @@ export const StakePoolsTable = ({
   fetchingPools,
   isLoadingList,
   scrollableTargetId,
+  sort,
+  setSort,
 }: StakePoolsTableProps) => {
   const { delegationStoreSetSelectedStakePool, walletStoreWalletUICardanoCoin } = useOutsideHandles();
   const { setIsDrawerVisible } = useStakePoolDetails();
-  const [sort, setSort] = useState<StakePoolSortOptions>(DEFAULT_SORT_OPTIONS);
   const { t } = useTranslation();
   const tableHeaderTranslations = {
     apy: t('browsePools.stakePoolTableBrowser.tableHeader.ros'),

--- a/packages/staking/src/features/i18n/translations/en.ts
+++ b/packages/staking/src/features/i18n/translations/en.ts
@@ -2,6 +2,7 @@ import { Translations } from '../types';
 
 export const en: Translations = {
   'browsePools.stakePoolTableBrowser.emptyMessage': 'No results matching your search',
+  'browsePools.stakePoolTableBrowser.searchInputPlaceholder': 'Search by type, token name or ID',
   'browsePools.stakePoolTableBrowser.tableHeader.cost': 'Cost',
   'browsePools.stakePoolTableBrowser.tableHeader.poolName': 'Pool name',
   'browsePools.stakePoolTableBrowser.tableHeader.ros': 'ROS',

--- a/packages/staking/src/features/i18n/types.ts
+++ b/packages/staking/src/features/i18n/types.ts
@@ -11,6 +11,7 @@ export type ConstructTranslationKeyUnion<T extends RecursiveStructure, K extends
 type KeysStructure = {
   browsePools: {
     stakePoolTableBrowser: {
+      searchInputPlaceholder: '';
       tableHeader: {
         poolName: '';
         ros: '';


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7099

---

## Proposed solution

Add mocked search and filtering (temporary limitation).

## Testing
1. Open Staking
2. Go to the Browse Pools tab
3. Search or Sort the Pools


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/700/5414784905/index.html) for [6f3cb083](https://github.com/input-output-hk/lace/pull/197/commits/6f3cb083a5e26321d057d5ed2b911a46717886c9)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 33     | 3      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->