### PR TITLE
feat(core): adds warning icon to wallet address item

### DIFF
--- a/packages/core/src/ui/assets/icons/missing.component.svg
+++ b/packages/core/src/ui/assets/icons/missing.component.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 8V12M12 16H12.01M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" stroke="#FF5470" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.module.scss
+++ b/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.module.scss
@@ -43,7 +43,8 @@
 .listItemBlock {
   align-items: center;
   display: flex;
-  gap: size_unit(3);
+  gap: size_unit(1);
+  width: auto !important;
   &.small {
     gap: size_unit(2);
 
@@ -73,6 +74,13 @@
     & > * {
       width: 100%;
     }
+    @media ( max-width: $breakpoint-popup) {
+      flex: initial;
+    }
+  }
+  .listItemWarning {
+    min-width: size_unit(2.5);
+    min-height: size_unit(2.5);
   }
   .textField {
     color: var(--text-color-primary) !important;
@@ -89,7 +97,6 @@
 }
 
 .addressBox {
-  display: block;
   min-width: 0;
 }
 

--- a/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.tsx
+++ b/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import cn from 'classnames';
-import { Typography } from 'antd';
+import { Typography, Tooltip } from 'antd';
 import { Ellipsis } from '@lace/common';
+import { ReactComponent as MissingIcon } from '../../assets/icons/missing.component.svg';
 import styles from './WalletAddressItem.module.scss';
+import { useTranslate } from '@src/ui/hooks';
 const { Text } = Typography;
 
 interface AddressBookSchema {
@@ -21,6 +23,7 @@ export type WalletAddressItemProps = {
   afterEllipsis?: number;
   isSmall?: boolean;
   shouldUseEllipsisBeforeAndAfter?: boolean;
+  isAddressWarningVisible?: boolean;
 };
 
 const defaultBeforeEllipsis = 8;
@@ -35,39 +38,52 @@ export const WalletAddressItem = ({
   afterEllipsis = defaultAfterEllipsis,
   className,
   isSmall = false,
-  shouldUseEllipsisBeforeAndAfter
-}: WalletAddressItemProps): React.ReactElement => (
-  <div
-    onClick={() => onClick({ id, name, address })}
-    data-testid="address-list-item"
-    className={cn(styles.listItemContainer, { [styles.small]: isSmall, className })}
-  >
-    <div>
-      <div className={cn(styles.listItemBlock, { [styles.small]: isSmall })}>
-        <div data-testid="address-list-item-avatar" className={cn(styles.listItemAvatar, { [styles.small]: isSmall })}>
-          {name.charAt(0).toLocaleUpperCase()}
-        </div>
-        <div data-testid="address-list-item-name" className={cn(styles.listItemName, { [styles.small]: isSmall })}>
-          <Text className={styles.textField} ellipsis={{ tooltip: name }}>
-            {name}
-          </Text>
+  shouldUseEllipsisBeforeAndAfter,
+  isAddressWarningVisible = false
+}: WalletAddressItemProps): React.ReactElement => {
+  const { t } = useTranslate();
+
+  return (
+    <div
+      onClick={() => onClick({ id, name, address })}
+      data-testid="address-list-item"
+      className={cn(styles.listItemContainer, { [styles.small]: isSmall, className })}
+    >
+      <div>
+        <div className={cn(styles.listItemBlock, { [styles.small]: isSmall })}>
+          <div
+            data-testid="address-list-item-avatar"
+            className={cn(styles.listItemAvatar, { [styles.small]: isSmall })}
+          >
+            {name.charAt(0).toLocaleUpperCase()}
+          </div>
+          <div data-testid="address-list-item-name" className={cn(styles.listItemName, { [styles.small]: isSmall })}>
+            <Text className={styles.textField} ellipsis={{ tooltip: name }}>
+              {name}
+            </Text>
+          </div>
         </div>
       </div>
+      <div className={cn(styles.listItemBlock, styles.addressBox)}>
+        {isAddressWarningVisible && (
+          <Tooltip title={t('package.core.addressBook.addressHandleTooltip')}>
+            <MissingIcon data-testid="address-list-item-warning" className={cn(styles.listItemWarning)} />
+          </Tooltip>
+        )}
+        <Ellipsis
+          dataTestId="address-list-item-address"
+          text={address}
+          textClassName={cn(styles.addressColor, styles.textField)}
+          className={cn(styles.listItemBlock, styles.listItemAddress)}
+          withTooltip={false}
+          {...(isSmall || shouldUseEllipsisBeforeAndAfter
+            ? {
+                beforeEllipsis,
+                afterEllipsis
+              }
+            : { ellipsisInTheMiddle: true })}
+        />
+      </div>
     </div>
-    <div className={cn(styles.listItemBlock, styles.addressBox)}>
-      <Ellipsis
-        dataTestId="address-list-item-address"
-        text={address}
-        textClassName={cn(styles.addressColor, styles.textField)}
-        className={cn(styles.listItemBlock, styles.listItemAddress)}
-        withTooltip={false}
-        {...(isSmall || shouldUseEllipsisBeforeAndAfter
-          ? {
-              beforeEllipsis,
-              afterEllipsis
-            }
-          : { ellipsisInTheMiddle: true })}
-      />
-    </div>
-  </div>
-);
+  );
+};

--- a/packages/core/src/ui/components/WalletAddresses/__tests__/WalletAddressItem.test.tsx
+++ b/packages/core/src/ui/components/WalletAddresses/__tests__/WalletAddressItem.test.tsx
@@ -12,14 +12,18 @@ describe('Testing WalletAddressItem component', () => {
     onClick: jest.fn()
   };
 
-  test('should render a wallet address item', async () => {
-    const elWidth = 300;
+  const elWidth = 300;
+
+  beforeAll(() => {
     // const originalOffsetWidth = window.HTMLElement.prototype.offsetWidth;
     Object.defineProperties(window.HTMLElement.prototype, {
       offsetWidth: {
         get: () => elWidth
       }
     });
+  });
+
+  test('should render a wallet address item with a correct address', async () => {
     const { findByTestId } = render(<WalletAddressItem {...props} />);
     const walletItem = await findByTestId('address-list-item');
 
@@ -37,6 +41,33 @@ describe('Testing WalletAddressItem component', () => {
     expect(walletAddress).toBeVisible();
     expect(walletNameText).toBeVisible();
     expect(walletAddressText).toBeVisible();
+  });
+
+  test('should render a wallet address item with an incorrect address', async () => {
+    const incorrectAddressProps: WalletAddressItemProps = {
+      isAddressWarningVisible: true,
+      ...props
+    };
+
+    const { findByTestId } = render(<WalletAddressItem {...incorrectAddressProps} />);
+    const walletItem = await findByTestId('address-list-item');
+
+    const walletAvatar = await findByTestId('address-list-item-avatar');
+    const avatarIcon = await within(walletItem).findByText(props.name.charAt(0).toLocaleUpperCase());
+
+    const walletName = await findByTestId('address-list-item-name');
+    const walletAddress = await findByTestId('address-list-item-address');
+    const walletNameText = await within(walletName).findByText(props.name);
+    const walletAddressText = await within(walletItem).findByText(props.address);
+    const walletAddressWarning = await within(walletItem).findByTestId('address-list-item-warning');
+
+    expect(walletAvatar).toBeVisible();
+    expect(avatarIcon).toBeVisible();
+    expect(walletName).toBeVisible();
+    expect(walletAddress).toBeVisible();
+    expect(walletNameText).toBeVisible();
+    expect(walletAddressText).toBeVisible();
+    expect(walletAddressWarning).toBeVisible();
   });
 
   test('should call the onClick function when clicking the item', async () => {

--- a/packages/core/src/ui/lib/translations/en.json
+++ b/packages/core/src/ui/lib/translations/en.json
@@ -1,5 +1,8 @@
 {
   "package.core": {
+    "addressBook": {
+      "addressHandleTooltip": "The address linked to this handle has changed, click to update or delete."
+    },
     "assetActivityItem": {
       "entry": {
         "asset": "asset",


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-7304](https://input-output.atlassian.net/browse/LW-7304)
- [x] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Add an optional proptype to `WalletAddress` so that we can display a warning when an address has changed. 

## Testing

Running the tests. 
Also, by going to the address book and setting the prop `isWarningVisible` to true/false. 

## Screenshots
<img width="355" alt="Screenshot 2023-06-30 at 13 54 18" src="https://github.com/input-output-hk/lace/assets/4052063/ebf03478-09ec-4eb6-ba50-93b4ce0702dd">
<img width="1660" alt="Screenshot 2023-06-30 at 13 53 56" src="https://github.com/input-output-hk/lace/assets/4052063/962130fc-d3db-4e7e-ae4f-d161d4b8910a">
<img width="1830" alt="Screenshot 2023-06-30 at 13 53 51" src="https://github.com/input-output-hk/lace/assets/4052063/b69be724-357b-4e67-b571-b72811841c72">

<img width="353" alt="Screenshot 2023-06-30 at 13 54 24" src="https://github.com/input-output-hk/lace/assets/4052063/7026fa10-4921-425e-86bc-0c1baf70e741">

[LW-7304]: https://input-output.atlassian.net/browse/LW-7304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/719/5422813261/index.html) for [ceeed2b3](https://github.com/input-output-hk/lace/pull/202/commits/ceeed2b3430d8cf7d294dff7ceb18cbad6b83030)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 33     | 3      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->