### PR TITLE
fix(staking): prevent retired indicator from being visible by default

### DIFF
--- a/packages/staking/src/features/i18n/translations/en.ts
+++ b/packages/staking/src/features/i18n/translations/en.ts
@@ -74,6 +74,7 @@ export const en: Translations = {
   'overview.stakingInfoCard.poolRetired': 'Pool retired',
   'overview.stakingInfoCard.poolSaturated': 'Pool over-saturated',
   'overview.stakingInfoCard.ros': 'ROS',
+  'overview.stakingInfoCard.tooltipFiatLabel': 'USD Value',
   'overview.stakingInfoCard.totalRewards': 'Total rewards',
   'overview.stakingInfoCard.totalStaked': 'Total staked',
   'overview.yourPoolsSection.heading': 'Your pools',

--- a/packages/staking/src/features/i18n/types.ts
+++ b/packages/staking/src/features/i18n/types.ts
@@ -132,6 +132,7 @@ type KeysStructure = {
       totalStaked: '';
       poolRetired: '';
       poolSaturated: '';
+      tooltipFiatLabel: '';
     };
     yourPoolsSection: {
       heading: '';

--- a/packages/staking/src/features/overview/staking-info-card/StakingInfoCard.tsx
+++ b/packages/staking/src/features/overview/staking-info-card/StakingInfoCard.tsx
@@ -80,7 +80,7 @@ export const StakingInfoCard = ({
   popupView,
   cardanoCoinSymbol,
   markerColor,
-  status = 'retired',
+  status,
 }: StakingInfoCardProps): React.ReactElement => {
   const { t } = useTranslation();
 

--- a/packages/staking/src/features/overview/staking-info-card/StatsTooltip.tsx
+++ b/packages/staking/src/features/overview/staking-info-card/StatsTooltip.tsx
@@ -1,5 +1,6 @@
 import { Tooltip as AntdTooltip } from 'antd';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import styles from './Stats.module.scss';
 
 export const Tooltip = ({
@@ -11,11 +12,12 @@ export const Tooltip = ({
   children: string | React.ReactElement | React.ReactNode;
   content?: React.ReactNode;
 }): React.ReactElement => {
+  const { t } = useTranslation();
   const body =
     content ||
     (title && (
       <>
-        <div>{'USD Value'}</div>
+        <div>{t('overview.stakingInfoCard.tooltipFiatLabel')}</div>
         <div>{title}</div>
       </>
     ));


### PR DESCRIPTION
# Checklist

- [x] JIRA - [\<link>](https://input-output.atlassian.net/browse/LW-7545)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Previous PR adding the saturation and retired indicators introduced a bug causing retired indicators being visible by default. Here this bug is eleminated.
Moreover one missing translation is added

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1053/5596372592/index.html) for [6a49338a](https://github.com/input-output-hk/lace/pull/289/commits/6a49338a8af2f256481981b431d43d80173cb114)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->