### PR TITLE
feat: persists HandleResolution to addressBookContext

### DIFF
--- a/apps/browser-extension-wallet/src/features/address-book/components/AddressBook.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/components/AddressBook.tsx
@@ -20,6 +20,8 @@ import {
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { useAnalyticsContext } from '@providers';
 import { AddressDetailsSteps } from './AddressDetailDrawer/types';
+import { getAddressToSave } from '@src/utils/validators';
+import { useHandleResolver } from '@hooks';
 
 const scrollableTargetId = 'popupAddressBookContainerId';
 
@@ -29,25 +31,28 @@ export const AddressBook = withAddressBookContext(() => {
   const { setIsEditAddressVisible, isEditAddressVisible, setAddressToEdit, addressToEdit } = useAddressBookStore();
   const { t: translate } = useTranslation();
   const analytics = useAnalyticsContext();
+  const handleResolver = useHandleResolver();
 
   const addressListTranslations = {
     name: translate('core.walletAddressList.name'),
     address: translate('core.walletAddressList.address')
   };
 
-  const onAddressSave = (address: AddressBookSchema | Omit<AddressBookSchema, 'id'>): Promise<string> => {
+  const onAddressSave = async (address: AddressBookSchema | Omit<AddressBookSchema, 'id'>): Promise<string> => {
     analytics.sendEvent({
       category: AnalyticsEventCategories.ADDRESS_BOOK,
       action: AnalyticsEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.AddressBook.ADD_ADDRESS_POPUP
     });
 
+    const addressToSave = await getAddressToSave(address, handleResolver);
+
     return 'id' in addressToEdit
-      ? updateAddress(addressToEdit.id, address, {
+      ? updateAddress(addressToEdit.id, addressToSave, {
           text: translate('browserView.addressBook.toast.editAddress'),
           icon: EditIcon
         })
-      : saveAddress(address, {
+      : saveAddress(addressToSave, {
           text: translate('browserView.addressBook.toast.addAddress'),
           icon: AddIcon
         });

--- a/apps/browser-extension-wallet/src/features/address-book/components/AddressDetailDrawer/AddressDetailDrawer.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/components/AddressDetailDrawer/AddressDetailDrawer.tsx
@@ -77,7 +77,7 @@ export const AddressDetailDrawer = ({
     () => ({
       name: validateWalletName,
       address: validateWalletAddress,
-      handle: async (value: string) => await validateWalletHandle(value, handleResolver)
+      handle: async (value: string) => await validateWalletHandle({ value, handleResolver })
     }),
     [handleResolver]
   );

--- a/apps/browser-extension-wallet/src/features/address-book/context/AddressBookProvider.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/context/AddressBookProvider.tsx
@@ -13,7 +13,7 @@ interface AddressBookProviderProps {
   initialState?: Array<AddressBookSchema>;
 }
 
-export type AddressRecordParams = Pick<AddressBookSchema, 'address' | 'name'>;
+export type AddressRecordParams = Pick<AddressBookSchema, 'address' | 'name' | 'handleResolution'>;
 
 export const cardanoNetworkMap = {
   Mainnet: Wallet.Cardano.NetworkMagics.Mainnet,

--- a/apps/browser-extension-wallet/src/features/address-book/context/__test__/context.test.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/context/__test__/context.test.tsx
@@ -9,7 +9,7 @@ import { DatabaseProvider } from '@src/providers/DatabaseProvider';
 import { StoreProvider } from '@src/stores';
 import create from 'zustand';
 import { AppSettingsProvider } from '@providers';
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, Asset } from '@cardano-sdk/core';
 import { act } from 'react-dom/test-utils';
 import { waitFor } from '@testing-library/react';
 
@@ -18,6 +18,18 @@ jest.mock('../AddressBookProvider', () => ({
   ...jest.requireActual<any>('../AddressBookProvider'),
   withAddressBookContext: jest.fn()
 }));
+
+const mockHandleResolution = {
+  backgroundImage: Asset.Uri('ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd'),
+  cardanoAddress: Cardano.PaymentAddress(
+    'addr_test1qzrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3ydtmkg0e7e2jvzg443h0ffzfwd09wpcxy2fuql9tk0g'
+  ),
+  handle: 'bob',
+  hasDatum: false,
+  image: Asset.Uri('ipfs://c8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe'),
+  policyId: Cardano.PolicyId('50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb'),
+  profilePic: Asset.Uri('ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd1')
+};
 
 const makeDbContextWrapper =
   (dbInstance: WalletDatabase): FunctionComponent =>
@@ -38,7 +50,8 @@ describe('testing useAddressBookState', () => {
     id: i + 1,
     address: `addr_test${i + 1}`,
     name: `atest wallet ${i + 1}`,
-    network: Cardano.NetworkMagics.Preprod
+    network: Cardano.NetworkMagics.Preprod,
+    handleResolution: mockHandleResolution
   }));
 
   beforeEach(async () => {
@@ -106,7 +119,8 @@ describe('testing useAddressBookState', () => {
       id: result.current.list[0].id,
       name: 'newName',
       address: 'newAddress',
-      network: Cardano.NetworkMagics.Preprod
+      network: Cardano.NetworkMagics.Preprod,
+      handleResolution: mockHandleResolution
     };
 
     await act(async () => {

--- a/apps/browser-extension-wallet/src/features/address-book/context/context.ts
+++ b/apps/browser-extension-wallet/src/features/address-book/context/context.ts
@@ -6,6 +6,7 @@ export const AddressBookContext = createContext<useDbStateValue<AddressBookSchem
 
 export const useAddressBookContext = (): ReturnType<typeof useDbState> => {
   const bookContext = useContext(AddressBookContext);
+
   if (bookContext === null) throw new Error('AddressBookContext is not defined.');
   return bookContext;
 };

--- a/apps/browser-extension-wallet/src/features/address-book/hooks/__tests__/useGetFilteredAddressBook.test.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/hooks/__tests__/useGetFilteredAddressBook.test.tsx
@@ -9,8 +9,19 @@ import { WalletDatabase, AddressBookSchema, addressBookSchema } from '../../../.
 import { StoreProvider } from '@src/stores';
 import create from 'zustand';
 import { AppSettingsProvider } from '@providers';
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, Asset } from '@cardano-sdk/core';
 
+const mockHandleResolution = {
+  backgroundImage: Asset.Uri('ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd'),
+  cardanoAddress: Cardano.PaymentAddress(
+    'addr_test1qzrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3ydtmkg0e7e2jvzg443h0ffzfwd09wpcxy2fuql9tk0g'
+  ),
+  handle: 'bob',
+  hasDatum: false,
+  image: Asset.Uri('ipfs://c8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe'),
+  policyId: Cardano.PolicyId('50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb'),
+  profilePic: Asset.Uri('ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd1')
+};
 const makeDbContextWrapper =
   (dbIntance: WalletDatabase): FunctionComponent =>
   ({ children }: { children?: React.ReactNode }) =>
@@ -28,19 +39,22 @@ describe('Testing useGetFilteredAddressBook hook', () => {
       id: 1,
       address: 'addr_test1',
       name: 'test wallet',
-      network: Cardano.NetworkMagics.Preprod
+      network: Cardano.NetworkMagics.Preprod,
+      handleResolution: mockHandleResolution
     },
     {
       id: 2,
       address: 'addr_test2',
       name: 'Other wallet',
-      network: Cardano.NetworkMagics.Preprod
+      network: Cardano.NetworkMagics.Preprod,
+      handleResolution: mockHandleResolution
     },
     {
       id: 3,
       address: 'addr_test3',
       name: 'Other wallet 2',
-      network: Cardano.NetworkMagics.Preprod
+      network: Cardano.NetworkMagics.Preprod,
+      handleResolution: mockHandleResolution
     }
   ];
 

--- a/apps/browser-extension-wallet/src/lib/storage/__tests__/address-book.test.ts
+++ b/apps/browser-extension-wallet/src/lib/storage/__tests__/address-book.test.ts
@@ -16,16 +16,17 @@ describe('Testing addressBook table', () => {
   });
   afterEach(() => db.delete());
 
-  test('should have an addressBook table with id, name and address fields', () => {
+  test('should have an addressBook table with id, name, address and handleResolution fields', () => {
     expect(db.table('addressBook')).toBeDefined();
     expect(db.getConnection(addressBookSchema)).toEqual(db.table('addressBook'));
     expect(db.getConnection(addressBookSchema).schema.primKey.name).toEqual('id');
-    expect(db.getConnection(addressBookSchema).schema.indexes).toHaveLength(3);
+    expect(db.getConnection(addressBookSchema).schema.indexes).toHaveLength(4);
     expect(db.getConnection(addressBookSchema).schema.indexes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: 'name' }),
         expect.objectContaining({ name: 'address' }),
-        expect.objectContaining({ name: 'network' })
+        expect.objectContaining({ name: 'network' }),
+        expect.objectContaining({ name: 'handleResolution' })
       ])
     );
   });

--- a/apps/browser-extension-wallet/src/lib/storage/__tests__/database.test.ts
+++ b/apps/browser-extension-wallet/src/lib/storage/__tests__/database.test.ts
@@ -19,16 +19,17 @@ describe('Testing WalletDatabase', () => {
   describe('Database schema', () => {
     const db = new WalletDatabase();
 
-    test('should have an addressBook table with id, name and address fields', () => {
+    test('should have an addressBook table with id, name, address and handleResolution fields', () => {
       expect(db.table('addressBook')).toBeDefined();
       expect(db.getConnection(addressBookSchema)).toEqual(db.table('addressBook'));
       expect(db.getConnection(addressBookSchema).schema.primKey.name).toEqual('id');
-      expect(db.getConnection(addressBookSchema).schema.indexes).toHaveLength(3);
+      expect(db.getConnection(addressBookSchema).schema.indexes).toHaveLength(4);
       expect(db.getConnection(addressBookSchema).schema.indexes).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ name: 'name' }),
           expect.objectContaining({ name: 'address' }),
-          expect.objectContaining({ name: 'network' })
+          expect.objectContaining({ name: 'network' }),
+          expect.objectContaining({ name: 'handleResolution' })
         ])
       );
     });

--- a/apps/browser-extension-wallet/src/lib/storage/models/address-book.ts
+++ b/apps/browser-extension-wallet/src/lib/storage/models/address-book.ts
@@ -4,11 +4,13 @@ import { Wallet } from '@lace/cardano';
 import { DbQueries } from '../hooks';
 import { AddressRecordParams } from '@src/features/address-book/context';
 import { sortTabletByName } from '../helpers';
+import { Cardano, HandleResolution } from '@cardano-sdk/core';
 
 export interface AddressBookSchema {
   id: number;
   name: string;
-  address: string;
+  address: string | Cardano.PaymentAddress;
+  handleResolution?: HandleResolution;
   network: Wallet.Cardano.NetworkMagics;
 }
 
@@ -16,7 +18,7 @@ export const addressBookSchema: VersionedSchema = {
   table: 'addressBook',
   indexedFields: {
     1: ['++id', 'name', 'address'],
-    2: ['++id', 'name', 'address', 'network']
+    2: ['++id', 'name', 'address', 'network', 'handleResolution']
   }
 };
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/adress-book/components/AddressBook/AddressBook.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/adress-book/components/AddressBook/AddressBook.tsx
@@ -24,6 +24,8 @@ import {
   AnalyticsEventNames
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { AddressDetailsSteps } from '@src/features/address-book/components/AddressDetailDrawer/types';
+import { getAddressToSave } from '@src/utils/validators';
+import { useHandleResolver } from '@hooks';
 
 const ELLIPSIS_LEFT_SIDE_LENGTH = 34;
 const ELLIPSIS_RIGHT_SIDE_LENGTH = 34;
@@ -35,6 +37,7 @@ export const AddressBook = withAddressBookContext((): React.ReactElement => {
   const { extendLimit, saveRecord: saveAddress, updateRecord: updateAddress, deleteRecord: deleteAddress } = utils;
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
   const analytics = useAnalyticsContext();
+  const handleResolver = useHandleResolver();
 
   const addressListTranslations = {
     name: translate('core.walletAddressList.name'),
@@ -86,18 +89,20 @@ export const AddressBook = withAddressBookContext((): React.ReactElement => {
     extendLimit();
   }, [extendLimit]);
 
-  const onAddressSave = (address: AddressBookSchema): Promise<string> => {
+  const onAddressSave = async (address: AddressBookSchema): Promise<string> => {
     analytics.sendEvent({
       category: AnalyticsEventCategories.ADDRESS_BOOK,
       action: AnalyticsEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.AddressBook.ADD_ADDRESS_BROWSER
     });
+
+    const addressToSave = await getAddressToSave(address, handleResolver);
     return 'id' in addressToEdit
-      ? updateAddress(addressToEdit.id, address, {
+      ? updateAddress(addressToEdit.id, addressToSave, {
           text: translate('browserView.addressBook.toast.editAddress'),
           icon: EditIcon
         })
-      : saveAddress(address, {
+      : saveAddress(addressToSave, {
           text: translate('browserView.addressBook.toast.addAddress'),
           icon: AddIcon
         });

--- a/apps/browser-extension-wallet/src/views/browser-view/features/adress-book/components/AddressForm/AddressForm.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/adress-book/components/AddressForm/AddressForm.tsx
@@ -32,7 +32,7 @@ export const AddressForm = ({ initialValues, onConfirmClick }: AddressFormProps)
     () => ({
       name: validateWalletName,
       address: validateWalletAddress,
-      handle: async (value: string) => await validateWalletHandle(value, handleResolver)
+      handle: async (value: string) => await validateWalletHandle({ value, handleResolver })
     }),
     [handleResolver]
   );

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AddressForm.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AddressForm.tsx
@@ -8,7 +8,12 @@ import { useSections } from '../store';
 import { CancelEditAddressModal } from './CancelEditAddressModal';
 import AddIcon from '../../../../../assets/icons/add.component.svg';
 import EditIcon from '../../../../../assets/icons/edit.component.svg';
-import { validateWalletAddress, validateWalletHandle, validateWalletName } from '@src/utils/validators';
+import {
+  getAddressToSave,
+  validateWalletAddress,
+  validateWalletHandle,
+  validateWalletName
+} from '@src/utils/validators';
 import { useHandleResolver } from '@hooks/useHandleResolver';
 import { Form } from 'antd';
 
@@ -32,7 +37,7 @@ export const AddressForm = withAddressBookContext(({ isPopupView }: AddressFormP
     () => ({
       name: validateWalletName,
       address: validateWalletAddress,
-      handle: async (value: string) => await validateWalletHandle(value, handleResolver)
+      handle: async (value: string) => await validateWalletHandle({ value, handleResolver })
     }),
     [handleResolver]
   );
@@ -42,16 +47,19 @@ export const AddressForm = withAddressBookContext(({ isPopupView }: AddressFormP
     address: t('core.editAddressForm.address')
   };
 
-  const onAddressSave = (address: AddressBookSchema): Promise<string> =>
-    'id' in addressToEdit
-      ? updateAddress(addressToEdit.id, address, {
+  const onAddressSave = async (address: AddressBookSchema): Promise<string> => {
+    const addressToSave = await getAddressToSave(address, handleResolver);
+
+    return 'id' in addressToEdit
+      ? updateAddress(addressToEdit.id, addressToSave, {
           text: t('browserView.addressBook.toast.editAddress'),
           icon: EditIcon
         })
-      : saveAddress(address, {
+      : saveAddress(addressToSave, {
           text: t('browserView.addressBook.toast.addAddress'),
           icon: AddIcon
         });
+  };
 
   const onConfirmClick = (address: AddressBookSchema) => {
     onAddressSave(address);

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AddressList.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AddressList.tsx
@@ -30,6 +30,7 @@ export const AddressList = withAddressBookContext(
           id: item.id,
           address: item.address,
           name: item.name,
+          handleResolution: item.handleResolution,
           onClick: (addr: AddressBookSchema) => {
             setAddressValue(row, addr.address);
             setSection();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/AddressFormFooter.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/AddressFormFooter.tsx
@@ -10,24 +10,30 @@ import { useAddressBookStore } from '@src/features/address-book/store';
 import AddIcon from '../../../../../../assets/icons/add.component.svg';
 import EditIcon from '../../../../../../assets/icons/edit.component.svg';
 import { useSections } from '../../store';
+import { getAddressToSave } from '@src/utils/validators';
+import { useHandleResolver } from '@hooks';
 
 export const AddressFormFooter = withAddressBookContext(() => {
   const { t } = useTranslation();
   const { utils } = useAddressBookContext();
   const { addressToEdit, setAddressToEdit } = useAddressBookStore();
   const { setPrevSection } = useSections();
+  const handleResolver = useHandleResolver();
   const { saveRecord: saveAddress, updateRecord: updateAddress } = utils;
 
-  const onAddressSave = (address: Partial<AddressBookSchema>): Promise<string> =>
-    'id' in addressToEdit
-      ? updateAddress(addressToEdit.id, address, {
+  const onAddressSave = async (address: Omit<AddressBookSchema, 'id' | 'network'>): Promise<string> => {
+    const addressToSave = await getAddressToSave(address, handleResolver);
+
+    return 'id' in addressToEdit
+      ? updateAddress(addressToEdit.id, addressToSave, {
           text: t('browserView.addressBook.toast.editAddress'),
           icon: EditIcon
         })
-      : saveAddress(address, {
+      : saveAddress(addressToSave, {
           text: t('browserView.addressBook.toast.addAddress'),
           icon: AddIcon
         });
+  };
 
   const onFormSubmit = async () => {
     try {

--- a/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.tsx
+++ b/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import cn from 'classnames';
+import { Cardano } from '@cardano-sdk/core';
 import { Typography, Tooltip } from 'antd';
 import { Ellipsis } from '@lace/common';
 import { ReactComponent as MissingIcon } from '../../assets/icons/missing.component.svg';
@@ -10,7 +11,7 @@ const { Text } = Typography;
 interface AddressBookSchema {
   id: number;
   name: string;
-  address: string;
+  address: Cardano.PaymentAddress | string;
 }
 
 export type WalletAddressItemProps = {


### PR DESCRIPTION
# Checklist

- [x] [JIRA-7379] 
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Adds `HandleResolution` to the `AddressBookContext` so that later on we can save and compare both values for a validation on the client side. 

## Testing

- Run the app make sure ADA Handle works without any regression.
- Address book renders 
- Profile renders and they both render the address and the handle. 

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/858/5487037446/index.html) for [b81d60a3](https://github.com/input-output-hk/lace/pull/235/commits/b81d60a385606e54c1803abcf4ded26a959b9974)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 28     | 8      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->