### PR TITLE
[LW-7422] Transaction confirmation screen is not purged

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
@@ -54,7 +54,7 @@ export const useHandleClose = (): {
   const resetUi = useResetUiStore();
   const { hasOutput } = useTransactionProps();
   const [, setIsDrawerVisible] = useDrawer();
-  const { currentSection: section } = useSections();
+  const { currentSection: section, resetSection } = useSections();
   const reditectToTransactions = useRedirection(walletRoutePaths.activity);
   const reditectToOverview = useRedirection(walletRoutePaths.assets);
   const isInMemory = useMemo(() => getKeyAgentType() === Wallet.KeyManagement.KeyAgentType.InMemory, [getKeyAgentType]);
@@ -62,7 +62,8 @@ export const useHandleClose = (): {
   const resetStates = useCallback(() => {
     reset();
     resetUi();
-  }, [reset, resetUi]);
+    resetSection();
+  }, [reset, resetUi, resetSection]);
 
   const closeDrawer = useCallback(() => {
     resetStates();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionLayout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionLayout.tsx
@@ -20,7 +20,8 @@ export const SendTransactionLayout = ({ children, isPopupView }: SendTransaction
   const { onClose } = useHandleClose();
   const [, setIsDrawerVisible] = useDrawer();
   const {
-    currentSection: { currentSection }
+    currentSection: { currentSection },
+    resetSection
   } = useSections();
   const reset = useResetStore();
   const resetUi = useResetUiStore();
@@ -32,7 +33,8 @@ export const SendTransactionLayout = ({ children, isPopupView }: SendTransaction
     setIsDrawerVisible();
     resetUi();
     reset();
-  }, [reset, resetUi, setIsDrawerVisible]);
+    resetSection();
+  }, [reset, resetUi, resetSection, setIsDrawerVisible]);
 
   // TODO: review if there's a better way to do this [LW-5456]
   useEffect(() => {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendWarningModal.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendWarningModal.tsx
@@ -28,7 +28,7 @@ export const SendWarningModal = ({ isPopupView }: SendWarningModalProps): React.
   const reset = useResetStore();
   const resetUi = useResetUiStore();
   const redirectToOverview = useRedirection(walletRoutePaths.assets);
-  const { currentSection: section } = useSections();
+  const { currentSection: section, resetSection } = useSections();
 
   const analytics = useAnalyticsContext();
 
@@ -55,6 +55,7 @@ export const SendWarningModal = ({ isPopupView }: SendWarningModalProps): React.
   const resetStates = () => {
     reset();
     resetUi();
+    resetSection();
   };
 
   const handleConfirm = () => {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/store/uiStore.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/store/uiStore.ts
@@ -38,13 +38,20 @@ const useStore = create<UIStore>((set) => ({
 export const useDrawer = (): [UIStore['isDrawerVisible'], UIStore['setIsDrawerVisible']] =>
   useStore((state) => [state.isDrawerVisible, state.setIsDrawerVisible]);
 
-const useSectionsStore = createSectionsStore<Sections>({ section: sectionsConfig.form, config: sectionsConfig });
+const useSectionsStore = createSectionsStore<Sections>({
+  section: sectionsConfig.form,
+  config: sectionsConfig
+});
 
-export const useSections = (): Pick<SectionsStore<Sections>, 'currentSection' | 'setPrevSection' | 'setSection'> =>
-  useSectionsStore(({ currentSection, setSection, setPrevSection }) => ({
+export const useSections = (): Pick<
+  SectionsStore<Sections>,
+  'currentSection' | 'setPrevSection' | 'setSection' | 'resetSection'
+> =>
+  useSectionsStore(({ currentSection, setSection, setPrevSection, resetSection }) => ({
     currentSection,
     setSection,
-    setPrevSection
+    setPrevSection,
+    resetSection
   }));
 
 export const useWarningModal = (): [UIStore['isWarningModalVisible'], UIStore['setWarnigModalVisibility']] =>

--- a/apps/browser-extension-wallet/src/views/browser-view/stores/sections-store.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/stores/sections-store.ts
@@ -12,6 +12,7 @@ export interface SectionsStore<T> {
   currentSection?: SectionConfig<T>;
   setSection: (section?: SectionConfig<T>) => void;
   setPrevSection: () => void;
+  resetSection?: () => void;
   sectionsConfig?: SimpleSectionsConfig<T>;
 }
 
@@ -28,6 +29,9 @@ export const createSectionsStore = <T>({
     return {
       sectionsConfig,
       currentSection,
+      resetSection: () => {
+        set({ currentSection });
+      },
       setSection: (section) =>
         set({
           currentSection: section ?? get().sectionsConfig[get().currentSection.nextSection as Extract<T, string>]


### PR DESCRIPTION
# Checklist

- [ ] JIRA - LW-7422
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Resets the section store on drawer close.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/928/5524199407/index.html) for [e27d0a38](https://github.com/input-output-hk/lace/pull/253/commits/e27d0a38266ae2efede28200b6842cec5eaa1c4a)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 6      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->