### PR TITLE
test(extension): e2e - add tests for create folder button click

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/NameForm.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/NameForm.tsx
@@ -57,9 +57,10 @@ export const NameForm = ({
         label={t('browserView.nfts.folderDrawer.nameForm.inputPlaceholder')}
         value={name}
         onChange={handleNameChange}
+        dataTestId="folder-name-input"
       />
       {isDirty && nameValidationError && !isNameEmpty && (
-        <p className={styles.formError} data-testid="wallet-setup-register-name-error">
+        <p className={styles.formError} data-testid="folder-name-input-error">
           {t(nameValidationError, { length: MAX_CHARS })}
         </p>
       )}

--- a/packages/common/src/ui/components/Form/Input/Input.tsx
+++ b/packages/common/src/ui/components/Form/Input/Input.tsx
@@ -41,7 +41,11 @@ export const Input = ({
       ref={inputRef}
       onChange={onValChange}
       {...(label && {
-        prefix: <div className={cn(styles.label, { [styles.filled]: localVal })}>{label}</div>
+        prefix: (
+          <div className={cn(styles.label, { [styles.filled]: localVal })} data-testid="input-label">
+            {label}
+          </div>
+        )
       })}
       value={localVal}
       data-testid={dataTestId}

--- a/packages/e2e-tests/src/assert/nftAssert.ts
+++ b/packages/e2e-tests/src/assert/nftAssert.ts
@@ -115,13 +115,6 @@ class NftAssert {
       await expect(await NftDetails.sendNFTButton.getText()).to.equal(await t('core.nftDetail.sendNFT'));
     }
   }
-
-  async assertSeeCreateFolderButton(shouldSee: boolean, mode: 'extended' | 'popup') {
-    await NftsPage.createFolderButton.waitForDisplayed({ reverse: !shouldSee });
-    if (mode === 'extended' && shouldSee === true) {
-      await expect(await NftsPage.createFolderButton.getText()).to.equal(await t('browserView.nfts.createFolder'));
-    }
-  }
 }
 
 export default new NftAssert();

--- a/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
+++ b/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
@@ -1,0 +1,64 @@
+import NftsPage from '../elements/NFTs/nftsPage';
+import { t } from '../utils/translationService';
+import { expect } from 'chai';
+import NftFolderNameInput from '../elements/NFTs/nftFolderNameInput';
+import NftCreateFolderPage from '../elements/NFTs/nftCreateFolderPage';
+
+class NftCreateFolderAssert {
+  async assertSeeCreateFolderButton(shouldSee: boolean, mode: 'extended' | 'popup') {
+    await NftsPage.createFolderButton.waitForDisplayed({ reverse: !shouldSee });
+    if (mode === 'extended' && shouldSee === true) {
+      await expect(await NftsPage.createFolderButton.getText()).to.equal(await t('browserView.nfts.createFolder'));
+    }
+  }
+
+  async assertSeeCreateFolderPageDrawerNavigation(mode: 'extended' | 'popup') {
+    if (mode === 'popup') {
+      await NftCreateFolderPage.drawerHeaderBackButton.waitForDisplayed();
+    } else {
+      await NftCreateFolderPage.drawerBody.waitForDisplayed();
+      await NftCreateFolderPage.drawerNavigationTitle.waitForDisplayed();
+      await NftCreateFolderPage.drawerNavigationTitle.scrollIntoView();
+      await expect(await NftCreateFolderPage.drawerNavigationTitle.getText()).to.equal(
+        await t('browserView.nfts.folderDrawer.header')
+      );
+      await NftCreateFolderPage.drawerHeaderCloseButton.waitForDisplayed();
+    }
+  }
+
+  async assertSeeCreateFolderPage(shouldSee: boolean, mode: 'extended' | 'popup') {
+    if (shouldSee) {
+      await this.assertSeeCreateFolderPageDrawerNavigation(mode);
+      await NftCreateFolderPage.drawerHeaderTitle.waitForDisplayed();
+      await expect(await NftCreateFolderPage.drawerHeaderTitle.getText()).to.equal(
+        await t('browserView.nfts.folderDrawer.nameForm.title')
+      );
+
+      await NftCreateFolderPage.folderNameInput.input.waitForDisplayed();
+
+      await NftCreateFolderPage.folderNameInput.inputLabel.waitForDisplayed();
+      await expect(await NftCreateFolderPage.folderNameInput.inputLabel.getText()).to.equal(
+        await t('browserView.nfts.folderDrawer.nameForm.inputPlaceholder')
+      );
+
+      await NftCreateFolderPage.nextButton.waitForDisplayed();
+      await expect(await NftCreateFolderPage.nextButton.getText()).to.equal(
+        await t('browserView.nfts.folderDrawer.cta.create')
+      );
+    } else {
+      await NftCreateFolderPage.drawerBody.waitForDisplayed({ reverse: true });
+    }
+  }
+
+  async assertSeeEmptyNameInput() {
+    await expect(await NftFolderNameInput.input.getValue()).to.be.empty;
+  }
+
+  async assertSeeNextButtonEnabled(isEnabled: boolean) {
+    await (isEnabled
+      ? expect(await NftCreateFolderPage.nextButton.isEnabled()).to.be.true
+      : expect(await NftCreateFolderPage.nextButton.isEnabled()).to.be.false);
+  }
+}
+
+export default new NftCreateFolderAssert();

--- a/packages/e2e-tests/src/elements/NFTs/nftCreateFolderPage.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftCreateFolderPage.ts
@@ -1,0 +1,16 @@
+import CommonDrawerElements from '../CommonDrawerElements';
+import NftFolderNameInput from './nftFolderNameInput';
+
+class NftCreateFolderPage extends CommonDrawerElements {
+  private NEXT_BUTTON = '[data-testid="create-folder-drawer-form-cta"]';
+
+  get nextButton() {
+    return $(this.NEXT_BUTTON);
+  }
+
+  get folderNameInput(): typeof NftFolderNameInput {
+    return NftFolderNameInput;
+  }
+}
+
+export default new NftCreateFolderPage();

--- a/packages/e2e-tests/src/elements/NFTs/nftFolderNameInput.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftFolderNameInput.ts
@@ -1,0 +1,19 @@
+class NftFolderNameInput {
+  private INPUT = '[data-testid="folder-name-input"]';
+  private INPUT_LABEL = '[data-testid="input-label"]';
+  private INPUT_ERROR = '[data-testid="folder-name-input-error"]';
+
+  get input() {
+    return $(this.INPUT);
+  }
+
+  get inputLabel() {
+    return $(this.INPUT_LABEL);
+  }
+
+  get inputError() {
+    return $(this.INPUT_ERROR);
+  }
+}
+
+export default new NftFolderNameInput();

--- a/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
@@ -1,0 +1,13 @@
+@NFT-Folders-Extended @Testnet
+Feature: NFT - Folders - Extended view
+
+  Background:
+    Given Wallet is synced
+
+  @LW-7242
+  Scenario: Extended-view - NFT Folders - "Create folder" button click
+    Given I navigate to NFTs extended page
+    When I click "Create folder" button on NFTs page
+    Then I see "Create NFT folder" page in extended mode
+    And "Folder name" input is empty on "Name your folder" page
+    And "Next" button is disabled on "Name your folder" page

--- a/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
@@ -1,0 +1,13 @@
+@NFT-Folders-Popup @Testnet
+Feature: NFT - Folders - Popup view
+
+  Background:
+    Given Wallet is synced
+
+  @LW-7260
+  Scenario: Popup-view - NFT Folders - "Create folder" button click
+    Given I navigate to NFTs popup page
+    When I click "Create folder" button on NFTs page
+    Then I see "Create NFT folder" page in popup mode
+    And "Folder name" input is empty on "Name your folder" page
+    And "Next" button is disabled on "Name your folder" page

--- a/packages/e2e-tests/src/hooks/beforeTagHooks.ts
+++ b/packages/e2e-tests/src/hooks/beforeTagHooks.ts
@@ -26,14 +26,14 @@ Before(
 
 Before(
   {
-    tags: '@AddressBook-extended or @Transactions-Extended or @Tokens-extended or @Staking-Extended or @LockWallet-extended or @Top-Navigation-Extended or @NFTs-Extended or @SendTx-Bundles-Extended or @SendTx-Simple-Extended or @MainNavigation-Extended or @Send-Transaction-Metadata-Extended or @Settings-Extended or @DAppConnector or @DAppConnector-Extended'
+    tags: '@AddressBook-extended or @Transactions-Extended or @Tokens-extended or @Staking-Extended or @LockWallet-extended or @Top-Navigation-Extended or @NFTs-Extended or @NFT-Folders-Extended or @SendTx-Bundles-Extended or @SendTx-Simple-Extended or @MainNavigation-Extended or @Send-Transaction-Metadata-Extended or @Settings-Extended or @DAppConnector or @DAppConnector-Extended'
   },
   async () => await extendedViewWalletInitialization()
 );
 
 Before(
   {
-    tags: '@Tokens-popup or @Transactions-Popup or @Staking-Popup or @LockWallet-popup or @Top-Navigation-Popup or @AddressBook-popup or @Common-Popup or @SendTx-Simple-Popup or @MainNavigation-Popup or @Settings-Popup or @NFTs-Popup or @Send-Transaction-Metadata-Popup or @ForgotPassword or @DAppConnector-Popup'
+    tags: '@Tokens-popup or @Transactions-Popup or @Staking-Popup or @LockWallet-popup or @Top-Navigation-Popup or @AddressBook-popup or @Common-Popup or @SendTx-Simple-Popup or @MainNavigation-Popup or @Settings-Popup or @NFTs-Popup or @NFT-Folders-Popup or @Send-Transaction-Metadata-Popup or @ForgotPassword or @DAppConnector-Popup'
   },
   async () => await popupViewWalletInitialization()
 );

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -1,0 +1,33 @@
+import { When } from '@wdio/cucumber-framework';
+import { Given, Then } from '@cucumber/cucumber';
+import NftsPage from '../elements/NFTs/nftsPage';
+import nftCreateFolderAssert from '../assert/nftCreateFolderAssert';
+
+Given(
+  /^I (see|do not see) "Create folder" button on NFTs page in (popup|extended) mode$/,
+  async (shouldSee: 'see' | 'do not see', mode: 'extended' | 'popup') => {
+    await nftCreateFolderAssert.assertSeeCreateFolderButton(shouldSee === 'see', mode);
+  }
+);
+
+When(/^I click "Create folder" button on NFTs page$/, async () => {
+  await NftsPage.createFolderButton.click();
+});
+
+Then(
+  /^I (see|do not see) "Create NFT folder" page in (popup|extended) mode$/,
+  async (shouldSee: 'see' | 'do not see', mode: 'extended' | 'popup') => {
+    await nftCreateFolderAssert.assertSeeCreateFolderPage(shouldSee === 'see', mode);
+  }
+);
+
+Then(/^"Folder name" input is empty on "Name your folder" page$/, async () => {
+  await nftCreateFolderAssert.assertSeeEmptyNameInput();
+});
+
+Then(
+  /^"Next" button is (enabled|disabled) on "Name your folder" page$/,
+  async (isButtonEnabled: 'enabled' | 'disabled') => {
+    await nftCreateFolderAssert.assertSeeNextButtonEnabled(isButtonEnabled === 'enabled');
+  }
+);

--- a/packages/e2e-tests/src/steps/nftsCommonSteps.ts
+++ b/packages/e2e-tests/src/steps/nftsCommonSteps.ts
@@ -81,13 +81,6 @@ Given(
   }
 );
 
-Given(
-  /^I (see|do not see) "Create folder" button on NFTs page in (popup|extended) mode$/,
-  async (shouldSee: 'see' | 'do not see', mode: 'extended' | 'popup') => {
-    await nftAssert.assertSeeCreateFolderButton(shouldSee === 'see', mode);
-  }
-);
-
 Then(/^A gallery view showing my NFTs is displayed$/, async () => {
   await $(new NftItem().container().toJSLocator()).waitForDisplayed({ timeout: 15_000 });
   await nftAssert.assertSeeNftList(1);


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/720/5422910777/index.html) for [f91916ed](https://github.com/input-output-hk/lace/pull/200/commits/f91916edc99008804b103439a90b8840e4bc8285)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 33     | 3      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->