### PR TITLE
chore(all): run CI on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - 'release/**'

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -2,8 +2,6 @@ name: Smoke Tests
 
 on:
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
I'd like to propose to run continous integration and smoke tests for all PRs, not only those targetting `main`.

Rationale: although it's recommended to avoid creating dependencies between PRs, in rare cases, development teams need to work with stacked PRs. Examples include working with temporary integration branches or while making contributions into someone else's PR. When such a PR is open, several checks are ran against it, but not CI nor smoke tests, which could delay finding problems in code to a point when it's merged to main PR.  