### PR TITLE
Implements hardware wallet post hog events

### DIFF
--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/events.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/events.ts
@@ -52,7 +52,12 @@ export const postHogOnboardingActions: PostHogOnboardingActionsType = {
   },
   hw: {
     ANALYTICS_AGREE_CLICK: PostHogAction.OnboardingHWAnalyticsAgreeClick,
-    ANALYTICS_SKIP_CLICK: PostHogAction.OnboardingHWAnalyticsSkipClick
+    ANALYTICS_SKIP_CLICK: PostHogAction.OnboardingHWAnalyticsSkipClick,
+    WALLET_NAME_NEXT_CLICK: PostHogAction.OnboardingHWNameNextClick,
+    LACE_TERMS_OF_USE_NEXT_CLICK: PostHogAction.OnboardinHWLaceTermsOfUseNextClick,
+    CONNECT_HW_NEXT_CLICK: PostHogAction.OnboardingHWConnectNextClick,
+    SELECT_HW_ACCOUNT_NEXT_CLICK: PostHogAction.OnboardingHWSelectAccountNextClick,
+    SETUP_OPTION_CLICK: PostHogAction.OnboardingHWClick
   }
 };
 

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -35,6 +35,11 @@ export enum PostHogAction {
   // Hardware wallet connect
   OnboardingHWAnalyticsAgreeClick = 'onboarding | hardware wallet | analytics | agree | click',
   OnboardingHWAnalyticsSkipClick = 'onboarding | hardware wallet | analytics | skip | click',
+  OnboardingHWClick = 'onboarding | hardware wallet | connect | click',
+  OnboardinHWLaceTermsOfUseNextClick = 'onboarding | hardware wallet | lace terms of use | next | click',
+  OnboardingHWConnectNextClick = 'onboarding | hardware wallet | connect hw | next | click',
+  OnboardingHWSelectAccountNextClick = 'onboarding | hardware wallet | select hw account | next | click',
+  OnboardingHWNameNextClick = 'onboarding | hardware wallet | name hw wallet | next | click',
   // Restore wallet
   OnboardingRestoreAnalyticsAgreeClick = 'onboarding | restore wallet | analytics | agree | click',
   OnboardingRestoreAnalyticsSkipClick = 'onboarding | restore wallet | analytics | skip | click',
@@ -91,7 +96,9 @@ export type PostHogActionsKeys =
   | 'ENTER_PASSPHRASE_17_NEXT_CLICK'
   | 'RESTORE_MULTI_ADDR_OK_CLICK'
   | 'RESTORE_MULTI_ADDR_CANCEL_CLICK'
-  | 'RECOVERY_PASSPHRASE_LENGTH_NEXT_CLICK';
+  | 'RECOVERY_PASSPHRASE_LENGTH_NEXT_CLICK'
+  | 'CONNECT_HW_NEXT_CLICK'
+  | 'SELECT_HW_ACCOUNT_NEXT_CLICK';
 export type PostHogOnboardingActionsValueType = Partial<Record<PostHogActionsKeys, PostHogAction>>;
 export type PostHogOnboardingActionsType = Partial<Record<OnboardingFlows, PostHogOnboardingActionsValueType>>;
 export type PostHogMetadata = {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 import {
   AnalyticsEventNames,
   EnhancedAnalyticsOptInStatus,
+  ExtensionViews,
   postHogOnboardingActions
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { config } from '@src/config';
@@ -213,7 +214,11 @@ export const HardwareWalletFlow = ({
       <WalletSetupLegalStep
         onBack={() => onCancel()}
         onNext={() => {
-          sendAnalytics(Events.LEGAL_STUFF_NEXT, undefined, calculateTimeSpentOnPage());
+          sendAnalytics(
+            Events.LEGAL_STUFF_NEXT,
+            postHogOnboardingActions.hw?.LACE_TERMS_OF_USE_NEXT_CLICK,
+            calculateTimeSpentOnPage()
+          );
           navigateTo('analytics');
         }}
         translations={walletSetupLegalStepTranslations}
@@ -236,6 +241,9 @@ export const HardwareWalletFlow = ({
         onConnect={handleConnect}
         onNext={() => {
           sendAnalytics(Events.SELECT_MODEL_NEXT);
+          analytics.sendEventToPostHog(postHogOnboardingActions.hw?.CONNECT_HW_NEXT_CLICK, {
+            view: ExtensionViews.Extended
+          });
           navigateTo('accounts');
         }}
         isNextEnable={!!deviceConnection}
@@ -248,7 +256,7 @@ export const HardwareWalletFlow = ({
         accounts={TOTAL_ACCOUNTS}
         onBack={showStartOverDialog}
         onSubmit={(account: number) => {
-          sendAnalytics(Events.SELECT_ACCOUNT_NEXT);
+          sendAnalytics(Events.SELECT_ACCOUNT_NEXT, postHogOnboardingActions.hw?.SELECT_HW_ACCOUNT_NEXT_CLICK);
           setAccountIndex(account);
           navigateTo('register');
         }}
@@ -259,7 +267,7 @@ export const HardwareWalletFlow = ({
       <WalletSetupWalletNameStep
         onBack={showStartOverDialog}
         onNext={(name: string) => {
-          sendAnalytics(Events.WALLET_NAME_NEXT);
+          sendAnalytics(Events.WALLET_NAME_NEXT, postHogOnboardingActions.hw?.WALLET_NAME_NEXT_CLICK);
           handleCreateWallet(name);
           navigateTo('create');
         }}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -22,7 +22,6 @@ import { useTranslation } from 'react-i18next';
 import {
   AnalyticsEventNames,
   EnhancedAnalyticsOptInStatus,
-  ExtensionViews,
   postHogOnboardingActions
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { config } from '@src/config';
@@ -241,9 +240,7 @@ export const HardwareWalletFlow = ({
         onConnect={handleConnect}
         onNext={() => {
           sendAnalytics(Events.SELECT_MODEL_NEXT);
-          analytics.sendEventToPostHog(postHogOnboardingActions.hw?.CONNECT_HW_NEXT_CLICK, {
-            view: ExtensionViews.Extended
-          });
+          analytics.sendEventToPostHog(postHogOnboardingActions.hw?.CONNECT_HW_NEXT_CLICK);
           navigateTo('accounts');
         }}
         isNextEnable={!!deviceConnection}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
@@ -12,7 +12,6 @@ import {
   AnalyticsEventActions,
   AnalyticsEventCategories,
   AnalyticsEventNames,
-  ExtensionViews,
   PostHogAction,
   postHogOnboardingActions
 } from '@providers/AnalyticsProvider/analyticsTracker';
@@ -101,9 +100,7 @@ export const WalletSetup = ({ initialStep = WalletSetupSteps.Legal }: WalletSetu
 
   const handleStartHardwareOnboarding = () => {
     setIsDappConnectorWarningOpen(true);
-    analytics.sendEventToPostHog(postHogOnboardingActions.hw?.SETUP_OPTION_CLICK, {
-      view: ExtensionViews.Extended
-    });
+    analytics.sendEventToPostHog(postHogOnboardingActions.hw?.SETUP_OPTION_CLICK);
   };
 
   const sendAnalytics = (

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
@@ -12,6 +12,7 @@ import {
   AnalyticsEventActions,
   AnalyticsEventCategories,
   AnalyticsEventNames,
+  ExtensionViews,
   PostHogAction,
   postHogOnboardingActions
 } from '@providers/AnalyticsProvider/analyticsTracker';
@@ -98,7 +99,12 @@ export const WalletSetup = ({ initialStep = WalletSetupSteps.Legal }: WalletSetu
 
   const cancelWalletFlow = () => history.push(walletRoutePaths.setup.home);
 
-  const handleStartHardwareOnboarding = () => setIsDappConnectorWarningOpen(true);
+  const handleStartHardwareOnboarding = () => {
+    setIsDappConnectorWarningOpen(true);
+    analytics.sendEventToPostHog(postHogOnboardingActions.hw?.SETUP_OPTION_CLICK, {
+      view: ExtensionViews.Extended
+    });
+  };
 
   const sendAnalytics = (
     category: SetupAnalyticsCategories,


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-7200](https://input-output.atlassian.net/browse/LW-7200)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

# Todos
- [ ] Remove `{ view: extended }` from UI code (refactor to getEventMetaData)

---

## Proposed solution

This PR adds tracking for the hardware wallet onboarding PostHog events

[LW-7200]: https://input-output.atlassian.net/browse/LW-7200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/774/5447733466/index.html) for [a9a084af](https://github.com/input-output-hk/lace/pull/212/commits/a9a084afcb3874ba63169b00c4814ae4c20b16b9)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 7      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->