### PR TITLE
test(extension): e2e - add tests for create folder cancellation popup

### DIFF
--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -892,6 +892,12 @@
         "description2": "Don’t worry, you won’t loose your NFTs. They will be restored in your main gallery.",
         "confirm": "Confirm",
         "cancel": "Cancel"
+      },
+      "youllHaveToStartAgainModal": {
+        "title": "You'll have to start again",
+        "description": "Are you sure you want to exit? This will not be saved",
+        "cancel": "Cancel",
+        "agree": "Agree"
       }
     },
     "pinExtension.title": "Pin the wallet extension",

--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -892,12 +892,6 @@
         "description2": "Don’t worry, you won’t loose your NFTs. They will be restored in your main gallery.",
         "confirm": "Confirm",
         "cancel": "Cancel"
-      },
-      "youllHaveToStartAgainModal": {
-        "title": "You'll have to start again",
-        "description": "Are you sure you want to exit? This will not be saved",
-        "cancel": "Cancel",
-        "agree": "Agree"
       }
     },
     "pinExtension.title": "Pin the wallet extension",

--- a/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
+++ b/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
@@ -13,29 +13,23 @@ class NftCreateFolderAssert {
     }
   }
 
-  async assertSeeCreateFolderPageDrawerNavigation(shouldSee: boolean, mode: 'extended' | 'popup') {
-    if (shouldSee) {
-      if (mode === 'popup') {
-        await NftCreateFolderPage.drawerHeaderBackButton.waitForDisplayed();
-      } else {
-        await NftCreateFolderPage.drawerBody.waitForDisplayed();
-        await NftCreateFolderPage.drawerNavigationTitle.waitForDisplayed();
-        await NftCreateFolderPage.drawerNavigationTitle.scrollIntoView();
-        await expect(await NftCreateFolderPage.drawerNavigationTitle.getText()).to.equal(
-          await t('browserView.nfts.folderDrawer.header')
-        );
-        await NftCreateFolderPage.drawerHeaderCloseButton.waitForDisplayed();
-      }
-    } else if (mode === 'popup') {
-      await NftCreateFolderPage.drawerHeaderBackButton.waitForDisplayed({ reverse: true });
+  async assertSeeCreateFolderPageDrawerNavigation(mode: 'extended' | 'popup') {
+    if (mode === 'popup') {
+      await NftCreateFolderPage.drawerHeaderBackButton.waitForDisplayed();
     } else {
-      await NftCreateFolderPage.drawerBody.waitForDisplayed({ reverse: true });
+      await NftCreateFolderPage.drawerBody.waitForDisplayed();
+      await NftCreateFolderPage.drawerNavigationTitle.waitForDisplayed();
+      await NftCreateFolderPage.drawerNavigationTitle.scrollIntoView();
+      await expect(await NftCreateFolderPage.drawerNavigationTitle.getText()).to.equal(
+        await t('browserView.nfts.folderDrawer.header')
+      );
+      await NftCreateFolderPage.drawerHeaderCloseButton.waitForDisplayed();
     }
   }
 
   async assertSeeCreateFolderPage(shouldSee: boolean, mode: 'extended' | 'popup') {
     if (shouldSee) {
-      await this.assertSeeCreateFolderPageDrawerNavigation(shouldSee, mode);
+      await this.assertSeeCreateFolderPageDrawerNavigation(mode);
       await NftCreateFolderPage.drawerHeaderTitle.waitForDisplayed();
       await expect(await NftCreateFolderPage.drawerHeaderTitle.getText()).to.equal(
         await t('browserView.nfts.folderDrawer.nameForm.title')
@@ -79,30 +73,7 @@ class NftCreateFolderAssert {
   }
 
   async assertSeeYoullHaveToStartAgainModal(shouldBeDisplayed: boolean) {
-    if (shouldBeDisplayed) {
-      await YoullHaveToStartAgainModal.container.waitForDisplayed();
-      await YoullHaveToStartAgainModal.title.waitForDisplayed();
-      await expect(await YoullHaveToStartAgainModal.title.getText()).to.equal(
-        await t('browserView.nfts.youllHaveToStartAgainModal.title')
-      );
-
-      await YoullHaveToStartAgainModal.description.waitForDisplayed();
-      await expect(await YoullHaveToStartAgainModal.description.getText()).to.equal(
-        await t('browserView.nfts.youllHaveToStartAgainModal.description')
-      );
-
-      await YoullHaveToStartAgainModal.cancelButton.waitForDisplayed();
-      await expect(await YoullHaveToStartAgainModal.cancelButton.getText()).to.equal(
-        await t('browserView.nfts.youllHaveToStartAgainModal.cancel')
-      );
-
-      await YoullHaveToStartAgainModal.agreeButton.waitForDisplayed();
-      await expect(await YoullHaveToStartAgainModal.agreeButton.getText()).to.equal(
-        await t('browserView.nfts.youllHaveToStartAgainModal.agree')
-      );
-    } else {
-      await YoullHaveToStartAgainModal.container.waitForDisplayed({ reverse: true });
-    }
+    await YoullHaveToStartAgainModal.container.waitForDisplayed({ reverse: !shouldBeDisplayed });
   }
 }
 

--- a/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
+++ b/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
@@ -3,6 +3,7 @@ import { t } from '../utils/translationService';
 import { expect } from 'chai';
 import NftFolderNameInput from '../elements/NFTs/nftFolderNameInput';
 import NftCreateFolderPage from '../elements/NFTs/nftCreateFolderPage';
+import YoullHaveToStartAgainModal from '../elements/NFTs/youllHaveToStartAgainModal';
 
 class NftCreateFolderAssert {
   async assertSeeCreateFolderButton(shouldSee: boolean, mode: 'extended' | 'popup') {
@@ -12,23 +13,29 @@ class NftCreateFolderAssert {
     }
   }
 
-  async assertSeeCreateFolderPageDrawerNavigation(mode: 'extended' | 'popup') {
-    if (mode === 'popup') {
-      await NftCreateFolderPage.drawerHeaderBackButton.waitForDisplayed();
+  async assertSeeCreateFolderPageDrawerNavigation(shouldSee: boolean, mode: 'extended' | 'popup') {
+    if (shouldSee) {
+      if (mode === 'popup') {
+        await NftCreateFolderPage.drawerHeaderBackButton.waitForDisplayed();
+      } else {
+        await NftCreateFolderPage.drawerBody.waitForDisplayed();
+        await NftCreateFolderPage.drawerNavigationTitle.waitForDisplayed();
+        await NftCreateFolderPage.drawerNavigationTitle.scrollIntoView();
+        await expect(await NftCreateFolderPage.drawerNavigationTitle.getText()).to.equal(
+          await t('browserView.nfts.folderDrawer.header')
+        );
+        await NftCreateFolderPage.drawerHeaderCloseButton.waitForDisplayed();
+      }
+    } else if (mode === 'popup') {
+      await NftCreateFolderPage.drawerHeaderBackButton.waitForDisplayed({ reverse: true });
     } else {
-      await NftCreateFolderPage.drawerBody.waitForDisplayed();
-      await NftCreateFolderPage.drawerNavigationTitle.waitForDisplayed();
-      await NftCreateFolderPage.drawerNavigationTitle.scrollIntoView();
-      await expect(await NftCreateFolderPage.drawerNavigationTitle.getText()).to.equal(
-        await t('browserView.nfts.folderDrawer.header')
-      );
-      await NftCreateFolderPage.drawerHeaderCloseButton.waitForDisplayed();
+      await NftCreateFolderPage.drawerBody.waitForDisplayed({ reverse: true });
     }
   }
 
   async assertSeeCreateFolderPage(shouldSee: boolean, mode: 'extended' | 'popup') {
     if (shouldSee) {
-      await this.assertSeeCreateFolderPageDrawerNavigation(mode);
+      await this.assertSeeCreateFolderPageDrawerNavigation(shouldSee, mode);
       await NftCreateFolderPage.drawerHeaderTitle.waitForDisplayed();
       await expect(await NftCreateFolderPage.drawerHeaderTitle.getText()).to.equal(
         await t('browserView.nfts.folderDrawer.nameForm.title')
@@ -68,6 +75,33 @@ class NftCreateFolderAssert {
         maxLength.toString()
       );
       expect(await NftCreateFolderPage.folderNameInput.inputError.getText()).to.equal(expectedErrorMessage);
+    }
+  }
+
+  async assertSeeYoullHaveToStartAgainModal(shouldBeDisplayed: boolean) {
+    if (shouldBeDisplayed) {
+      await YoullHaveToStartAgainModal.container.waitForDisplayed();
+      await YoullHaveToStartAgainModal.title.waitForDisplayed();
+      await expect(await YoullHaveToStartAgainModal.title.getText()).to.equal(
+        await t('browserView.nfts.youllHaveToStartAgainModal.title')
+      );
+
+      await YoullHaveToStartAgainModal.description.waitForDisplayed();
+      await expect(await YoullHaveToStartAgainModal.description.getText()).to.equal(
+        await t('browserView.nfts.youllHaveToStartAgainModal.description')
+      );
+
+      await YoullHaveToStartAgainModal.cancelButton.waitForDisplayed();
+      await expect(await YoullHaveToStartAgainModal.cancelButton.getText()).to.equal(
+        await t('browserView.nfts.youllHaveToStartAgainModal.cancel')
+      );
+
+      await YoullHaveToStartAgainModal.agreeButton.waitForDisplayed();
+      await expect(await YoullHaveToStartAgainModal.agreeButton.getText()).to.equal(
+        await t('browserView.nfts.youllHaveToStartAgainModal.agree')
+      );
+    } else {
+      await YoullHaveToStartAgainModal.container.waitForDisplayed({ reverse: true });
     }
   }
 }

--- a/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
+++ b/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
@@ -74,6 +74,27 @@ class NftCreateFolderAssert {
 
   async assertSeeYoullHaveToStartAgainModal(shouldBeDisplayed: boolean) {
     await YoullHaveToStartAgainModal.container.waitForDisplayed({ reverse: !shouldBeDisplayed });
+    if (shouldBeDisplayed) {
+      await YoullHaveToStartAgainModal.title.waitForDisplayed();
+      await expect(await YoullHaveToStartAgainModal.title.getText()).to.equal(
+        await t('browserView.nfts.exitModal.header')
+      );
+
+      await YoullHaveToStartAgainModal.description.waitForDisplayed();
+      await expect(await YoullHaveToStartAgainModal.description.getText()).to.equal(
+        await t('browserView.nfts.exitModal.description')
+      );
+
+      await YoullHaveToStartAgainModal.cancelButton.waitForDisplayed();
+      await expect(await YoullHaveToStartAgainModal.cancelButton.getText()).to.equal(
+        await t('browserView.nfts.exitModal.cancel')
+      );
+
+      await YoullHaveToStartAgainModal.agreeButton.waitForDisplayed();
+      await expect(await YoullHaveToStartAgainModal.agreeButton.getText()).to.equal(
+        await t('browserView.nfts.exitModal.confirm')
+      );
+    }
   }
 }
 

--- a/packages/e2e-tests/src/elements/NFTs/youllHaveToStartAgainModal.ts
+++ b/packages/e2e-tests/src/elements/NFTs/youllHaveToStartAgainModal.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-undef */
+import { ChainablePromiseElement } from 'webdriverio';
+
+class YoullHaveToStartAgainModal {
+  private CONTAINER = '.ant-modal-content';
+  private TITLE = '[data-testid="create-foler-modal-title"]';
+  private DESCRIPTION = '[data-testid="create-foler-modal-description"]';
+  private CANCEL_BUTTON = '[data-testid="create-foler-modal-cancel"]';
+  private AGREE_BUTTON = '[data-testid="create-foler-modal-confirm"]';
+
+  get container(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CONTAINER);
+  }
+
+  get title(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.TITLE);
+  }
+
+  get description(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.DESCRIPTION);
+  }
+
+  get cancelButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CANCEL_BUTTON);
+  }
+
+  get agreeButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.AGREE_BUTTON);
+  }
+}
+
+export default new YoullHaveToStartAgainModal();

--- a/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
@@ -26,3 +26,35 @@ Feature: NFT - Folders - Extended view
     And I enter a folder name "01234567890123456789" into "Folder name" input
     Then I don't see "Folder name" input max length 20 error
     And "Next" button is enabled on "Name your folder" page
+
+  @LW-7244
+  Scenario Outline: Extended-view - NFT Folders - "Create folder" flow and warning modal when <action>
+    Given I navigate to NFTs extended page
+    And I click "Create folder" button on NFTs page
+    When <action>
+    Then I see "You'll have to start again" modal
+    Examples:
+      | action                                      |
+      | I close the drawer by clicking close button |
+      | I click outside the drawer                  |
+
+  @LW-7245
+  Scenario: Extended-view - NFT Folders - "Create folder" flow and warning modal cancellation
+    Given I navigate to NFTs extended page
+    And I click "Create folder" button on NFTs page
+    And I see "Create NFT folder" drawer in extended mode
+    And I close the drawer by clicking close button
+    When I click "Cancel" button on "You'll have to start again" modal for create NFTs folder
+    Then I don't see "You'll have to start again" modal
+    And I see "Create NFT folder" drawer in extended mode
+
+    @LW-7246
+    Scenario: Extended-view - NFT Folders - "Create folder" flow and warning modal confirmation
+      Given I navigate to NFTs extended page
+      And I click "Create folder" button on NFTs page
+      And I see "Create NFT folder" drawer in extended mode
+      And I close the drawer by clicking close button
+      When I click "Agree" button on "You'll have to start again" modal for create NFTs folder
+      Then I don't see "You'll have to start again" modal
+      And I don't see "Create NFT folder" drawer in extended mode
+      And A gallery view showing my NFTs is displayed

--- a/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
@@ -26,3 +26,31 @@ Feature: NFT - Folders - Popup view
     And I enter a folder name "01234567890123456789" into "Folder name" input
     Then I don't see "Folder name" input max length 20 error
     And "Next" button is enabled on "Name your folder" page
+
+  @LW-7262
+  Scenario: Popup-view - NFT Folders - "Create folder" flow and warning modal when closing the drawer by clicking back button
+    Given I navigate to NFTs popup page
+    And I click "Create folder" button on NFTs page
+    When I close the drawer by clicking back button
+    Then I see "You'll have to start again" modal
+
+  @LW-7263
+  Scenario: Popup-view - NFT Folders - "Create folder" flow and warning modal cancellation
+    Given I navigate to NFTs popup page
+    And I click "Create folder" button on NFTs page
+    And I see "Create NFT folder" drawer in popup mode
+    And I close the drawer by clicking back button
+    When I click "Cancel" button on "You'll have to start again" modal for create NFTs folder
+    Then I don't see "You'll have to start again" modal
+    And I see "Create NFT folder" drawer in popup mode
+
+  @LW-7264
+  Scenario: Popup-view - NFT Folders - "Create folder" flow and warning modal confirmation
+    Given I navigate to NFTs popup page
+    And I click "Create folder" button on NFTs page
+    And I see "Create NFT folder" drawer in popup mode
+    And I close the drawer by clicking back button
+    When I click "Agree" button on "You'll have to start again" modal for create NFTs folder
+    Then I don't see "You'll have to start again" modal
+    And I don't see "Create NFT folder" drawer in popup mode
+    And A gallery view showing my NFTs is displayed

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -3,6 +3,7 @@ import { Given, Then } from '@cucumber/cucumber';
 import NftsPage from '../elements/NFTs/nftsPage';
 import nftCreateFolderAssert from '../assert/nftCreateFolderAssert';
 import NftCreateFolderPage from '../elements/NFTs/nftCreateFolderPage';
+import YoullHaveToStartAgainModal from '../elements/NFTs/youllHaveToStartAgainModal';
 
 Given(
   /^I (see|do not see) "Create folder" button on NFTs page in (popup|extended) mode$/,
@@ -44,3 +45,32 @@ When(/^I clear "Folder name" input$/, async () => {
 Then(/^I (see|don't see) "Folder name" input max length (\d+) error$/, async (shouldSee: string, maxLength: number) => {
   await nftCreateFolderAssert.assertSeeInputMaxLengthError(shouldSee === 'see', maxLength);
 });
+
+Then(/^I (see|don't see) "You'll have to start again" modal$/, async (shouldSee: string) => {
+  await nftCreateFolderAssert.assertSeeYoullHaveToStartAgainModal(shouldSee === 'see');
+});
+
+Then(
+  /^I (see|don't see) "Create NFT folder" drawer in (popup|extended) mode$/,
+  async (shouldSee: string, mode: 'extended' | 'popup') => {
+    await nftCreateFolderAssert.assertSeeCreateFolderPageDrawerNavigation(shouldSee === 'see', mode);
+  }
+);
+
+Then(
+  /^I click "(Agree|Cancel)" button on "You'll have to start again" modal for create NFTs folder$/,
+  async (button: 'Agree' | 'Cancel') => {
+    switch (button) {
+      case 'Agree':
+        await YoullHaveToStartAgainModal.agreeButton.waitForClickable();
+        await YoullHaveToStartAgainModal.agreeButton.click();
+        break;
+      case 'Cancel':
+        await YoullHaveToStartAgainModal.cancelButton.waitForClickable();
+        await YoullHaveToStartAgainModal.cancelButton.click();
+        break;
+      default:
+        throw new Error(`Unsupported button name: ${button}`);
+    }
+  }
+);

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -53,7 +53,7 @@ Then(/^I (see|don't see) "You'll have to start again" modal$/, async (shouldSee:
 Then(
   /^I (see|don't see) "Create NFT folder" drawer in (popup|extended) mode$/,
   async (shouldSee: string, mode: 'extended' | 'popup') => {
-    await nftCreateFolderAssert.assertSeeCreateFolderPageDrawerNavigation(shouldSee === 'see', mode);
+    await nftCreateFolderAssert.assertSeeCreateFolderPage(shouldSee === 'see', mode);
   }
 );
 


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/944/5530458897/index.html) for [48da448a](https://github.com/input-output-hk/lace/pull/245/commits/48da448a6762a4367c818474f431a3eee67e57fc)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 1      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->