### PR TITLE
chore(extension): fix svgs icons imports

### DIFF
--- a/apps/browser-extension-wallet/src/features/address-book/hooks/__tests__/useGetFilteredAddressBook.test.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/hooks/__tests__/useGetFilteredAddressBook.test.tsx
@@ -64,13 +64,15 @@ describe('Testing useGetFilteredAddressBook hook', () => {
     });
     expect(result.current.getAddressBookByNameOrAddress).toBeDefined();
 
-    await result.current.getAddressBookByNameOrAddress({ value: 't' });
+    await act(async () => {
+      await result.current.getAddressBookByNameOrAddress({ value: 't' });
+    });
     expect(result.current.filteredAddresses).toHaveLength(1);
     expect(result.current.filteredAddresses).toStrictEqual([
       { id: 1, walletAddress: 'addr_test1', walletName: 'test wallet' }
     ]);
 
-    await act(() => result.current.resetAddressList());
+    act(() => result.current.resetAddressList());
     expect(result.current.filteredAddresses).toHaveLength(0);
     expect(result.current.filteredAddresses).toStrictEqual([]);
   });
@@ -81,10 +83,14 @@ describe('Testing useGetFilteredAddressBook hook', () => {
     });
     expect(result.current.getAddressBookByNameOrAddress).toBeDefined();
 
-    await result.current.getAddressBookByNameOrAddress({ value: 'oth' });
+    await act(async () => {
+      await result.current.getAddressBookByNameOrAddress({ value: 'oth' });
+    });
     expect(result.current.filteredAddresses).toHaveLength(2);
 
-    await result.current.getAddressBookByNameOrAddress({ value: 'oth', limit: 1 });
+    await act(async () => {
+      await result.current.getAddressBookByNameOrAddress({ value: 'oth', limit: 1 });
+    });
     expect(result.current.filteredAddresses).toHaveLength(1);
   });
 
@@ -94,7 +100,9 @@ describe('Testing useGetFilteredAddressBook hook', () => {
     });
     expect(result.current.getAddressBookByNameOrAddress).toBeDefined();
 
-    await result.current.getAddressBookByNameOrAddress({ value: 'addr_test3' });
+    await act(async () => {
+      await result.current.getAddressBookByNameOrAddress({ value: 'addr_test3' });
+    });
     expect(result.current.filteredAddresses).toHaveLength(1);
     expect(result.current.filteredAddresses).toStrictEqual([
       { id: 3, walletAddress: 'addr_test3', walletName: 'Other wallet 2' }

--- a/apps/browser-extension-wallet/src/features/dapp/components/Connect.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/Connect.tsx
@@ -15,7 +15,7 @@ import * as cip30 from '@cardano-sdk/dapp-connector';
 import { UserPromptService } from '@lib/scripts/background/services/dappService';
 import { of } from 'rxjs';
 import InfoIcon from '../../../assets/icons/info.component.svg';
-import ShieldExclamation from '@assets/icons/shield-exclamation.component.svg';
+import ShieldExclamation from '../../../assets/icons/shield-exclamation.component.svg';
 import { Tooltip } from 'antd';
 import { useWalletStore } from '@src/stores';
 

--- a/apps/browser-extension-wallet/src/features/nfts/context/__test__/context.test.tsx
+++ b/apps/browser-extension-wallet/src/features/nfts/context/__test__/context.test.tsx
@@ -9,6 +9,8 @@ import { DatabaseProvider } from '@src/providers/DatabaseProvider';
 import { StoreProvider } from '@src/stores';
 import create from 'zustand';
 import { AppSettingsProvider } from '@providers';
+import { act } from 'react-dom/test-utils';
+import { waitFor } from '@testing-library/react';
 
 jest.mock('../NftsFoldersProvider', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -49,14 +51,17 @@ describe('testing useNftsFoldersState', () => {
     const { result, waitForNextUpdate } = renderHook(() => useNftsFoldersContext(), {
       wrapper: makeDbContextWrapper(db)
     });
-    expect(result.current.utils.deleteRecord).toBeDefined();
-    expect(result.current.utils.saveRecord).toBeDefined();
-    expect(result.current.utils.extendLimit).toBeDefined();
 
     await waitForNextUpdate();
 
-    expect(result.current.list.length).toBe(10);
-    expect(result.current.count).toBe(15);
+    await waitFor(() => {
+      expect(result.current.utils.deleteRecord).toBeDefined();
+      expect(result.current.utils.saveRecord).toBeDefined();
+      expect(result.current.utils.extendLimit).toBeDefined();
+
+      expect(result.current.list.length).toBe(10);
+      expect(result.current.count).toBe(15);
+    });
   });
 
   test('should add new folder and extend limit', async () => {
@@ -66,45 +71,48 @@ describe('testing useNftsFoldersState', () => {
 
     await waitForNextUpdate();
 
-    result.current.utils.saveRecord({ assets: ['folder_test16'], name: 'test folder 16' });
-
-    await waitForNextUpdate();
-
-    result.current.utils.extendLimit();
-
-    await waitForNextUpdate();
-
-    expect(result.current.list).toContainEqual({
-      assets: ['folder_test16'],
-      id: 16,
-      name: 'test folder 16',
-      network: 'Preprod'
+    await act(async () => {
+      await result.current.utils.saveRecord({ assets: ['folder_test16'], name: 'test folder 16' });
     });
-    expect(result.current.list.length).toBe(16);
-    expect(result.current.count).toBe(16);
+
+    act(() => {
+      result.current.utils.extendLimit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.list).toContainEqual({
+        assets: ['folder_test16'],
+        id: 16,
+        name: 'test folder 16',
+        network: 'Preprod'
+      });
+      expect(result.current.list.length).toBe(16);
+      expect(result.current.count).toBe(16);
+    });
   });
 
   test('should delete folder', async () => {
     const { result, waitForNextUpdate } = renderHook(() => useNftsFoldersContext(), {
       wrapper: makeDbContextWrapper(db)
     });
-
     await waitForNextUpdate();
 
-    result.current.utils.deleteRecord(1);
-
-    await waitForNextUpdate();
-
-    result.current.utils.extendLimit();
-
-    await waitForNextUpdate();
-
-    expect(result.current.list).not.toContainEqual({
-      assets: ['asset_test1'],
-      name: 'test folder',
-      id: 1
+    await act(async () => {
+      await result.current.utils.deleteRecord(1);
     });
-    expect(result.current.list.length).toBe(14);
-    expect(result.current.count).toBe(14);
+
+    act(() => {
+      result.current.utils.extendLimit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.list).not.toContainEqual({
+        assets: ['asset_test1'],
+        name: 'test folder',
+        id: 1
+      });
+      expect(result.current.list.length).toBe(14);
+      expect(result.current.count).toBe(14);
+    });
   });
 });

--- a/apps/browser-extension-wallet/src/hooks/__tests__/useActionExecution.test.ts
+++ b/apps/browser-extension-wallet/src/hooks/__tests__/useActionExecution.test.ts
@@ -93,7 +93,7 @@ describe('Testing useActionExecution hook', () => {
     expect(mockNotify).toBeCalledWith({
       text: errorResult,
       duration: 'toastDuration',
-      icon: 'test-file-stub'
+      icon: 'div'
     });
 
     hook.rerender(false);
@@ -105,7 +105,7 @@ describe('Testing useActionExecution hook', () => {
     expect(mockNotify).toBeCalledWith({
       text: errorMessage,
       duration: 3,
-      icon: 'test-file-stub'
+      icon: 'div'
     });
   });
 });

--- a/apps/browser-extension-wallet/src/hooks/__tests__/useMaxAda.test.ts
+++ b/apps/browser-extension-wallet/src/hooks/__tests__/useMaxAda.test.ts
@@ -4,6 +4,8 @@ import { renderHook } from '@testing-library/react-hooks';
 import { mockWalletInfoTestnet } from '@src/utils/mocks/test-helpers';
 import { Subject, of } from 'rxjs';
 import { Wallet } from '@lace/cardano';
+import { waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 const mockInitializeTx = jest.fn();
 
 const inMemoryWallet = {
@@ -47,11 +49,14 @@ describe('Testing useMaxAda hook', () => {
   });
 
   test('should return 0 in case balance.coins is empty', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useMaxAda());
-    inMemoryWallet.balance.utxo.available$.next({ coins: undefined });
+    const { result } = renderHook(() => useMaxAda());
+    act(() => {
+      inMemoryWallet.balance.utxo.available$.next({ coins: undefined });
+    });
 
-    await waitForNextUpdate();
-    expect(result.current.toString()).toBe('0');
+    await waitFor(() => {
+      expect(result.current.toString()).toBe('0');
+    });
   });
 
   test('should return 0 in case there is an error', async () => {
@@ -59,33 +64,43 @@ describe('Testing useMaxAda hook', () => {
     mockInitializeTx.mockImplementation(async () => {
       throw new Error('init tx error');
     });
-    const { result, waitForNextUpdate } = renderHook(() => useMaxAda());
+    const { result } = renderHook(() => useMaxAda());
 
-    inMemoryWallet.balance.utxo.available$.next({ coins: BigInt('10000000') });
-
-    await waitForNextUpdate();
-    expect(result.current.toString()).toBe('0');
+    act(() => {
+      inMemoryWallet.balance.utxo.available$.next({ coins: BigInt('10000000') });
+    });
+    await waitFor(() => {
+      expect(result.current.toString()).toBe('0');
+    });
   });
 
   test('should return 7874869', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useMaxAda());
-    inMemoryWallet.balance.utxo.available$.next({ coins: BigInt('10000000') });
-    await waitForNextUpdate();
-    expect(result.current.toString()).toBe('7874869');
+    const { result } = renderHook(() => useMaxAda());
+
+    act(() => {
+      inMemoryWallet.balance.utxo.available$.next({ coins: BigInt('10000000') });
+    });
+    await waitFor(() => {
+      expect(result.current.toString()).toBe('7874869');
+    });
   });
 
   test('should return 7689539', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useMaxAda());
-    inMemoryWallet.balance.utxo.available$.next({
-      coins: BigInt('10000000'),
-      assets: new Map([
-        [
-          Wallet.Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'),
-          BigInt('100000000')
-        ]
-      ])
+    const { result } = renderHook(() => useMaxAda());
+    act(() => {
+      inMemoryWallet.balance.utxo.available$.next({
+        coins: BigInt('10000000'),
+        assets: new Map([
+          [
+            Wallet.Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'),
+            BigInt('100000000')
+          ]
+        ])
+      });
     });
-    await waitForNextUpdate();
-    expect(result.current.toString()).toBe('7689539');
+
+    await waitFor(() => {
+      expect(result.current.toString()).toBe('7689539');
+    });
   });
 });

--- a/apps/browser-extension-wallet/src/types/side-menu.ts
+++ b/apps/browser-extension-wallet/src/types/side-menu.ts
@@ -1,13 +1,13 @@
 import { MenuItemList } from '@utils/constants';
-import { SVGFactory } from 'react';
+import { FC, SVGProps } from 'react';
 
 export interface SideMenuItemConfig {
   id: MenuItemList;
   label: string;
   testId: string;
   path: string;
-  regularIcon: SVGFactory;
-  hoverIcon: SVGFactory;
-  activeIcon: SVGFactory;
+  regularIcon: FC<SVGProps<SVGSVGElement>>;
+  hoverIcon: FC<SVGProps<SVGSVGElement>>;
+  activeIcon: FC<SVGProps<SVGSVGElement>>;
   iconClassName?: string;
 }

--- a/apps/browser-extension-wallet/test/__mocks__/svgMock.js
+++ b/apps/browser-extension-wallet/test/__mocks__/svgMock.js
@@ -1,0 +1,1 @@
+module.exports = 'div';

--- a/apps/browser-extension-wallet/test/jest.config.js
+++ b/apps/browser-extension-wallet/test/jest.config.js
@@ -5,7 +5,9 @@ const { createJestConfig } = require('../../../test/createJestConfig');
 module.exports = createJestConfig({
   moduleNameMapper: {
     '.*\\.(scss|sass|css|less)$': '<rootDir>/test/__mocks__/styleMock.js',
-    '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$': '<rootDir>/test/__mocks__/fileMock.js',
+    '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2)$': '<rootDir>/test/__mocks__/fileMock.js',
+    '^[.]*(?!.*\\.component\\.svg$).*\\.svg*$': '<rootDir>/test/__mocks__/fileMock.js',
+    'component\\.svg(\\?v=\\d+\\.d+\\.\\d+)?$': '<rootDir>/test/__mocks__/svgMock.js',
     '^lodash-es$': 'lodash',
     // https://github.com/LedgerHQ/ledger-live/issues/763
     '@ledgerhq/devices/hid-framing': '@ledgerhq/devices/lib/hid-framing',

--- a/packages/cardano/test/__mocks__/svgMock.js
+++ b/packages/cardano/test/__mocks__/svgMock.js
@@ -1,0 +1,1 @@
+module.exports = { ReactComponent: 'div' };

--- a/packages/cardano/test/jest.config.js
+++ b/packages/cardano/test/jest.config.js
@@ -7,7 +7,9 @@ const rootDir = process.cwd();
 module.exports = createJestConfig({
   moduleNameMapper: {
     '.*\\.(scss|sass|css|less)$': '<rootDir>/test/__mocks__/styleMock.js',
-    '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$': '<rootDir>/test/__mocks__/fileMock.js',
+    '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2)$': '<rootDir>/test/__mocks__/fileMock.js',
+    '^[.]*(?!.*\\.component\\.svg$).*\\.svg*$': '<rootDir>/test/__mocks__/fileMock.js',
+    'component\\.svg(\\?v=\\d+\\.d+\\.\\d+)?$': '<rootDir>/test/__mocks__/svgMock.js',
     '^lodash-es$': 'lodash',
     '^webextension-polyfill': '<rootDir>/test/__mocks__/fileMock.js',
     // https://github.com/LedgerHQ/ledger-live/issues/763

--- a/packages/common/src/ui/components/Banner/Banner.tsx
+++ b/packages/common/src/ui/components/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Typography } from 'antd';
 import cn from 'classnames';
-import DefaultIcon from '../../assets/icons/banner-icon.component.svg';
+import { ReactComponent as DefaultIcon } from '../../assets/icons/banner-icon.component.svg';
 import styles from './Banner.module.scss';
 
 const { Text } = Typography;

--- a/packages/common/test/jest.config.js
+++ b/packages/common/test/jest.config.js
@@ -6,7 +6,8 @@ module.exports = createJestConfig({
   moduleNameMapper: {
     '.*\\.(scss|sass|css|less)$': '<rootDir>/test/__mocks__/styleMock.js',
     '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2)$': '<rootDir>/test/__mocks__/fileMock.js',
-    '\\.svg': '<rootDir>/test/__mocks__/svgMock.js',
+    '^[.]*(?!.*\\.component\\.svg$).*\\.svg*$': '<rootDir>/test/__mocks__/fileMock.js',
+    'component\\.svg(\\?v=\\d+\\.d+\\.\\d+)?$': '<rootDir>/test/__mocks__/svgMock.js',
     ...pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/src' })
   },
   roots: ['<rootDir>/src'],

--- a/packages/core/src/ui/components/WalletSetup/__tests__/WalletSetupMnemonicVerificationStep.test.tsx
+++ b/packages/core/src/ui/components/WalletSetup/__tests__/WalletSetupMnemonicVerificationStep.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, within, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { WalletSetupMnemonicVerificationStep } from '../WalletSetupMnemonicVerificationStep';
 import { useEffect } from 'react';
+import { act } from 'react-dom/test-utils';
 
 const Test = () => {
   useEffect(() => {
@@ -54,7 +55,9 @@ const findInputByIndex = async (index: number): Promise<HTMLElement> => {
 describe('<WalletSetupMnemonicVerificationStep>', () => {
   it('should render IogSwitch component', async () => {
     const user = userEvent.setup();
-    render(<Test />);
+    act(() => {
+      render(<Test />);
+    });
 
     const input1th = await findInputByIndex(1);
     expect(input1th).toHaveValue('weapon');
@@ -62,11 +65,15 @@ describe('<WalletSetupMnemonicVerificationStep>', () => {
     const input8th = await findInputByIndex(8);
     expect(input8th).toHaveValue('');
 
-    fireEvent.change(input8th, {
-      target: { value: 'lecture' }
+    act(() => {
+      fireEvent.change(input8th, {
+        target: { value: 'lecture' }
+      });
     });
 
-    await user.type(input8th, '{enter}');
+    await act(async () => {
+      await user.type(input8th, '{enter}');
+    });
 
     expect(window.document.activeElement.id).toBe('mnemonic-word-9');
 
@@ -78,7 +85,9 @@ describe('<WalletSetupMnemonicVerificationStep>', () => {
   });
 
   it('should render proper description', async () => {
-    render(<Test />);
+    act(() => {
+      render(<Test />);
+    });
 
     const { getByText } = within(screen.getByTestId('wallet-setup-step-subtitle'));
     expect(getByText('Enter passphrase description')).toBeInTheDocument();

--- a/packages/core/test/jest.config.js
+++ b/packages/core/test/jest.config.js
@@ -6,7 +6,8 @@ module.exports = createJestConfig({
   moduleNameMapper: {
     '.*\\.(scss|sass|css|less)$': '<rootDir>/test/__mocks__/styleMock.js',
     '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2)$': '<rootDir>/test/__mocks__/fileMock.js',
-    '\\.svg': '<rootDir>/test/__mocks__/svgMock.js',
+    '^[.]*(?!.*\\.component\\.svg$).*\\.svg*$': '<rootDir>/test/__mocks__/fileMock.js',
+    'component\\.svg(\\?v=\\d+\\.d+\\.\\d+)?$': '<rootDir>/test/__mocks__/svgMock.js',
     ...pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/src' })
   },
   roots: ['<rootDir>/src'],


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-7302
- [x] https://input-output.atlassian.net/browse/LW-7303
- [x] https://input-output.atlassian.net/browse/LW-7306
- [x] https://input-output.atlassian.net/browse/LW-7308
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

- fix svgs icons imports;
- align svgMock between packages in jest;
- fix tests related warnings;

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/734/5441699042/index.html) for [d4031046](https://github.com/input-output-hk/lace/pull/207/commits/d40310462ad425b3630e327ad77f9309cd5ece4c)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->