### PR TITLE
Change copy for hardware wallet setup steps

### DIFF
--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -1119,11 +1119,13 @@
       "personalData": "Not sell your personal data"
     },
     "walletSetupConnectHardwareWalletStep": {
-      "title": "Connect Hardware Wallet",
+      "title": "Connect hardware wallet",
       "subTitle": "Choose the brand of your hardware wallet.",
-      "supportedDevicesFull": "Lace is supporting Ledger Nano X, Nano S, Nano S Plus and Trezor Model T",
+      "subTitleFull": "Select your hardware wallet brand",
+      "supportedDevicesFull": "Lace supports Ledger Nano X, Nano S, Nano S Plus, and Trezor Model T",
       "supportedDevices": "Lace is supporting Ledger Nano X, Nano S and Nano S Plus",
-      "connectDevice": "Just connect your device to your computer, unlock and open the Cardano app to hit continue."
+      "connectDevice": "Just connect your device to your computer, unlock and open the Cardano app to hit continue.",
+      "connectDeviceFull": "Just connect your device to your computer and unlock it to continue. If you're using a Ledger device, make sure you open the Cardano App."
     },
     "walletSetupCreateStep": {
       "title": "Creating your wallet",
@@ -1198,7 +1200,7 @@
       "selectAccount": "Select Account",
       "exportKeys": "Next",
       "chooseAccountToExport": "Choose which account you would like to export.",
-      "useHWToConfirm": "Use your {{wallet}} device to confirm exporting keys",
+      "useHWToConfirm": "Use your device to confirm the export of your public key",
       "account": "Account"
     },
     "walletSetupWalletNameStep": {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -99,11 +99,13 @@ export const HardwareWalletFlow = ({
 
   const walletSetupConnectHardwareWalletStepTranslations = {
     title: t('core.walletSetupConnectHardwareWalletStep.title'),
-    subTitle: t('core.walletSetupConnectHardwareWalletStep.subTitle'),
+    subTitle: t(`core.walletSetupConnectHardwareWalletStep.${isTrezorHWSupported() ? 'subTitleFull' : 'subTitle'}`),
     supportedDevices: t(
       `core.walletSetupConnectHardwareWalletStep.${isTrezorHWSupported() ? 'supportedDevicesFull' : 'supportedDevices'}`
     ),
-    connectDevice: t('core.walletSetupConnectHardwareWalletStep.connectDevice')
+    connectDevice: t(
+      `core.walletSetupConnectHardwareWalletStep.${isTrezorHWSupported() ? 'connectDeviceFull' : 'connectDevice'}`
+    )
   };
 
   const walletSetupFinalStepTranslations = {

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupSelectAccountsStep.module.scss
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupSelectAccountsStep.module.scss
@@ -68,4 +68,5 @@
   font-size: var(--bodySmall);
   line-height: size_unit(3);
   margin-bottom: size_unit(5);
+  padding-left: 44px;
 }


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-6558](https://input-output.atlassian.net/browse/LW-6558) | [LW-6557](https://input-output.atlassian.net/browse/LW-6557)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR changes the copy for **Connect hardware wallet** and **Select Account** steps in onboarding flow.

Also address a small alignment issue with _Use your device to confirm the export of your public key_ text in **Select Account** step.

## Testing

To be able see the changes on **Connect hardware wallet** step, the `USE_TREZOR_HW` env variable should be set to `true`, otherwise, the previous copy will be visible

For **Select Account** step it is necessary to connect HW to be able to see this step

## Screenshots

<img width="879" alt="Screenshot 2023-07-12 at 16 46 56" src="https://github.com/input-output-hk/lace/assets/65184652/7b0d1b89-d99c-4ce2-91b3-385d1f96f3c4">

<img width="879" alt="Screenshot 2023-07-12 at 16 53 22" src="https://github.com/input-output-hk/lace/assets/65184652/842dd4f4-fffd-4215-a3a1-fbaeb7dd8d70">


[LW-6558]: https://input-output.atlassian.net/browse/LW-6558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LW-6557]: https://input-output.atlassian.net/browse/LW-6557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/954/5535974258/index.html) for [cc5b890d](https://github.com/input-output-hk/lace/pull/261/commits/cc5b890d9c292907bfa36f2b3c3ffb39b5a8c671)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 5      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->