### PR TITLE
[LW-7324] Personalized ADA Handle in NFT screen

### DIFF
--- a/apps/browser-extension-wallet/src/features/nfts/components/NftDetail.tsx
+++ b/apps/browser-extension-wallet/src/features/nfts/components/NftDetail.tsx
@@ -1,4 +1,4 @@
-import { useRedirection } from '@hooks';
+import { useAssetInfo, useRedirection } from '@hooks';
 import { walletRoutePaths } from '@routes';
 import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
@@ -27,7 +27,7 @@ export const NftDetail = (): React.ReactElement => {
   const redirectToNfts = useRedirection(walletRoutePaths.nfts);
   const redirectToSend = useRedirection<{ params: { id?: string } }>(walletRoutePaths.send);
   const { id } = useParams<{ id: string }>();
-  const assetsInfo = useObservable(inMemoryWallet.assetInfo$);
+  const assetsInfo = useAssetInfo();
   const setSendInitialState = useOutputInitialState();
 
   const assetId = Wallet.Cardano.AssetId(id);

--- a/apps/browser-extension-wallet/src/features/nfts/components/Nfts.tsx
+++ b/apps/browser-extension-wallet/src/features/nfts/components/Nfts.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/no-useless-undefined */
-import { useRedirection } from '@hooks';
+import { useAssetInfo, useRedirection } from '@hooks';
 import { useWalletStore } from '@src/stores';
 import { Button, useObservable } from '@lace/common';
 import { DEFAULT_WALLET_BALANCE } from '@src/utils/constants';
@@ -36,7 +36,7 @@ export const Nfts = withNftsFoldersContext((): React.ReactElement => {
   const [selectedFolderId, setSelectedFolderId] = useState<number | undefined>();
   const { walletInfo, inMemoryWallet } = useWalletStore();
   const { t } = useTranslation();
-  const assetsInfo = useObservable(inMemoryWallet.assetInfo$);
+  const assetsInfo = useAssetInfo();
   const assetsBalance = useObservable(inMemoryWallet.balance.utxo.total$, DEFAULT_WALLET_BALANCE.utxo.total$);
   const analytics = useAnalyticsContext();
   const { fiatCurrency } = useCurrencyStore();

--- a/apps/browser-extension-wallet/src/hooks/__tests__/useAssetInfo.test.ts
+++ b/apps/browser-extension-wallet/src/hooks/__tests__/useAssetInfo.test.ts
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useAssetInfo } from '../useAssetInfo';
+import { BehaviorSubject } from 'rxjs';
+import { Wallet } from '@lace/cardano';
+import { HandleInfo, ObservableWallet } from '@cardano-sdk/wallet';
+import * as stores from '@stores';
+jest.mock('@stores');
+
+const assets: Partial<Wallet.Asset.AssetInfo>[] = [
+  {
+    assetId: Wallet.Cardano.AssetId('6b8d07d69639e9413dd637a1a815a7323c69c86abbafb66dbfdb1aa7'),
+    nftMetadata: { image: Wallet.Asset.Uri('ipfs://image1'), name: 'name1', version: '1' }
+  },
+  {
+    assetId: Wallet.Cardano.AssetId('6b8d07d69639e9413dd637a1a815a7323c69c86abbafb66dbfdb1aa6'),
+    nftMetadata: { image: Wallet.Asset.Uri('ipfs://image2'), name: 'name2', version: '1' }
+  }
+];
+const handles: Partial<HandleInfo>[] = [
+  {
+    ...assets[0],
+    image: Wallet.Asset.Uri('ipfs://personalizedImage1')
+  }
+];
+
+const assetInfo = new Map<Wallet.Cardano.AssetId, Partial<Wallet.Asset.AssetInfo>>(
+  assets.map((asset) => [asset.assetId, asset])
+);
+
+describe('Testing useAssetInfo hook', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('should return empty map when values are undefined', () => {
+    const inMemoryWallet = {
+      handles$: new BehaviorSubject(undefined),
+      assetInfo$: new BehaviorSubject(undefined)
+    };
+    jest.spyOn(stores, 'useWalletStore').mockImplementation(() => ({
+      inMemoryWallet
+    }));
+    const { result } = renderHook(() => useAssetInfo());
+    expect(result.current).toEqual(new Map());
+  });
+
+  test('should return empty map when values are empty', () => {
+    const inMemoryWallet: Partial<ObservableWallet> = {
+      handles$: new BehaviorSubject([]),
+      assetInfo$: new BehaviorSubject(new Map())
+    };
+    jest.spyOn(stores, 'useWalletStore').mockImplementation(() => ({
+      inMemoryWallet
+    }));
+    const { result } = renderHook(() => useAssetInfo());
+    expect(result.current).toEqual(new Map());
+  });
+
+  test('should return asset map when handles$ is undefined', () => {
+    const inMemoryWallet = {
+      handles$: new BehaviorSubject(undefined),
+      assetInfo$: new BehaviorSubject(assetInfo)
+    };
+    jest.spyOn(stores, 'useWalletStore').mockImplementation(() => ({
+      inMemoryWallet
+    }));
+    const { result } = renderHook(() => useAssetInfo());
+    expect(result.current).toEqual(assetInfo);
+  });
+
+  test('should return asset map when handles$ is not in assets', () => {
+    const inMemoryWallet = {
+      handles$: new BehaviorSubject([
+        { ...handles, assetId: Wallet.Cardano.AssetId('6b8d07d69639e9413dd637a1a815a7323c69c86abbafb66dbfdb1aa8') }
+      ]),
+      assetInfo$: new BehaviorSubject(assetInfo)
+    };
+    jest.spyOn(stores, 'useWalletStore').mockImplementation(() => ({
+      inMemoryWallet
+    }));
+    const { result } = renderHook(() => useAssetInfo());
+    expect(result.current).toEqual(assetInfo);
+  });
+
+  test('should return asset with handle information', () => {
+    const inMemoryWallet = {
+      handles$: new BehaviorSubject(handles),
+      assetInfo$: new BehaviorSubject(assetInfo)
+    };
+    jest.spyOn(stores, 'useWalletStore').mockImplementation(() => ({
+      inMemoryWallet
+    }));
+    const { result } = renderHook(() => useAssetInfo());
+    expect(result.current.get(assets[0].assetId)).toEqual(handles[0]);
+    expect(result.current.get(assets[1].assetId)).toEqual(assets[1]);
+  });
+});

--- a/apps/browser-extension-wallet/src/hooks/index.ts
+++ b/apps/browser-extension-wallet/src/hooks/index.ts
@@ -18,3 +18,4 @@ export * from './useMaxAda';
 export * from './useSyncingTheFirstTime';
 export * from './useGetHandles';
 export * from './useHandleResolver';
+export * from './useAssetInfo';

--- a/apps/browser-extension-wallet/src/hooks/useAssetInfo.ts
+++ b/apps/browser-extension-wallet/src/hooks/useAssetInfo.ts
@@ -1,0 +1,25 @@
+import { Wallet } from '@lace/cardano';
+import { useObservable } from '@lace/common';
+import { useWalletStore } from '@src/stores';
+import { HandleInfo } from '@cardano-sdk/wallet';
+import { useMemo } from 'react';
+
+export type AssetOrHandleInfo = Wallet.Asset.AssetInfo | HandleInfo;
+export type AssetOrHandleInfoMap = Map<Wallet.Cardano.AssetId, AssetOrHandleInfo>;
+
+const withHandleInfo = (assets: Wallet.Assets, handles: HandleInfo[] = []): AssetOrHandleInfoMap => {
+  const assetsWithHandleInfo = new Map(assets);
+  handles.map((handle) => {
+    if (assetsWithHandleInfo.has(handle.assetId)) {
+      assetsWithHandleInfo.set(handle.assetId, handle);
+    }
+  });
+  return assetsWithHandleInfo;
+};
+
+export const useAssetInfo = (): AssetOrHandleInfoMap => {
+  const { inMemoryWallet } = useWalletStore();
+  const handles = useObservable(inMemoryWallet.handles$);
+  const assets = useObservable(inMemoryWallet.assetInfo$);
+  return useMemo(() => withHandleInfo(assets, handles), [assets, handles]);
+};

--- a/apps/browser-extension-wallet/src/utils/__tests__/get-asset-image.test.ts
+++ b/apps/browser-extension-wallet/src/utils/__tests__/get-asset-image.test.ts
@@ -1,0 +1,38 @@
+import { AssetOrHandleInfo } from '@hooks';
+import { getAssetImage } from '../get-asset-image';
+import { Wallet } from '@lace/cardano';
+import { HandleInfo } from '@cardano-sdk/wallet';
+
+describe('Testing getAssetImage function', () => {
+  test('should return the handle image if available', () => {
+    const asset: Partial<HandleInfo> = {
+      image: Wallet.Asset.Uri('ipfs://image1')
+    };
+
+    const result = getAssetImage(asset as HandleInfo);
+
+    expect(result).toBe(asset.image);
+  });
+
+  test('should return the NFT metadata image if asset image is not available', () => {
+    const asset: Partial<Wallet.Asset.AssetInfo> = {
+      nftMetadata: {
+        image: Wallet.Asset.Uri('ipfs://image1'),
+        name: 'NFT',
+        version: '1.0'
+      }
+    };
+
+    const result = getAssetImage(asset as Wallet.Asset.AssetInfo);
+
+    expect(result).toBe(asset.nftMetadata.image);
+  });
+
+  test('should return undefined if both handle image and NFT metadata image are not available', () => {
+    const asset = {} as AssetOrHandleInfo;
+
+    const result = getAssetImage(asset);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/browser-extension-wallet/src/utils/get-asset-image.ts
+++ b/apps/browser-extension-wallet/src/utils/get-asset-image.ts
@@ -1,0 +1,5 @@
+import { AssetOrHandleInfo } from '@hooks';
+import { Wallet } from '@lace/cardano';
+
+export const getAssetImage = (asset: AssetOrHandleInfo): Wallet.Asset.Uri =>
+  'image' in asset ? asset.image : asset.nftMetadata?.image;

--- a/apps/browser-extension-wallet/src/utils/get-token-list.ts
+++ b/apps/browser-extension-wallet/src/utils/get-token-list.ts
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 /* eslint-disable sonarjs/cognitive-complexity */
-import { PriceResult } from '@hooks';
+import { AssetOrHandleInfoMap, PriceResult } from '@hooks';
 import { Wallet } from '@lace/cardano';
 import { addEllipsis, getRandomIcon } from '@lace/common';
 import { nftImageSelector } from '@src/views/browser-view/features/nfts/selectors';
@@ -11,6 +11,7 @@ import { getAssetImageUrl } from './get-asset-image-url';
 import { EnvironmentTypes } from '@stores';
 import { CurrencyInfo } from '@src/types';
 import { isNFT } from './is-nft';
+import { getAssetImage } from './get-asset-image';
 
 export interface NFT {
   assetId: Wallet.Cardano.AssetId;
@@ -29,7 +30,7 @@ export interface NonNFTAsset {
 }
 
 export interface GetTokenListParams {
-  assetsInfo: Map<Wallet.Cardano.AssetId, Wallet.Asset.AssetInfo>;
+  assetsInfo: AssetOrHandleInfoMap;
   balance: Wallet.Cardano.Value['assets'];
   prices?: PriceResult;
   tokensSpent?: SpentBalances;
@@ -39,7 +40,7 @@ export interface GetTokenListParams {
 
 export const getTokenList = (params: GetTokenListParams): { tokenList: NonNFTAsset[]; nftList: NFT[] } => {
   const {
-    assetsInfo = new Map<Wallet.Cardano.AssetId, Wallet.Asset.AssetInfo>(),
+    assetsInfo = new Map() as AssetOrHandleInfoMap,
     balance,
     prices,
     tokensSpent,
@@ -65,7 +66,7 @@ export const getTokenList = (params: GetTokenListParams): { tokenList: NonNFTAss
       nfts.push({
         assetId,
         name: info.nftMetadata?.name || `SingleNFT${environmentName || ''}`,
-        image: nftImageSelector(info.nftMetadata?.image),
+        image: nftImageSelector(getAssetImage(info)),
         amount
       });
     } else {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/AssetPicker.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/AssetPicker.tsx
@@ -7,6 +7,7 @@ import { useObservable } from '@lace/common';
 import styles from './CreateFolderDrawer.module.scss';
 import { formatNftsList } from '../utils';
 import { useCurrencyStore } from '@providers';
+import { useAssetInfo } from '@hooks';
 
 const nftsPerRow = {
   popupView: 2,
@@ -30,7 +31,7 @@ export const AssetPicker = ({
 }: AssetPickerProps): React.ReactElement => {
   const { t } = useTranslation();
   const { inMemoryWallet, environmentName } = useWalletStore();
-  const assets = useObservable(inMemoryWallet.assetInfo$);
+  const assets = useAssetInfo();
   const balance = useObservable(inMemoryWallet.balance.utxo.total$);
   const { fiatCurrency } = useCurrencyStore();
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/NftsList.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/NftsList.tsx
@@ -8,6 +8,7 @@ import { useWalletStore } from '../../../../../../stores';
 import styles from './CreateFolderDrawer.module.scss';
 import { useCurrencyStore } from '@providers';
 import { useObservable } from '@lace/common';
+import { useAssetInfo } from '@hooks';
 
 const nftsPerRow = {
   popupView: 2,
@@ -31,7 +32,7 @@ export const NftsList = ({
 }: NftsListProps): React.ReactElement => {
   const { t } = useTranslation();
   const { inMemoryWallet, environmentName } = useWalletStore();
-  const assetsInfo = useObservable(inMemoryWallet.assetInfo$);
+  const assetsInfo = useAssetInfo();
   const balance = useObservable(inMemoryWallet.balance.utxo.total$);
   const nftsIds = useMemo(() => nfts?.map(({ assetId }) => assetId), [nfts]);
   const { fiatCurrency } = useCurrencyStore();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftsLayout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftsLayout.tsx
@@ -32,6 +32,7 @@ import { NFTFolderDrawer } from './CreateFolder/CreateFolderDrawer';
 import { NftFoldersRecordParams, useNftsFoldersContext, withNftsFoldersContext } from '@src/features/nfts/context';
 import { RenameFolderDrawer } from './RenameFolderDrawer';
 import { NftFolderConfirmationModal } from './NftFolderConfirmationModal';
+import { useAssetInfo } from '@hooks';
 
 export type RenameFolderType = Pick<NftFoldersRecordParams, 'id' | 'name'>;
 
@@ -40,7 +41,7 @@ export const NftsLayout = withNftsFoldersContext((): React.ReactElement => {
   const { walletInfo, inMemoryWallet, blockchainProvider, environmentName } = useWalletStore();
   const [selectedFolderId, setSelectedFolderId] = useState<number | undefined>();
   const { t } = useTranslation();
-  const assetsInfo = useObservable(inMemoryWallet.assetInfo$);
+  const assetsInfo = useAssetInfo();
   const assetsBalance = useObservable(inMemoryWallet.balance.utxo.total$, DEFAULT_WALLET_BALANCE.utxo.total$);
   const total = useObservable(inMemoryWallet.balance.utxo.total$);
   const analytics = useAnalyticsContext();
@@ -103,7 +104,12 @@ export const NftsLayout = withNftsFoldersContext((): React.ReactElement => {
   // eslint-disable-next-line unicorn/no-useless-undefined
   const closeNftDetails = () => setSelectedNft(undefined);
   const nfts: NftItemProps[] = useMemo(() => {
-    const { nftList } = getTokenList({ assetsInfo, balance: assetsBalance?.assets, environmentName, fiatCurrency });
+    const { nftList } = getTokenList({
+      assetsInfo,
+      balance: assetsBalance?.assets,
+      environmentName,
+      fiatCurrency
+    });
     return nftList.map((nft) => ({
       ...nft,
       type: NftsItemsTypes.NFT,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/selectors.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/selectors.ts
@@ -3,6 +3,8 @@ import { Wallet } from '@lace/cardano';
 import { getAssetImageUrl } from '@src/utils/get-asset-image-url';
 import i18n from 'i18next';
 import { EnvironmentTypes } from '@stores';
+import { AssetOrHandleInfo } from '@hooks';
+import { getAssetImage } from '@src/utils/get-asset-image';
 
 export const nftImageSelector = (imageUri: Wallet.Asset.Uri | Wallet.Asset.Uri[]): string | undefined => {
   const uri = Array.isArray(imageUri) ? imageUri[0] : imageUri;
@@ -22,21 +24,21 @@ const nftAttributesSelector = (metadata: Map<string, Wallet.Cardano.Metadatum>):
   return JSON.stringify(metadataRecord, undefined, JSON_INDENTATION);
 };
 
-export const nftDetailSelector = ({ policyId, assetId, nftMetadata }: Wallet.Asset.AssetInfo): NftDetailProps => {
-  const image = nftImageSelector(nftMetadata?.image);
+export const nftDetailSelector = (asset: AssetOrHandleInfo): NftDetailProps => {
+  const image = nftImageSelector(getAssetImage(asset));
 
-  const { otherProperties } = nftMetadata || {};
+  const { otherProperties } = asset.nftMetadata || {};
 
   return {
     image,
     tokenInformation: [
       {
         name: 'Policy ID',
-        value: policyId.toString()
+        value: asset.policyId.toString()
       },
       {
         name: 'Asset ID',
-        value: assetId.toString()
+        value: asset.assetId.toString()
       },
       {
         name: 'Media URL',

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AssetPicker.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AssetPicker.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { AssetSelectorOverlay, AssetSelectorOverlayProps } from '@lace/core';
 import { Wallet } from '@lace/cardano';
 import CardanoLogo from '../../../../../assets/icons/browser-view/cardano-logo.svg';
-import { useFetchCoinPrice, PriceResult, useMaxAda } from '@hooks';
+import { useFetchCoinPrice, PriceResult, useMaxAda, AssetOrHandleInfoMap, useAssetInfo } from '@hooks';
 import { EnvironmentTypes, useWalletStore } from '@src/stores';
 import {
   useCoinStateSelector,
@@ -30,7 +30,7 @@ import { isNFT } from '@src/utils/is-nft';
 import { useObservable } from '@lace/common';
 
 const formatAssetPickerLists = (
-  assetsInfo: Map<Wallet.Cardano.AssetId, Wallet.Asset.AssetInfo> = new Map(),
+  assetsInfo: AssetOrHandleInfoMap = new Map(),
   balance: Wallet.Cardano.Value,
   prices: PriceResult,
   addCardanoAsAnAsset: boolean,
@@ -133,7 +133,7 @@ export const AssetPicker = ({ isPopupView }: AssetPickerProps): React.ReactEleme
     environmentName
   } = useWalletStore();
   const [row] = useCurrentRow();
-  const assets = useObservable(inMemoryWallet.assetInfo$);
+  const assets = useAssetInfo();
   const { priceResult } = useFetchCoinPrice();
   const balance = useObservable(inMemoryWallet.balance.utxo.total$);
   const availableRewards = useObservable(inMemoryWallet.balance.rewardAccounts.rewards$);


### PR DESCRIPTION
# Checklist

- [ ] JIRA - LW-7324
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR adds handle information to assets so the personalized image can be used where nfts image are displayed.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

- NFT screen
<img width="724" alt="image" src="https://github.com/input-output-hk/lace/assets/11845759/92fc06c5-ce7c-4df2-ac79-ad2b83161a44">

- NFT folder screen
<img width="675" alt="image" src="https://github.com/input-output-hk/lace/assets/11845759/d0093249-bf81-4964-a17f-88e005eae20a">

- NFT detail screen
<img width="675" alt="image" src="https://github.com/input-output-hk/lace/assets/11845759/71a5f96a-8a52-4c18-ad1c-dc38de7d03e8">

- Send screen asset picker
<img width="675" alt="image" src="https://github.com/input-output-hk/lace/assets/11845759/5c28a46e-de7f-4f39-b9cd-78b9c46f0c27">

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/850/5486098721/index.html) for [10e3a214](https://github.com/input-output-hk/lace/pull/234/commits/10e3a21472a7589e5d4cf4b27e89ddc03689cabc)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->