### PR TITLE
fix(extension): onboarding bug with mnemonics

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -79,7 +79,6 @@ export const WalletSetupWizard = ({
   const [mnemonicLength, setMnemonicLength] = useState<number>(DEFAULT_MNEMONIC_LENGTH);
   const [mnemonic, setMnemonic] = useState<string[]>([]);
   const [walletIsCreating, setWalletIsCreating] = useState(false);
-  const [isBackToMnemonic, setIsBackToMnemonic] = useState<boolean>(false);
   const [resetMnemonicStage, setResetMnemonicStage] = useState<MnemonicStage | ''>('');
   const [isResetMnemonicModalOpen, setIsResetMnemonicModalOpen] = useState(false);
 
@@ -271,11 +270,6 @@ export const WalletSetupWizard = ({
     setupType
   ]);
 
-  const goBackToMnemonic = () => {
-    setIsBackToMnemonic(true);
-    return moveBack();
-  };
-
   useEffect(() => {
     if (password && currentStep === WalletSetupSteps.Create && !walletIsCreating) {
       setWalletIsCreating(true);
@@ -315,8 +309,6 @@ export const WalletSetupWizard = ({
           isSubmitEnabled={isMnemonicSubmitEnabled}
           translations={walletSetupMnemonicStepTranslations}
           suggestionList={wordList}
-          isBackToMnemonic={isBackToMnemonic}
-          setIsBackToMnemonic={setIsBackToMnemonic}
         />
       );
     }
@@ -393,7 +385,7 @@ export const WalletSetupWizard = ({
       )}
       {currentStep === WalletSetupSteps.Register && (
         <WalletSetupRegisterStep
-          onBack={goBackToMnemonic}
+          onBack={moveBack}
           onNext={(result) => {
             sendAnalytics(Events.WALLET_NAME_NEXT);
             setWalletName(result.walletName);

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupMnemonicVerificationStep.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupMnemonicVerificationStep.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { WalletSetupStepLayout, WalletTimelineSteps } from './WalletSetupStepLayout';
 import { MnemonicWordsConfirmInput } from './MnemonicWordsConfirmInput';
 import styles from './WalletSetupOption.module.scss';
 import { TranslationsFor } from '@ui/utils/types';
 import { defaultMnemonicWordsInStep } from '@src/ui/utils/constants';
 
-const LAST_MNEMONIC_STEP = 2;
 export const hasEmptyString = (arr: string[]): boolean => arr.includes('');
 
 export interface WalletSetupMnemonicVerificationStepProps {
@@ -18,8 +17,6 @@ export interface WalletSetupMnemonicVerificationStepProps {
   mnemonicWordsInStep?: number;
   translations: TranslationsFor<'enterPassphrase' | 'passphraseError' | 'enterPassphraseDescription'>;
   suggestionList?: Array<string>;
-  isBackToMnemonic: boolean;
-  setIsBackToMnemonic: (value: boolean) => void;
 }
 
 export const WalletSetupMnemonicVerificationStep = ({
@@ -31,9 +28,7 @@ export const WalletSetupMnemonicVerificationStep = ({
   isSubmitEnabled,
   mnemonicWordsInStep = defaultMnemonicWordsInStep,
   translations,
-  suggestionList,
-  isBackToMnemonic,
-  setIsBackToMnemonic
+  suggestionList
 }: WalletSetupMnemonicVerificationStepProps): React.ReactElement => {
   const mnemonicLength = mnemonic.length;
   const mnemonicSteps = Math.round(mnemonicLength / mnemonicWordsInStep);
@@ -77,13 +72,6 @@ export const WalletSetupMnemonicVerificationStep = ({
     () => mnemonic.slice(currentStepFirstWordIndex, currentStepLastWordIndex),
     [currentStepFirstWordIndex, currentStepLastWordIndex, mnemonic]
   );
-
-  useEffect(() => {
-    if (!isBackToMnemonic) return;
-    console.log(isBackToMnemonic, LAST_MNEMONIC_STEP);
-    setMnemonicStep(LAST_MNEMONIC_STEP);
-    setIsBackToMnemonic(false);
-  }, [isBackToMnemonic, setIsBackToMnemonic]);
 
   const isNextEnabled = useMemo(
     () => currentStepWords.every((word) => word) && (mnemonicStep !== mnemonicSteps - 1 || isSubmitEnabled),

--- a/packages/core/src/ui/components/WalletSetup/__tests__/WalletSetupMnemonicVerificationStep.test.tsx
+++ b/packages/core/src/ui/components/WalletSetup/__tests__/WalletSetupMnemonicVerificationStep.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, within, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { WalletSetupMnemonicVerificationStep } from '../WalletSetupMnemonicVerificationStep';
+import { WalletSetupMnemonicVerificationStep } from '@ui/components/WalletSetup';
 import { useEffect } from 'react';
 import { act } from 'react-dom/test-utils';
 
@@ -40,8 +40,6 @@ const Test = () => {
         passphraseError: 'Passphrase error',
         enterPassphraseDescription: 'Enter passphrase description'
       }}
-      setIsBackToMnemonic={jest.fn()}
-      isBackToMnemonic={false}
       isSubmitEnabled
     />
   );


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-6141
- [x] Screenshots added.

---

## Proposed solution

This PR fixes two separate issues:
1. Fixes a bug in the extension on-boarding flow outlined in https://input-output.atlassian.net/browse/LW-6141
2. Enable different mnemonic length selection for desktop on-boarding flow (to make it work like in the extension) 

## Testing

1. follow the steps outlined in https://input-output.atlassian.net/browse/LW-6141 and you should see the expected result of seeing the first page of mnemonic input
2. Try restoring a wallet with 12/15 mnemonics on desktop app

## Screenshots

https://user-images.githubusercontent.com/172414/236194207-85a3a192-d98a-422b-8490-d77c7a383725.mp4

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/912/5521455919/index.html) for [efc8caba](https://github.com/input-output-hk/lace/pull/248/commits/efc8caba3d1c9811e9ec375b050844df334fcbc7)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 2      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->