### PR TITLE
chore(extension): add unit tests for analytics tracker class

### DIFF
--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.test.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.test.ts
@@ -1,0 +1,121 @@
+/* eslint-disable import/imports-first */
+const userIdServiceMock: UserIdService = {
+  getId: jest.fn(),
+  extendLifespan: jest.fn(),
+  makeTemporary: jest.fn(),
+  makePersistent: jest.fn(),
+  clearId: jest.fn()
+};
+
+import { Wallet } from '@lace/cardano';
+import { UserIdService } from '@lib/scripts/types';
+import { getUserIdService } from '@providers/AnalyticsProvider/getUserIdService';
+import { MatomoClient } from '@providers/AnalyticsProvider/matomo';
+import { PostHogClient } from '@providers/AnalyticsProvider/postHog';
+import {
+  AnalyticsEventActions,
+  AnalyticsEventCategories,
+  AnalyticsTracker,
+  EnhancedAnalyticsOptInStatus,
+  PostHogAction
+} from '.';
+
+jest.mock('../matomo/MatomoClient');
+jest.mock('../posthog/PostHogClient');
+jest.mock('../getUserIdService', () => ({
+  getUserIdService: jest.fn().mockReturnValue(userIdServiceMock)
+}));
+
+describe('AnalyticsTracker', () => {
+  const preprodChain = Wallet.Cardano.ChainIds.Preprod;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('construction', () => {
+    it('should setup both clients with the user id service', () => {
+      // eslint-disable-next-line no-new
+      new AnalyticsTracker(preprodChain, false, true);
+      expect(getUserIdService).toHaveBeenCalledTimes(1);
+      expect(MatomoClient).toHaveBeenCalledWith(preprodChain, userIdServiceMock);
+      expect(PostHogClient).toHaveBeenCalledWith(preprodChain, userIdServiceMock);
+    });
+    it('should only setup matomo client if posthog is disabled', () => {
+      // eslint-disable-next-line no-new
+      new AnalyticsTracker(preprodChain, false, false);
+      expect(getUserIdService).toHaveBeenCalledTimes(1);
+      expect(MatomoClient).toHaveBeenCalledWith(preprodChain, userIdServiceMock);
+      expect(PostHogClient).not.toHaveBeenCalled();
+    });
+    it('should not setup anything if analytics are disabled', () => {
+      // eslint-disable-next-line no-new
+      new AnalyticsTracker(preprodChain, true);
+      expect(getUserIdService).not.toHaveBeenCalled();
+      expect(MatomoClient).not.toHaveBeenCalled();
+      expect(PostHogClient).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setOptedInForEnhancedAnalytics', () => {
+    it('should make the user id persistent if user opted-in', async () => {
+      const tracker = new AnalyticsTracker(preprodChain);
+      await tracker.setOptedInForEnhancedAnalytics(EnhancedAnalyticsOptInStatus.OptedIn);
+      expect(userIdServiceMock.makePersistent).toHaveBeenCalledTimes(1);
+    });
+    it('should make the user id temporary if user opted-out', async () => {
+      const tracker = new AnalyticsTracker(preprodChain);
+      await tracker.setOptedInForEnhancedAnalytics(EnhancedAnalyticsOptInStatus.OptedOut);
+      expect(userIdServiceMock.makeTemporary).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sendPageNavigationEvent', () => {
+    it('should use the posthog client to send a page navigation event', async () => {
+      const tracker = new AnalyticsTracker(preprodChain, false, true);
+      const mockedPostHogClient = (PostHogClient as jest.Mock<PostHogClient>).mock.instances[0];
+      await tracker.sendPageNavigationEvent();
+      expect(mockedPostHogClient.sendPageNavigationEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sendEvent', () => {
+    it('should use the matomo client to send an event', async () => {
+      const tracker = new AnalyticsTracker(preprodChain);
+      const mockedMatomoClient = (MatomoClient as jest.Mock<MatomoClient>).mock.instances[0];
+      const event = {
+        category: AnalyticsEventCategories.WALLET_RESTORE,
+        action: AnalyticsEventActions.CLICK_EVENT,
+        name: 'test'
+      };
+      await tracker.sendEvent(event);
+      expect(mockedMatomoClient.sendEvent).toHaveBeenCalledTimes(1);
+      expect(mockedMatomoClient.sendEvent).toHaveBeenCalledWith(event);
+      expect(userIdServiceMock.extendLifespan).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sendEventToPostHog', () => {
+    it('should use the posthog client to send an event', async () => {
+      const tracker = new AnalyticsTracker(preprodChain, false, true);
+      const mockedPostHogClient = (PostHogClient as jest.Mock<PostHogClient>).mock.instances[0];
+      const event = PostHogAction.OnboardingCreateClick;
+      await tracker.sendEventToPostHog(event);
+      expect(mockedPostHogClient.sendEvent).toHaveBeenCalledWith(event, {});
+      expect(mockedPostHogClient.sendEvent).toHaveBeenCalledTimes(1);
+      expect(userIdServiceMock.extendLifespan).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setChain', () => {
+    it('should set the chain on both clients', async () => {
+      const tracker = new AnalyticsTracker(preprodChain, false, true);
+      const mockedPostHogClient = (PostHogClient as jest.Mock<PostHogClient>).mock.instances[0];
+      const mockedMatomoClient = (MatomoClient as jest.Mock<MatomoClient>).mock.instances[0];
+      const previewChain = Wallet.Cardano.ChainIds.Preview;
+      await tracker.setChain(previewChain);
+      expect(mockedPostHogClient.setChain).toHaveBeenCalledWith(previewChain);
+      expect(mockedMatomoClient.setChain).toHaveBeenCalledWith(previewChain);
+    });
+  });
+});

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.ts
@@ -10,12 +10,12 @@ export class AnalyticsTracker {
   protected postHogClient?: PostHogClient;
   protected userIdService?: UserIdService;
 
-  constructor(chain: Wallet.Cardano.ChainId, analyticsDisabled: boolean) {
+  constructor(chain: Wallet.Cardano.ChainId, analyticsDisabled = false, isPostHogEnabled = POSTHOG_ENABLED) {
     if (analyticsDisabled) return;
     this.userIdService = getUserIdService();
     this.matomoClient = new MatomoClient(chain, this.userIdService);
 
-    if (POSTHOG_ENABLED) {
+    if (isPostHogEnabled) {
       this.postHogClient = new PostHogClient(chain, this.userIdService);
     }
   }

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/matomo/MatomoClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/matomo/MatomoClient.ts
@@ -24,15 +24,15 @@ export class MatomoClient {
     };
   }
 
-  sendPageNavigationEvent = async (pageTitle: string): Promise<void> => {
+  async sendPageNavigationEvent(pageTitle: string): Promise<void> {
     console.debug('[ANALYTICS] Logging page navigation event to Matomo', pageTitle);
     this.matomoTracker.track({
       ...(await this.getMetadata()),
       action_name: pageTitle
     });
-  };
+  }
 
-  sendEvent = async ({ category, action, name, value }: SendEventProps): Promise<void> => {
+  async sendEvent({ category, action, name, value }: SendEventProps): Promise<void> {
     const payload = {
       ...(await this.getMetadata()),
       ca: 1,
@@ -43,7 +43,7 @@ export class MatomoClient {
     };
     console.debug('[ANALYTICS] Logging event to Matomo', payload);
     this.matomoTracker.track(payload);
-  };
+  }
 
   setChain(chain: Wallet.Cardano.ChainId): void {
     const siteId = this.getMatomoSiteId(chain);

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -32,7 +32,7 @@ export class PostHogClient {
     });
   }
 
-  sendPageNavigationEvent = async (): Promise<void> => {
+  async sendPageNavigationEvent(): Promise<void> {
     if (!this.initialized) {
       await this.init();
     }
@@ -42,9 +42,9 @@ export class PostHogClient {
     posthog.capture('$pageview', {
       ...(await this.getEventMetadata())
     });
-  };
+  }
 
-  sendEvent = async (action: PostHogAction, properties: Record<string, string | boolean> = {}): Promise<void> => {
+  async sendEvent(action: PostHogAction, properties: Record<string, string | boolean> = {}): Promise<void> {
     if (!this.initialized) {
       await this.init();
     }
@@ -56,7 +56,7 @@ export class PostHogClient {
 
     console.debug('[ANALYTICS] Logging event to PostHog', action, payload);
     posthog.capture(String(action), payload);
-  };
+  }
 
   setChain(chain: Wallet.Cardano.ChainId): void {
     const token = this.getApiToken(chain);


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-6791
- [x] Proper tests implemented

---

## Proposed solution

Adds unit tests for the `AnalyticsTracker` class that routes analytics events to `PostHogClient` and `MatomoClient`

## Testing

`yarn test AnalyticsTracker.test.ts`

## Screenshots

Attach screenshots here if implementation involves some UI changes
