### PR TITLE
feat(staking): handle multiple stake pools on staking confirmation drawer

### DIFF
--- a/packages/staking/.eslintrc.cjs
+++ b/packages/staking/.eslintrc.cjs
@@ -23,6 +23,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/switch-exhaustiveness-check': 'error',
     'import/no-default-export': 'error',
+    'import/no-extraneous-dependencies': 2,
     'import/no-unresolved': 'off',
     'import/order': [
       'error',
@@ -45,6 +46,5 @@ module.exports = {
     'sort-keys/sort-keys-fix': ['error', 'asc', { natural: true }],
     'unicorn/no-null': 'off',
     'unicorn/prefer-query-selector': 'off',
-    'import/no-extraneous-dependencies': 2,
   },
 };

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -35,7 +35,7 @@
     "build": "tsc && tsup",
     "cleanup": "shx rm -rf dist node_modules && shx rm -rf ../../.cache/eslintcache",
     "dev": "ladle serve",
-    "eslint:check": "eslint --cache --cache-location ../../.cache/eslintcache --cache-strategy metadata --ignore-path '../../.eslintignore' '.*/**/*.{cjs,mjs,js,ts,tsx}'",
+    "eslint:check": "eslint --cache --cache-location ../../.cache/eslintcache --cache-strategy metadata --ignore-path '../../.eslintignore' '**/*.{cjs,mjs,js,ts,tsx}'",
     "eslint:fix": "yarn eslint:check --fix",
     "lint": "echo 'Staking package runs lint in its own CI'",
     "lint:all": "yarn eslint:check && yarn prettier:check",
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
+    "classnames": "^2.3.2",
     "i18next": "^22.5.1",
     "immer": "^10.0.2",
     "lodash": "4.17.21",
@@ -69,6 +70,7 @@
     "@lace/ui": "^0.1.0",
     "@ladle/react": "^2.12.3",
     "@svgr/plugin-jsx": "^8.0.1",
+    "@testing-library/react-hooks": "^8.0.1",
     "@tsconfig/create-react-app": "^1.0.3",
     "@vanilla-extract/css": "^1.11.1",
     "@vanilla-extract/esbuild-plugin": "^2.2.2",
@@ -84,13 +86,15 @@
     "normalize.css": "^8.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-infinite-scroll-component": "^6.1.0",
     "tsup": "^6.7.0",
     "typescript": "^4.9.5",
     "vite-plugin-checker": "^0.6.0",
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-svgr": "^3.2.0",
     "vitest": "^0.31.0",
-    "wait-on": "^7.0.1"
+    "wait-on": "^7.0.1",
+    "zustand": "3.5.14"
   },
   "peerDependencies": {
     "@cardano-sdk/input-selection": "0.11.1",
@@ -103,6 +107,8 @@
     "antd": "^4.17.3",
     "bignumber.js": "^9.0.1",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-infinite-scroll-component": "^6.1.0",
+    "zustand": "3.5.14"
   }
 }

--- a/packages/staking/src/features/drawer/StakePoolConfirmation.module.scss
+++ b/packages/staking/src/features/drawer/StakePoolConfirmation.module.scss
@@ -39,6 +39,10 @@
     height: size_unit(13);
     padding: 0px size_unit(4);
 
+    & + .item {
+      margin-top: size_unit(2);
+    }
+
     &:first-child {
       .itemData {
         gap: 4px;

--- a/packages/staking/src/features/drawer/StakePoolConfirmation.tsx
+++ b/packages/staking/src/features/drawer/StakePoolConfirmation.tsx
@@ -5,12 +5,21 @@ import { Wallet } from '@lace/cardano';
 import { Banner, Button, Ellipsis, useObservable } from '@lace/common';
 import { RowContainer, renderAmountInfo, renderLabel } from '@lace/core';
 import { Skeleton } from 'antd';
+import cn from 'classnames';
+import { Immutable } from 'immer';
 import isNil from 'lodash/isNil';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOutsideHandles } from '../outside-handles-provider';
-import { SelectedStakePoolDetails } from '../outside-handles-provider/types';
-import { Sections, StakingError, sectionsConfig, useStakePoolDetails } from '../store';
+import { Balance, CurrencyInfo, LegacySelectedStakePoolDetails } from '../outside-handles-provider/types';
+import {
+  DelegationPortfolioStakePool,
+  Sections,
+  StakingError,
+  sectionsConfig,
+  useDelegationPortfolioStore,
+  useStakePoolDetails,
+} from '../store';
 import ArrowDown from './arrow-down.svg';
 import Cardano from './cardano-blue.png';
 import ExclamationMarkIcon from './exclamation-circle-small.svg';
@@ -37,6 +46,98 @@ const isInputSelectionError = (error: any): error is { failure: InputSelectionFa
   Object.hasOwn(error, 'failure') &&
   Object.values(InputSelectionFailure).includes(error.failure);
 
+const ItemStatRenderer = ({ img, text, subText }: statRendererProps) => (
+  <div>
+    {img && <img data-testid="sp-confirmation-item-logo" src={img} alt="confirmation item" />}
+    <div className={styles.itemData}>
+      <div className={styles.dataTitle} data-testid="sp-confirmation-item-text">
+        {text}
+      </div>
+      <div className={styles.dataSubTitle} data-testid="sp-confirmation-item-subtext">
+        {subText}
+      </div>
+    </div>
+  </div>
+);
+
+interface StakePoolConfirmationBodyProps {
+  balance: Balance;
+  cardanoCoin: Wallet.CoinId;
+  fiatCurrency: CurrencyInfo;
+}
+interface SingleStakePoolConfirmationBodyProps extends StakePoolConfirmationBodyProps {
+  stakePool: LegacySelectedStakePoolDetails;
+}
+interface MultipleStakePoolConfirmationBodyProps extends StakePoolConfirmationBodyProps {
+  stakePools: Immutable<DelegationPortfolioStakePool[]>;
+}
+
+const SingleStakePoolConfirmationBody = ({
+  balance,
+  cardanoCoin,
+  fiatCurrency,
+  stakePool,
+}: SingleStakePoolConfirmationBodyProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.body}>
+      <div className={styles.item} data-testid="sp-confirmation-delegate-from-container">
+        <ItemStatRenderer img={Cardano} text={t('drawer.confirmation.cardanoName')} subText={cardanoCoin.symbol} />
+        <ItemStatRenderer
+          text={balance?.total?.coinBalance}
+          subText={`${balance?.total?.fiatBalance ?? '-'} ${fiatCurrency?.code}`}
+        />
+      </div>
+      <Icon style={{ color: '#702BED', fontSize: '24px', margin: '12px 0px' }} component={ArrowDown} />
+      <div className={styles.item} data-testid="sp-confirmation-delegate-to-container">
+        <ItemStatRenderer img={stakePool.logo} text={stakePool.name || '-'} subText={<span>{stakePool.ticker}</span>} />
+        <div className={styles.itemData}>
+          <Ellipsis beforeEllipsis={10} afterEllipsis={8} text={stakePool.id} ellipsisInTheMiddle />;
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const MultipleStakePoolConfirmationBody = ({
+  balance,
+  cardanoCoin,
+  fiatCurrency,
+  stakePools,
+}: MultipleStakePoolConfirmationBodyProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.body}>
+      <div className={styles.item} data-testid="sp-confirmation-delegate-from-container">
+        <ItemStatRenderer img={Cardano} text={t('drawer.confirmation.cardanoName')} subText={cardanoCoin.symbol} />
+        <ItemStatRenderer
+          text={balance?.total?.coinBalance}
+          subText={`${balance?.total?.fiatBalance ?? '-'} ${fiatCurrency?.code}`}
+        />
+      </div>
+      <Icon style={{ color: '#702BED', fontSize: '24px', margin: '12px 0px' }} component={ArrowDown} />
+      {stakePools.map((stakePool) => (
+        <div
+          key={stakePool.id}
+          className={cn(styles.item, styles.itemMulti)}
+          data-testid="sp-confirmation-delegate-to-container"
+        >
+          <ItemStatRenderer
+            img={stakePool.logo}
+            text={stakePool.name || '-'}
+            subText={<span>{stakePool.ticker}</span>}
+          />
+          <div className={styles.itemData}>
+            <Ellipsis beforeEllipsis={10} afterEllipsis={8} text={stakePool.id} ellipsisInTheMiddle />;
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
 export const StakePoolConfirmation = (): React.ReactElement => {
   const { t } = useTranslation();
   const { setIsBuildingTx, setStakingError, stakingError } = useStakePoolDetails();
@@ -46,18 +147,13 @@ export const StakePoolConfirmation = (): React.ReactElement => {
     walletStoreWalletUICardanoCoin: cardanoCoin,
     fetchCoinPricePriceResult: priceResult,
     delegationStoreDelegationTxFee: delegationTxFee = '0',
-    delegationStoreSelectedStakePoolDetails: {
-      logo: poolLogo,
-      id: poolId,
-      ticker: poolTicker,
-      name: poolName,
-      // TODO: remove this dumb casting and solve the issue on a different level (components composition)
-    } = {} as SelectedStakePoolDetails,
+    delegationStoreSelectedStakePoolDetails: selectedStakePool,
     delegationStoreSelectedStakePool: openPool,
     currencyStoreFiatCurrency: fiatCurrency,
     delegationStoreSetDelegationTxBuilder: setDelegationTxBuilder,
     delegationStoreSetDelegationTxFee: setDelegationTxFee,
   } = useOutsideHandles();
+  const draftPortfolio = useDelegationPortfolioStore((store) => store.draftPortfolio);
 
   useEffect(() => {
     (async () => {
@@ -84,7 +180,6 @@ export const StakePoolConfirmation = (): React.ReactElement => {
     })();
   }, [inMemoryWallet, openPool, setDelegationTxBuilder, setDelegationTxFee, setIsBuildingTx, setStakingError]);
 
-  const stakePoolName = poolName ?? '-';
   const protocolParameters = useObservable(inMemoryWallet?.protocolParameters$);
   const rewardAccounts = useObservable(inMemoryWallet.delegation.rewardAccounts$);
   const deposit =
@@ -97,22 +192,7 @@ export const StakePoolConfirmation = (): React.ReactElement => {
     [StakingError.UTXO_BALANCE_INSUFFICIENT]: t('drawer.confirmation.errors.utxoBalanceInsufficient'),
   };
 
-  const ItemStatRenderer = ({ img, text, subText }: statRendererProps) => (
-    <div>
-      {img && <img data-testid="sp-confirmation-item-logo" src={img} alt="confirmation item" />}
-      <div className={styles.itemData}>
-        <div className={styles.dataTitle} data-testid="sp-confirmation-item-text">
-          {text}
-        </div>
-        <div className={styles.dataSubTitle} data-testid="sp-confirmation-item-subtext">
-          {subText}
-        </div>
-      </div>
-    </div>
-  );
-
   const loading = isNil(inMemoryWallet.protocolParameters$) || isNil(inMemoryWallet.delegation.rewardAccounts$);
-  const stakePoolAddress = <Ellipsis beforeEllipsis={10} afterEllipsis={8} text={poolId} ellipsisInTheMiddle />;
 
   return (
     <>
@@ -131,25 +211,23 @@ export const StakePoolConfirmation = (): React.ReactElement => {
       )}
       <div className={styles.container} data-testid="sp-confirmation-container">
         <Skeleton loading={loading}>
-          <div className={styles.body}>
-            <div className={styles.item} data-testid="sp-confirmation-delegate-from-container">
-              <ItemStatRenderer
-                img={Cardano}
-                text={t('drawer.confirmation.cardanoName')}
-                subText={cardanoCoin.symbol}
+          {draftPortfolio.length > 0 ? (
+            <MultipleStakePoolConfirmationBody
+              stakePools={draftPortfolio}
+              balance={balance}
+              cardanoCoin={cardanoCoin}
+              fiatCurrency={fiatCurrency}
+            />
+          ) : (
+            !!selectedStakePool && (
+              <SingleStakePoolConfirmationBody
+                stakePool={selectedStakePool}
+                balance={balance}
+                cardanoCoin={cardanoCoin}
+                fiatCurrency={fiatCurrency}
               />
-              <ItemStatRenderer
-                text={balance?.total?.coinBalance}
-                subText={`${balance?.total?.fiatBalance ?? '-'} ${fiatCurrency?.code}`}
-              />
-            </div>
-            <Icon style={{ color: '#702BED', fontSize: '24px', margin: '12px 0px' }} component={ArrowDown} />
-            <div className={styles.item} data-testid="sp-confirmation-delegate-to-container">
-              <ItemStatRenderer img={poolLogo} text={stakePoolName} subText={<span>{poolTicker}</span>} />
-              <div className={styles.itemData}>{stakePoolAddress}</div>
-            </div>
-          </div>
-
+            )
+          )}
           <h1 className={styles.totalCostTitle}>{t('drawer.confirmation.totalCost.title')}</h1>
           <div className={styles.txCostContainer} data-testid="summary-fee-container">
             {deposit && (

--- a/packages/staking/src/features/drawer/StakePoolDetail.tsx
+++ b/packages/staking/src/features/drawer/StakePoolDetail.tsx
@@ -6,7 +6,7 @@ import { TFunction } from 'i18next';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOutsideHandles } from '../outside-handles-provider';
-import { SelectedStakePoolDetails } from '../outside-handles-provider/types';
+import { LegacySelectedStakePoolDetails } from '../outside-handles-provider/types';
 import { MAX_POOLS_COUNT, useDelegationPortfolioStore, useStakePoolDetails } from '../store';
 import { SocialNetwork, SocialNetworkIcon } from './SocialNetworks';
 import styles from './StakePoolDetail.module.scss';
@@ -30,7 +30,7 @@ export const StakePoolDetail = (): React.ReactElement => {
       ticker,
       status,
       contact,
-    } = {} as SelectedStakePoolDetails,
+    } = {} as LegacySelectedStakePoolDetails,
     openExternalLink,
     walletStoreWalletUICardanoCoin,
   } = useOutsideHandles();
@@ -176,7 +176,7 @@ type StakePoolDetailFooterProps = {
 type SelectorParams = Parameters<Parameters<typeof useDelegationPortfolioStore>[0]>[0];
 
 const makeSelector =
-  (openPool?: SelectedStakePoolDetails) =>
+  (openPool?: LegacySelectedStakePoolDetails) =>
   ({ currentPortfolio, draftPortfolio }: SelectorParams) => {
     const poolInCurrentPortfolio =
       !!openPool && currentPortfolio.some(({ id }) => id === Wallet.Cardano.PoolIdHex(openPool.hexId));
@@ -269,9 +269,10 @@ export const StakePoolDetailFooter = ({ onStake, canDelegate }: StakePoolDetailF
 
   const onSelectPool = useCallback(() => {
     if (!openPool) return;
-    const { hexId, name, ticker } = openPool;
+    const { hexId, name, ticker, logo } = openPool;
     portfolioMutators.addPoolToDraft({
       id: Wallet.Cardano.PoolIdHex(hexId),
+      logo,
       name,
       ticker,
       weight: 1,

--- a/packages/staking/src/features/outside-handles-provider/types.ts
+++ b/packages/staking/src/features/outside-handles-provider/types.ts
@@ -1,7 +1,7 @@
 import { TxBuilder } from '@cardano-sdk/tx-construction';
 import { Wallet } from '@lace/cardano';
 
-export type SelectedStakePoolDetails = {
+export type LegacySelectedStakePoolDetails = {
   delegators: number | string;
   description: string;
   hexId: string;
@@ -24,7 +24,7 @@ type WalletBalance = {
   fiatBalance: string | undefined;
 };
 
-type Balance = {
+export type Balance = {
   total: WalletBalance;
   available: WalletBalance;
 };
@@ -42,7 +42,7 @@ export type OutsideHandlesContextValue = {
     lastReward: BigInt | number;
   };
   delegationDetails: Wallet.Cardano.StakePool;
-  delegationStoreSelectedStakePoolDetails?: SelectedStakePoolDetails;
+  delegationStoreSelectedStakePoolDetails?: LegacySelectedStakePoolDetails;
   delegationStoreSelectedStakePool?: Wallet.Cardano.StakePool;
   delegationStoreSetDelegationTxBuilder: (txBuilder?: TxBuilder) => void;
   delegationStoreSetSelectedStakePool: (pool: Wallet.Cardano.StakePool & { logo: string }) => void;

--- a/packages/staking/src/features/staking/PortfolioBar.tsx
+++ b/packages/staking/src/features/staking/PortfolioBar.tsx
@@ -1,6 +1,7 @@
 import { Button, Card, Flex, Text } from '@lace/ui';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MAX_POOLS_COUNT, selectDraftPoolsCount, useDelegationPortfolioStore } from '../store';
+import { MAX_POOLS_COUNT, selectDraftPoolsCount, useDelegationPortfolioStore, useStakePoolDetails } from '../store';
 import ArrowRight from './arrow-right.svg';
 import * as styles from './PortfolioBar.css';
 
@@ -10,6 +11,17 @@ export const PortfolioBar = () => {
     portfolioMutators: store.mutators,
     selectedPoolsCount: selectDraftPoolsCount(store),
   }));
+  const { setIsDrawerVisible, setSection } = useStakePoolDetails();
+  const onStake = useCallback(() => {
+    // TODO: LW-7396 enable StakeConfirmation modal in the flow in the case of restaking
+    // if (isDelegating) {
+    //   setStakeConfirmationVisible(true);
+    //   return;
+    // }
+
+    setSection();
+    setIsDrawerVisible(true);
+  }, [setIsDrawerVisible, setSection]);
 
   if (selectedPoolsCount === 0) return null;
 
@@ -22,7 +34,7 @@ export const PortfolioBar = () => {
       </Text.Body.Normal>
       <Flex className={styles.buttons}>
         <Button.Secondary label="Clear" onClick={portfolioMutators.clearDraft} />
-        <Button.Primary label="Next" icon={<ArrowRight className={styles.nextIcon} />} />
+        <Button.Primary label="Next" icon={<ArrowRight className={styles.nextIcon} />} onClick={onStake} />
       </Flex>
     </Card.Elevated>
   );

--- a/packages/staking/src/features/store/types.ts
+++ b/packages/staking/src/features/store/types.ts
@@ -39,16 +39,20 @@ export interface StakePoolDetails {
   setStakingError: (error?: StakingError) => void;
 }
 
+export interface DelegationPortfolioStakePool extends Wallet.Cardano.Cip17Pool {
+  logo?: string;
+}
+
 export type DelegationPortfolioState = Immutable<{
-  draftPortfolio: Wallet.Cardano.Cip17Pool[];
-  currentPortfolio: Wallet.Cardano.Cip17Pool[];
+  draftPortfolio: DelegationPortfolioStakePool[];
+  currentPortfolio: DelegationPortfolioStakePool[];
 }>;
 
 type DelegationPortfolioMutators = {
   setCurrentPortfolio: (rewardAccountInfo?: Wallet.Cardano.RewardAccountInfo[]) => void;
-  addPoolToDraft: (pool: Wallet.Cardano.Cip17Pool) => void;
-  removePoolFromDraft: (params: Pick<Wallet.Cardano.Cip17Pool, 'id'>) => void;
-  updatePoolWeight: (params: Pick<Wallet.Cardano.Cip17Pool, 'id' | 'weight'>) => void;
+  addPoolToDraft: (pool: DelegationPortfolioStakePool) => void;
+  removePoolFromDraft: (params: Pick<DelegationPortfolioStakePool, 'id'>) => void;
+  updatePoolWeight: (params: Pick<DelegationPortfolioStakePool, 'id' | 'weight'>) => void;
   clearDraft: () => void;
 };
 


### PR DESCRIPTION
# Checklist

- [x] JIRA - 7094
- [x] Screenshots added.

---

## Proposed solution
Add support for displaying multiple stake pools in the confirmation step.

## Screenshots
![image](https://github.com/input-output-hk/lace/assets/17825044/58a7a3e1-8bfd-4a45-807d-d1d48960fa61)

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/942/5530072710/index.html) for [be112d35](https://github.com/input-output-hk/lace/pull/256/commits/be112d35b34a15d37f3902148a13a4bb94738767)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 1      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->