### PR TITLE
fix: long address name overflow on popup address book

### DIFF
--- a/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.module.scss
+++ b/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.module.scss
@@ -59,6 +59,9 @@
     display: flex;
     flex: 1;
     min-width: 236px;
+    @media (max-width: $breakpoint-popup) {
+      min-width: 0;
+    }
 
     &.small {
       font-size: var(--body) !important;
@@ -97,6 +100,9 @@
 
 .addressBox {
   min-width: 0;
+  @media (max-width: $breakpoint-popup) {
+    justify-self: end;
+  }
 }
 
 .listItemAvatar {


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7374
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Resolves long address name issue on popup address book

## Screenshots
<img width="358" alt="Screenshot 2023-07-10 at 15 24 14" src="https://github.com/input-output-hk/lace/assets/48496855/af02de81-6e34-43f1-9044-295069f8162b">




<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/887/5509456340/index.html) for [18ab7fd4](https://github.com/input-output-hk/lace/pull/243/commits/18ab7fd4767657286e27b45e1f4294d795116215)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 1      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->