### PR TITLE
chore(extension): fix cursor position for unformatted values in coin input

### DIFF
--- a/packages/core/src/ui/components/AssetInput/AssetInput.tsx
+++ b/packages/core/src/ui/components/AssetInput/AssetInput.tsx
@@ -89,11 +89,20 @@ export const AssetInput = ({
 
   useLayoutEffect(() => {
     if (focused) {
-      inputRef.current.focus({
-        cursor: 'end'
+      // place cursor at the end of the input in case user clicks outside of input but within the clickable area
+      inputRef.current.focus(document.activeElement !== inputRef.current.input ? { cursor: 'end' } : undefined);
+    }
+  }, [compactValue, focused, value]);
+
+  const onClick = useCallback(() => {
+    // place cursor at the end of the input in case the formatted(compact) value is different from the real one
+    if (value !== compactValue && !focused) {
+      setTimeout(() => {
+        inputRef.current.focus({ cursor: 'end' });
       });
     }
-  }, [focused]);
+  }, [compactValue, value, focused]);
+
   const { t } = useTranslate();
 
   useEffect(() => {
@@ -195,6 +204,7 @@ export const AssetInput = ({
 
           <Tooltip title={!isSameNumberFormat(value, compactValue) && !focused && displayValue}>
             <Input
+              onMouseDown={onClick}
               ref={inputRef}
               data-testid="coin-configure-input"
               placeholder={placeholderValue}


### PR DESCRIPTION


# Checklist

- [x] https://input-output.atlassian.net/browse/LW-6469
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

- fire `focus({ cursor: 'end' });` event in case user clicks outside of input but within the clickable area;
- fire `focus({ cursor: 'end' });` event in case user clicks on input but `compactValue` differs from the actual one

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/843/5484473895/index.html) for [c123fdd5](https://github.com/input-output-hk/lace/pull/219/commits/c123fdd57eaf85a7c7eb16152f82b85ce944c2ba)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 3      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->