### PR TITLE
test(extension): e2e - add test to create folder with too long name

### DIFF
--- a/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
+++ b/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
@@ -65,7 +65,7 @@ class NftCreateFolderAssert {
       ? expect(await NftCreateFolderPage.folderNameInput.inputError.getText()).to.equal(
           (await t('browserView.nfts.folderDrawer.nameForm.inputError')).replace('{{length}}', maxLength.toString())
         )
-      : expect(await NftCreateFolderPage.folderNameInput.inputError.isExisting()).to.be.false);
+      : expect(await NftCreateFolderPage.folderNameInput.inputError.waitForDisplayed({ reverse: true })));
   }
 }
 

--- a/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
+++ b/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
@@ -59,6 +59,14 @@ class NftCreateFolderAssert {
       ? expect(await NftCreateFolderPage.nextButton.isEnabled()).to.be.true
       : expect(await NftCreateFolderPage.nextButton.isEnabled()).to.be.false);
   }
+
+  async assertSeeInputMaxLengthError(isTrue: boolean, maxLength: number) {
+    await (isTrue
+      ? expect(await NftCreateFolderPage.folderNameInput.inputError.getText()).to.equal(
+          (await t('browserView.nfts.folderDrawer.nameForm.inputError')).replace('{{length}}', maxLength.toString())
+        )
+      : expect(await NftCreateFolderPage.folderNameInput.inputError.isExisting()).to.be.false);
+  }
 }
 
 export default new NftCreateFolderAssert();

--- a/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
+++ b/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
@@ -60,12 +60,15 @@ class NftCreateFolderAssert {
       : expect(await NftCreateFolderPage.nextButton.isEnabled()).to.be.false);
   }
 
-  async assertSeeInputMaxLengthError(isTrue: boolean, maxLength: number) {
-    await (isTrue
-      ? expect(await NftCreateFolderPage.folderNameInput.inputError.getText()).to.equal(
-          (await t('browserView.nfts.folderDrawer.nameForm.inputError')).replace('{{length}}', maxLength.toString())
-        )
-      : expect(await NftCreateFolderPage.folderNameInput.inputError.waitForDisplayed({ reverse: true })));
+  async assertSeeInputMaxLengthError(shouldBeDisplayed: boolean, maxLength: number) {
+    await NftCreateFolderPage.folderNameInput.inputError.waitForDisplayed({ reverse: !shouldBeDisplayed });
+    if (shouldBeDisplayed) {
+      const expectedErrorMessage = (await t('browserView.nfts.folderDrawer.nameForm.inputError')).replace(
+        '{{length}}',
+        maxLength.toString()
+      );
+      expect(await NftCreateFolderPage.folderNameInput.inputError.getText()).to.equal(expectedErrorMessage);
+    }
   }
 }
 

--- a/packages/e2e-tests/src/elements/NFTs/nftCreateFolderPage.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftCreateFolderPage.ts
@@ -14,8 +14,11 @@ class NftCreateFolderPage extends CommonDrawerElements {
   }
 
   async setFolderNameInput(value: string): Promise<void> {
+    await this.folderNameInput.input.setValue(value);
+  }
+
+  async clearFolderNameInput(): Promise<void> {
     await clearInputFieldValue(await this.folderNameInput.input);
-    (await this.folderNameInput.input).setValue(value);
   }
 }
 

--- a/packages/e2e-tests/src/elements/NFTs/nftCreateFolderPage.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftCreateFolderPage.ts
@@ -1,5 +1,6 @@
 import CommonDrawerElements from '../CommonDrawerElements';
 import NftFolderNameInput from './nftFolderNameInput';
+import { clearInputFieldValue } from '../../utils/inputFieldUtils';
 
 class NftCreateFolderPage extends CommonDrawerElements {
   private NEXT_BUTTON = '[data-testid="create-folder-drawer-form-cta"]';
@@ -10,6 +11,11 @@ class NftCreateFolderPage extends CommonDrawerElements {
 
   get folderNameInput(): typeof NftFolderNameInput {
     return NftFolderNameInput;
+  }
+
+  async setFolderNameInput(value: string): Promise<void> {
+    await clearInputFieldValue(await this.folderNameInput.input);
+    (await this.folderNameInput.input).setValue(value);
   }
 }
 

--- a/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
@@ -22,6 +22,7 @@ Feature: NFT - Folders - Extended view
     When I enter a folder name "012345678901234567890" into "Folder name" input
     Then I see "Folder name" input max length 20 error
     And "Next" button is disabled on "Name your folder" page
-    When I enter a folder name "01234567890123456789" into "Folder name" input
+    When I clear "Folder name" input
+    And I enter a folder name "01234567890123456789" into "Folder name" input
     Then I don't see "Folder name" input max length 20 error
     And "Next" button is enabled on "Name your folder" page

--- a/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
@@ -11,3 +11,17 @@ Feature: NFT - Folders - Extended view
     Then I see "Create NFT folder" page in extended mode
     And "Folder name" input is empty on "Name your folder" page
     And "Next" button is disabled on "Name your folder" page
+
+  @LW-7247
+  Scenario: Extended-view - NFT Folders - Trying to create folder using too long name
+    Given I navigate to NFTs extended page
+    And I click "Create folder" button on NFTs page
+    And I see "Create NFT folder" page in extended mode
+    And "Folder name" input is empty on "Name your folder" page
+    And "Next" button is disabled on "Name your folder" page
+    When I enter a folder name "012345678901234567890" into "Folder name" input
+    Then I see "Folder name" input max length 20 error
+    And "Next" button is disabled on "Name your folder" page
+    When I enter a folder name "01234567890123456789" into "Folder name" input
+    Then I don't see "Folder name" input max length 20 error
+    And "Next" button is enabled on "Name your folder" page

--- a/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
@@ -22,6 +22,7 @@ Feature: NFT - Folders - Popup view
     When I enter a folder name "012345678901234567890" into "Folder name" input
     Then I see "Folder name" input max length 20 error
     And "Next" button is disabled on "Name your folder" page
-    When I enter a folder name "01234567890123456789" into "Folder name" input
+    When I clear "Folder name" input
+    And I enter a folder name "01234567890123456789" into "Folder name" input
     Then I don't see "Folder name" input max length 20 error
     And "Next" button is enabled on "Name your folder" page

--- a/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
@@ -11,3 +11,17 @@ Feature: NFT - Folders - Popup view
     Then I see "Create NFT folder" page in popup mode
     And "Folder name" input is empty on "Name your folder" page
     And "Next" button is disabled on "Name your folder" page
+
+  @LW-7265
+  Scenario: Popup-view - NFT Folders - Trying to create folder using too long name
+    Given I navigate to NFTs popup page
+    And I click "Create folder" button on NFTs page
+    And I see "Create NFT folder" page in popup mode
+    And "Folder name" input is empty on "Name your folder" page
+    And "Next" button is disabled on "Name your folder" page
+    When I enter a folder name "012345678901234567890" into "Folder name" input
+    Then I see "Folder name" input max length 20 error
+    And "Next" button is disabled on "Name your folder" page
+    When I enter a folder name "01234567890123456789" into "Folder name" input
+    Then I don't see "Folder name" input max length 20 error
+    And "Next" button is enabled on "Name your folder" page

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -2,6 +2,7 @@ import { When } from '@wdio/cucumber-framework';
 import { Given, Then } from '@cucumber/cucumber';
 import NftsPage from '../elements/NFTs/nftsPage';
 import nftCreateFolderAssert from '../assert/nftCreateFolderAssert';
+import NftCreateFolderPage from '../elements/NFTs/nftCreateFolderPage';
 
 Given(
   /^I (see|do not see) "Create folder" button on NFTs page in (popup|extended) mode$/,
@@ -31,3 +32,11 @@ Then(
     await nftCreateFolderAssert.assertSeeNextButtonEnabled(isButtonEnabled === 'enabled');
   }
 );
+
+When(/^I enter a folder name "([^"]*)" into "Folder name" input$/, async (folderName: string) => {
+  await NftCreateFolderPage.setFolderNameInput(folderName);
+});
+
+Then(/^I (see|don't see) "Folder name" input max length (\d+) error$/, async (shouldSee: string, maxLength: number) => {
+  await nftCreateFolderAssert.assertSeeInputMaxLengthError(shouldSee === 'see', maxLength);
+});

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -37,6 +37,10 @@ When(/^I enter a folder name "([^"]*)" into "Folder name" input$/, async (folder
   await NftCreateFolderPage.setFolderNameInput(folderName);
 });
 
+When(/^I clear "Folder name" input$/, async () => {
+  await NftCreateFolderPage.clearFolderNameInput();
+});
+
 Then(/^I (see|don't see) "Folder name" input max length (\d+) error$/, async (shouldSee: string, maxLength: number) => {
   await nftCreateFolderAssert.assertSeeInputMaxLengthError(shouldSee === 'see', maxLength);
 });


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/846/5484951710/index.html) for [04491e25](https://github.com/input-output-hk/lace/pull/230/commits/04491e259aa31d149713c7a3b052293e15391516)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 4      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->