### PR TITLE
test(extension): e2e - fix workflow when running multiple tags

### DIFF
--- a/.github/workflows/e2e-tests-linux.yml
+++ b/.github/workflows/e2e-tests-linux.yml
@@ -80,9 +80,10 @@ jobs:
           if [ "$TAGS" == "empty" ]; then
             TAGS_TO_RUN="";
           else
-            TAGS_TO_RUN="--cucumberOpts.tagExpression=${TAGS}";
+            TAGS_TO_RUN="--cucumberOpts.tagExpression='${{ env.TAGS }}'";
           fi
-          ./node_modules/.bin/wdio run wdio.conf.${BROWSER}.ts $TAGS_TO_RUN
+          runCommand="./node_modules/.bin/wdio run wdio.conf.${BROWSER}.ts ${TAGS_TO_RUN}"
+          eval "$runCommand";
       - name: Create allure properties
         if: always()
         working-directory: ./packages/e2e-tests/reports/allure/results

--- a/.github/workflows/e2e-tests-win.yml
+++ b/.github/workflows/e2e-tests-win.yml
@@ -126,9 +126,11 @@ jobs:
           if [ "$TAGS" == "empty" ]; then
             TAGS_TO_RUN="";
           else
-            TAGS_TO_RUN="--cucumberOpts.tagExpression=${TAGS}";
+            TAGS_TO_RUN="--cucumberOpts.tagExpression='${{ env.TAGS }}'";
           fi
           ./node_modules/.bin/wdio run wdio.conf.${BROWSER}.ts $TAGS_TO_RUN
+          runCommand="./node_modules/.bin/wdio run wdio.conf.${BROWSER}.ts ${TAGS_TO_RUN}"
+          eval "$runCommand";
       - name: Create allure properties
         if: always()
         working-directory: ./packages/e2e-tests/reports/allure/results


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/982/5552989810/index.html) for [092edfa2](https://github.com/input-output-hk/lace/pull/271/commits/092edfa208a799fe1e8aba9c12b84614400c8c58)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->