### PR TITLE
fix(common): change icon import

### DIFF
--- a/packages/common/src/ui/components/Banner/Banner.tsx
+++ b/packages/common/src/ui/components/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Typography } from 'antd';
 import cn from 'classnames';
-import DefaultIcon from '../../assets/icons/banner-icon.component.svg';
+import { ReactComponent as DefaultIcon } from '../../assets/icons/banner-icon.component.svg';
 import styles from './Banner.module.scss';
 
 const { Text } = Typography;


### PR DESCRIPTION
# Checklist

- [ ] JIRA - LW 7308
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

In the common package, the svgs will be bundled with rollup (`@svgr/rollup` and `@rollup/plugin-image`) and the svg component is exported as named export `ReactComponent`. This is different to how webpack will bundle svgs in the extension app with default export. In this case, the default export is the svg data uri which caused this issue as it was being used as a react component. This PR fixes the import to named export, but to avoid this issue we should standardize the svg import across the repository or improve the svg type.

Import on rollup bundle
`import { ReactComponent as DefaultIcon } from '../../assets/icons/banner-icon.component.svg';
`

Svg import on webpack bundle
`import DefaultIcon from '../../assets/icons/banner-icon.component.svg';
`


## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/733/5426319999/index.html) for [f9faf797](https://github.com/input-output-hk/lace/pull/206/commits/f9faf7973c1fd0a27d92d6e9f282908073f19646)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->