### PR TITLE
chore(staking): enable ladle build with eslint errors

### DIFF
--- a/packages/staking/.ladle/vite.config.ts
+++ b/packages/staking/.ladle/vite.config.ts
@@ -18,6 +18,7 @@ export const ladleViteConfig = {
     eslint({
       include: './**/*.{ts,tsx,json}',
       overrideConfigFile: '.eslintrc.cjs',
+      failOnError: false,
     }),
     svgr({
       svgrOptions: {


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-6846

---

## Proposed solution
Enable ladle build with eslint errors. Ladle is used only for development purposes and our pipelines still won't allow merging PRs with ESLint errors.