### PR TITLE
chore/LW-7442 - Refactor format number utils

### DIFF
--- a/apps/browser-extension-wallet/src/api/transformers.ts
+++ b/apps/browser-extension-wallet/src/api/transformers.ts
@@ -9,7 +9,7 @@ import {
 } from '../types';
 import { Wallet } from '@lace/cardano';
 import { addEllipsis } from '@lace/common';
-import { formatNumber } from '../utils/format-number';
+import { getNumberWithUnit } from '../utils/format-number';
 import { TxOutputInput, CoinItemProps } from '@lace/core';
 import { formatDate, formatTime } from '../utils/format-date';
 import { TokenInfo } from '@src/utils/get-assets-information';
@@ -40,7 +40,7 @@ export const networkInfoTransformer = (
   },
   poolStats: Wallet.StakePoolStats
 ): NetworkInformation => ({
-  totalStaked: formatNumber(Wallet.util.lovelacesToAdaString(stake.active.toString())),
+  totalStaked: getNumberWithUnit(Wallet.util.lovelacesToAdaString(stake.active.toString())),
   totalStakedPercentage:
     Number.parseInt(((stake.active * BigInt(coercionMult)) / lovelaceSupply.circulating).toString()) / coercionDiv,
   nextEpochIn: currentEpoch.lastSlot.date,

--- a/apps/browser-extension-wallet/src/features/delegation/stores/createDelegationStore.ts
+++ b/apps/browser-extension-wallet/src/features/delegation/stores/createDelegationStore.ts
@@ -4,7 +4,7 @@ import { Wallet } from '@lace/cardano';
 import { formatPercentages, getRandomIcon } from '@lace/common';
 import { CardanoStakePool } from '../../../types';
 import { DelegationStore, stakePoolDetailsSelectorProps } from '../types';
-import { formatNumber } from '@src/utils/format-number';
+import { getNumberWithUnit } from '@src/utils/format-number';
 import { TxBuilder } from '@cardano-sdk/tx-construction';
 
 export const stakePoolDetailsSelector: StateSelector<DelegationStore, stakePoolDetailsSelectorProps> = ({
@@ -37,7 +37,7 @@ DelegationStore): stakePoolDetailsSelectorProps => {
       owners: owners ? owners.map((owner: Wallet.Cardano.RewardAccount) => owner.toString()) : [],
       saturation: saturation && formatPercentages(saturation),
       stake: stake?.active
-        ? formatNumber(Wallet.util.lovelacesToAdaString(stake?.active?.toString()))
+        ? getNumberWithUnit(Wallet.util.lovelacesToAdaString(stake?.active?.toString()))
         : { number: '-' },
       ticker,
       status,

--- a/apps/browser-extension-wallet/src/utils/__tests__/assets-transformers.test.ts
+++ b/apps/browser-extension-wallet/src/utils/__tests__/assets-transformers.test.ts
@@ -268,7 +268,7 @@ describe('Testing assets transformers', () => {
       const variationParserSpy = jest.spyOn(assetsTransformers, 'variationParser');
       variationParserSpy.mockReturnValue('variationParser');
 
-      const compactNumberSpy = jest.spyOn(formatNumber, 'compactNumber');
+      const compactNumberSpy = jest.spyOn(formatNumber, 'compactNumberWithUnit');
       compactNumberSpy.mockReturnValue('compactNumberBalance');
 
       const mockedTokenBalance = '100';
@@ -326,7 +326,7 @@ describe('Testing assets transformers', () => {
     test('to see proper name, icon, decimals taken from tokenMetadata level', () => {
       const getAssetImageUrlSpy = jest.spyOn(getAssetImage, 'getAssetImageUrl');
       getAssetImageUrlSpy.mockImplementation((str: string) => str);
-      const compactNumberSpy = jest.spyOn(formatNumber, 'compactNumber');
+      const compactNumberSpy = jest.spyOn(formatNumber, 'compactNumberWithUnit');
       compactNumberSpy.mockReturnValue('tokenMetadatacCompactNumberBalance');
       const tokenMetadataName = 'tokenMetadataName';
       const tokenMetadataIcon = 'tokenMetadataIcon';
@@ -356,7 +356,7 @@ describe('Testing assets transformers', () => {
     test('to see proper name, icon, decimals taken from nftMetadata level', () => {
       const getAssetImageUrlSpy = jest.spyOn(getAssetImage, 'getAssetImageUrl');
       getAssetImageUrlSpy.mockImplementation((str: string) => str);
-      const compactNumberSpy = jest.spyOn(formatNumber, 'compactNumber');
+      const compactNumberSpy = jest.spyOn(formatNumber, 'compactNumberWithUnit');
       compactNumberSpy.mockReturnValue('nftMetadatacCompactNumberBalance');
       const nftMetadataName = 'nftMetadataName';
       const nftMetadataIcon = 'nftMetadataIcon';

--- a/apps/browser-extension-wallet/src/utils/__tests__/format-number.test.ts
+++ b/apps/browser-extension-wallet/src/utils/__tests__/format-number.test.ts
@@ -2,335 +2,281 @@
 import '@testing-library/jest-dom';
 import * as formatNumber from '../format-number';
 
-describe('Testing formatLocaleNumber', () => {
-  test('should return 10000.123 format to 10,000.12', async () => {
-    const result = formatNumber.formatLocaleNumber('10000.123', 1);
-
-    expect(result).toEqual('10,000.1');
-  });
-  test('should format 10000.123 with default decimals', async () => {
-    const result = formatNumber.formatLocaleNumber('10000.123');
-
-    expect(result).toEqual('10,000.12');
-  });
-});
-
-describe('Testing isNumeric', () => {
-  test('isNumeric', async () => {
-    expect(formatNumber.isNumeric('asd')).toEqual(false);
-    expect(formatNumber.isNumeric('')).toEqual(false);
-    expect(formatNumber.isNumeric('11a')).toEqual(true);
-    expect(formatNumber.isNumeric('111.123a')).toEqual(true);
-    expect(formatNumber.isNumeric('111')).toEqual(true);
-    expect(formatNumber.isNumeric('111.123')).toEqual(true);
-    expect(formatNumber.isNumeric('111.123.123')).toEqual(true);
-  });
-});
-
-describe('Testing formatNumber', () => {
-  test('should return 10000 format to 10.2K', async () => {
-    const result = formatNumber.formatNumber('10200');
-
-    expect(result).toEqual({ number: '10.2', unit: 'K' });
-  });
-
-  test('should return 1200 format to 1.2K', async () => {
-    const result = formatNumber.formatNumber('1200');
-
-    expect(result).toEqual({ number: '1.2', unit: 'K' });
-  });
-
-  test('should return same value in case of NaN', async () => {
-    const result = formatNumber.formatNumber('asd');
-
-    expect(result).toEqual({ number: 'asd' });
-  });
-
-  test('should format 999 to 999', async () => {
-    const result = formatNumber.formatNumber('999');
-
-    expect(result).toEqual({ number: '999', unit: '' });
-  });
-
-  test('should format 1 to 1.00', async () => {
-    const result = formatNumber.compactNumber('1');
-
-    expect(result).toEqual('1.00');
-  });
-
-  test('should default to 0', async () => {
-    const result = formatNumber.compactNumber('');
-
-    expect(result).toEqual('0.00');
-  });
-
-  test('should return 0 in case the value is NaN', async () => {
-    const result = formatNumber.compactNumber('a');
-
-    expect(result).toEqual('0');
-  });
-
-  test('should format 10 to 10.00', async () => {
-    const result = formatNumber.compactNumber('10');
-
-    expect(result).toEqual('10.00');
-  });
-
-  test('should format 999999999 to 999.99M', async () => {
-    const result = formatNumber.compactNumber('999999999');
-
-    expect(result).toEqual('999.99M');
-  });
-
-  test('should format 999999933399 to 999.99B', async () => {
-    const result = formatNumber.compactNumber('999999933399');
-
-    expect(result).toEqual('999.99B');
-  });
-
-  test('should format 999999933333399 to 999.99T', async () => {
-    const result = formatNumber.compactNumber('999999933333399');
-
-    expect(result).toEqual('999.99T');
-  });
-
-  test('should format 999929922233333399 to 999.92Q', async () => {
-    const result = formatNumber.compactNumber('999929922233333399');
-
-    expect(result).toEqual('999.92Q');
-  });
-
-  test('should compact million properly', async () => {
-    const result = formatNumber.compactNumber('2000000');
-
-    expect(result).toEqual('2.00M');
-  });
-
-  test('should compact billion properly', async () => {
-    const result = formatNumber.compactNumber('5320000000');
-
-    expect(result).toEqual('5.32B');
-  });
-
-  test('should display number seperated by comma', async () => {
-    const result = formatNumber.compactNumber('40595');
-
-    expect(result).toEqual('40,595.00');
-  });
-
-  test('should compact trillion properly', async () => {
-    const result = formatNumber.compactNumber('40595000000000');
-
-    expect(result).toEqual('40.59T');
-  });
-
-  test('should compact quadrillion properly', async () => {
-    const result = formatNumber.compactNumber('49830000000000000');
-
-    expect(result).toEqual('49.83Q');
-  });
-
-  test('should compact the number which has more that 18 chars', async () => {
-    const result = formatNumber.compactNumber('10000000000000000000');
-
-    expect(result).toEqual('10,000.00Q');
-  });
-
-  test('compact function should round up decimal to 2dp', async () => {
-    const result = formatNumber.compactNumber('320.42343');
-
-    expect(result).toEqual('320.42');
-  });
-});
-
-describe('Testing formatValueToLocale function', () => {
-  let languageGetter: ReturnType<typeof jest.spyOn>;
-  const value = '10200';
-  beforeEach(() => {
-    languageGetter = jest.spyOn(window.navigator, 'language', 'get');
-  });
-
-  test('should use en locale by default', async () => {
-    const result = formatNumber.formatValueToLocale(value);
-    expect(result).toEqual('10,200.00');
-  });
-
-  // TODO: unskip when system locale formatting implemented
-  test.skip('Should format number with es locale and two decimal values', async () => {
-    languageGetter.mockReturnValue('es');
-    const result = formatNumber.formatValueToLocale(value);
-    expect(result).toEqual('10.200,00');
-  });
-
-  test('Should format number with en locale and two decimal values', async () => {
-    languageGetter.mockReturnValue('en');
-    const result = formatNumber.formatValueToLocale(value);
-    expect(result).toEqual('10,200.00');
-  });
-
-  test('should not use 1 as maximumFractionDigits as default is 2, number should have 2 decimal places', async () => {
-    const result = formatNumber.formatValueToLocale(value, 1);
-    expect(result).toEqual('10,200.00');
-  });
-
-  test('should have 6 decimal places', async () => {
-    const decimalPlaces = 6;
-    const result = formatNumber.formatValueToLocale('10.9283627182', decimalPlaces);
-    const decimalsLength = result.split('.')[1].length;
-    expect(decimalsLength).toEqual(decimalPlaces);
-  });
-
-  test('should default to max 15 decimal places', async () => {
-    const decimalPlaces = 30;
-    const result = formatNumber.formatValueToLocale('10.9283627182928362718292836271829283627182', decimalPlaces);
-    const decimalsLength = result.split('.')[1].length;
-    expect(decimalsLength).toEqual(15);
-  });
-});
-
-describe('Testing shortenNumber', () => {
-  test('shortenNumber', () => {
-    expect(formatNumber.shortenNumber('123', 2)).toEqual(`${'123'.slice(0, Math.max(0, 2))}`);
-    expect(formatNumber.shortenNumber('12', 2)).toEqual('12');
-  });
-});
-
-describe('Testing getInlineCurrencyFormat', () => {
-  test('getInlineCurrencyFormat', () => {
-    expect(formatNumber.getInlineCurrencyFormat('')).toEqual('0');
-    expect(formatNumber.getInlineCurrencyFormat('123a')).toEqual(
-      BigInt('123').toLocaleString('fullwide', { useGrouping: true })
-    );
-
-    const shortenNumberSpy = jest.spyOn(formatNumber, 'shortenNumber');
-
-    expect(formatNumber.getInlineCurrencyFormat('123a.123', 1)).toEqual(
-      `${BigInt('123').toLocaleString('fullwide', {
-        useGrouping: true
-      })}.1`
-    );
-    expect(shortenNumberSpy).toBeCalledTimes(1);
-    expect(shortenNumberSpy).toBeCalledWith('123', 1);
-    shortenNumberSpy.mockClear();
-
-    expect(formatNumber.getInlineCurrencyFormat('123a.123.123', 1)).toEqual(
-      `${BigInt('123').toLocaleString('fullwide', {
-        useGrouping: true
-      })}.${'123123'}`
-    );
-    shortenNumberSpy.mockClear();
-
-    expect(formatNumber.getInlineCurrencyFormat('123a.123.123')).toEqual(
-      BigInt('123').toLocaleString('fullwide', {
-        useGrouping: true
-      })
-    );
-  });
-});
-
-describe('Testing getChangedValue', () => {
-  test('should remove prev number if current removed value is comma', () => {
-    expect(
-      formatNumber.getChangedValue({
-        currentCursorPosition: 3,
-        currentDisplayValue: '123456,789',
-        displayValue: '123,456,789'
-      })
-    ).toEqual({
-      currentDisplayValue: '12456,789',
-      value: '12456789',
-      currentCursorPosition: 2
-    });
-  });
-  test('should return changed calue otherwise', () => {
-    expect(
-      formatNumber.getChangedValue({
-        currentCursorPosition: 3,
-        currentDisplayValue: '12456,789',
-        displayValue: '123,456,789'
-      })
-    ).toEqual({
-      currentDisplayValue: '12456,789',
-      value: '12456789',
-      currentCursorPosition: 3
+describe('format-number utils', () => {
+  describe('shortenNumber', () => {
+    test('shortens a number string to the new desired length', () => {
+      expect(formatNumber.shortenNumber('1234', 2)).toEqual('12');
     });
 
-    expect(
-      formatNumber.getChangedValue({
-        currentCursorPosition: 3,
-        currentDisplayValue: '12356,789',
-        displayValue: '123,456,789'
-      })
-    ).toEqual({
-      currentDisplayValue: '12356,789',
-      value: '12356789',
-      currentCursorPosition: 3
+    test('returns the same string if the new length is equal or greater than the string length', () => {
+      expect(formatNumber.shortenNumber('1234', 4)).toEqual('1234');
+      expect(formatNumber.shortenNumber('123', 4)).toEqual('123');
+    });
+
+    test('ignores negative values or zero as the new length', () => {
+      expect(formatNumber.shortenNumber('12345', -2)).toEqual('12345');
+      expect(formatNumber.shortenNumber('12345', 0)).toEqual('12345');
     });
   });
-});
 
-describe('Testing getCaretPositionForFormattedCurrency', () => {
-  test('should return current cursor position in case of integer value', () => {
-    expect(
-      formatNumber.getCaretPositionForFormattedCurrency({
-        currentDisplayValue: '12,456,789',
-        displayValue: '124,567,89',
-        currentCursorPosition: 4
-      })
-    ).toEqual(4);
+  describe('isNumeric', () => {
+    test('returns false if the string is not a valid number', () => {
+      expect(formatNumber.isNumeric('asd')).toEqual(false);
+      expect(formatNumber.isNumeric('')).toEqual(false);
+      expect(formatNumber.isNumeric('11a')).toEqual(false);
+      expect(formatNumber.isNumeric('111.123t')).toEqual(false);
+      expect(formatNumber.isNumeric('111.123.123')).toEqual(false);
+      expect(formatNumber.isNumeric('200,000')).toEqual(false);
+    });
+    test('returns true if the string is a valid number', () => {
+      expect(formatNumber.isNumeric('200')).toEqual(true);
+      expect(formatNumber.isNumeric('-200')).toEqual(true);
+      expect(formatNumber.isNumeric('111.123')).toEqual(true);
+      expect(formatNumber.isNumeric('5e6')).toEqual(true); // 5_000_000
+    });
   });
-  test('should return same cursor position in case of integer value', () => {
-    expect(
-      formatNumber.getCaretPositionForFormattedCurrency({
-        currentDisplayValue: '1234',
-        displayValue: '1,234',
-        currentCursorPosition: 1
-      })
-    ).toEqual(2);
+
+  describe('formatLocaleNumber', () => {
+    test('uses "." to separate decimals and "," to separate groups of 3 digits', () => {
+      expect(formatNumber.formatLocaleNumber('1000000.55', 2)).toEqual('1,000,000.55');
+    });
+    describe('formats the number with the desired amount of decimals', () => {
+      test('rounds number to 0 if the original value has more decimals than desired', () => {
+        expect(formatNumber.formatLocaleNumber('999.99', 1)).toEqual('999.9'); // does not round up
+        expect(formatNumber.formatLocaleNumber('999.44', 1)).toEqual('999.4');
+      });
+      test('fills with zeroes if the amount of desired decimals is greater than in the original value', () => {
+        expect(formatNumber.formatLocaleNumber('999.999', 4)).toEqual('999.9990');
+        expect(formatNumber.formatLocaleNumber('999', 4)).toEqual('999.0000'); // no decimals in original
+      });
+      test('defaults to 2 decimals if no amount for decimal places was provided', () => {
+        expect(formatNumber.formatLocaleNumber('100')).toEqual('100.00');
+      });
+      test('no decimal part if 0 is the desired amount', () => {
+        expect(formatNumber.formatLocaleNumber('500.999', 0)).toEqual('500');
+      });
+      test('works with negative values', () => {
+        expect(formatNumber.formatLocaleNumber('-999.999')).toEqual('-999.99');
+        expect(formatNumber.formatLocaleNumber('-100.12')).toEqual('-100.12');
+        expect(formatNumber.formatLocaleNumber('-100')).toEqual('-100.00');
+      });
+    });
   });
-  test('should return current cursor position in case of float value with last changed deciaml part ', () => {
-    expect(
-      formatNumber.getCaretPositionForFormattedCurrency({
-        currentDisplayValue: '123,456,789.12456',
-        displayValue: '123,456,789.12456',
-        currentCursorPosition: 14
-      })
-    ).toEqual(14);
+
+  describe('getNumberWithUnit', () => {
+    test('formats a number rounding up to 2 decimal places according to its unit', () => {
+      expect(formatNumber.getNumberWithUnit('10234')).toEqual({ number: '10.23', unit: 'K' });
+      expect(formatNumber.getNumberWithUnit('10235')).toEqual({ number: '10.24', unit: 'K' });
+      expect(formatNumber.getNumberWithUnit('10235000')).toEqual({ number: '10.24', unit: 'M' });
+      expect(formatNumber.getNumberWithUnit('10235000000')).toEqual({ number: '10.24', unit: 'B' });
+      expect(formatNumber.getNumberWithUnit('10235000000000')).toEqual({ number: '10.24', unit: 'T' });
+      expect(formatNumber.getNumberWithUnit('10235000000000000')).toEqual({ number: '10.24', unit: 'Q' });
+    });
+
+    test(
+      'formats a number rounding up to 2 decimal places and returns an empty string as the unit ' +
+        'when the number is less than 1000',
+      () => {
+        expect(formatNumber.getNumberWithUnit('999')).toEqual({ number: '999', unit: '' });
+        expect(formatNumber.getNumberWithUnit('999.99')).toEqual({ number: '999.99', unit: '' });
+        expect(formatNumber.getNumberWithUnit('999.991')).toEqual({ number: '999.99', unit: '' });
+        expect(formatNumber.getNumberWithUnit('999.999')).toEqual({ number: '1000', unit: '' });
+      }
+    );
+
+    test('returns the same value and no unit in case of a NaN value', () => {
+      expect(formatNumber.getNumberWithUnit('asd')).toEqual({ number: 'asd' });
+    });
+
+    test('formats negatives and decimal values', () => {
+      expect(formatNumber.getNumberWithUnit('-912180')).toEqual({ number: '-912.18', unit: 'K' });
+      expect(formatNumber.getNumberWithUnit('123452.2222')).toEqual({ number: '123.45', unit: 'K' });
+      expect(formatNumber.getNumberWithUnit('123455.5555')).toEqual({ number: '123.46', unit: 'K' });
+    });
+
+    test('removes any leading or trailing zeroes while formatting', () => {
+      expect(formatNumber.getNumberWithUnit('0000010234')).toEqual({ number: '10.23', unit: 'K' });
+      expect(formatNumber.getNumberWithUnit('1000.00000')).toEqual({ number: '1', unit: 'K' });
+    });
   });
-  test('should return current cursor position in case of float value with last changed whole part ', () => {
-    expect(
-      formatNumber.getCaretPositionForFormattedCurrency({
-        currentDisplayValue: '12,456,789.12456',
-        displayValue: '124,567,89.12456',
-        currentCursorPosition: 4
-      })
-    ).toEqual(4);
+
+  describe('compactNumberWithUnit', () => {
+    test('completes the decimal part with the correct amount of zeroes', () => {
+      expect(formatNumber.compactNumberWithUnit('10')).toEqual('10.00');
+      expect(formatNumber.compactNumberWithUnit('10', 3)).toEqual('10.000');
+      expect(formatNumber.compactNumberWithUnit('0.23', 4)).toEqual('0.2300');
+    });
+
+    test('truncates decimals to the desired amount', async () => {
+      expect(formatNumber.compactNumberWithUnit('100.123')).toEqual('100.12'); // 2 by default
+      expect(formatNumber.compactNumberWithUnit('100.999')).toEqual('100.99');
+      expect(formatNumber.compactNumberWithUnit('0.5009', 3)).toEqual('0.500');
+      expect(formatNumber.compactNumberWithUnit('100.999', 0)).toEqual('100');
+    });
+
+    test('returns zero when the given value is not defined, an empty string or NaN', () => {
+      expect(formatNumber.compactNumberWithUnit('')).toEqual('0.00');
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      expect(formatNumber.compactNumberWithUnit(undefined)).toEqual('0.00');
+      expect(formatNumber.compactNumberWithUnit('asd')).toEqual('0.00');
+    });
+
+    test('returns the compacted number with the corresponding decimals and unit when greater than one million', () => {
+      expect(formatNumber.compactNumberWithUnit('1000000')).toEqual('1.00M');
+      expect(formatNumber.compactNumberWithUnit('1000000000')).toEqual('1.00B');
+      expect(formatNumber.compactNumberWithUnit('1000000000000')).toEqual('1.00T');
+      expect(formatNumber.compactNumberWithUnit('1000000000000000')).toEqual('1.00Q');
+    });
+
+    test('separates thousands with commas', () => {
+      expect(formatNumber.compactNumberWithUnit('1000')).toEqual('1,000.00');
+      expect(formatNumber.compactNumberWithUnit('10000')).toEqual('10,000.00');
+      expect(formatNumber.compactNumberWithUnit('100000')).toEqual('100,000.00');
+    });
+
+    test('does not compact the number when it is less than one million', () => {
+      expect(formatNumber.compactNumberWithUnit('100')).toEqual('100.00');
+      expect(formatNumber.compactNumberWithUnit('1000')).toEqual('1,000.00');
+      expect(formatNumber.compactNumberWithUnit('999999')).toEqual('999,999.00');
+    });
+    test('should compact the number to quadrillion when its order of magnitude is 18 or higher', () => {
+      expect(formatNumber.compactNumberWithUnit(1e18)).toEqual('1,000.00Q');
+      expect(formatNumber.compactNumberWithUnit(1e21)).toEqual('1,000,000.00Q');
+      expect(formatNumber.compactNumberWithUnit(1e24)).toEqual('1,000,000,000.00Q');
+    });
+
+    test('does not lose any significant digits for big numbers', () => {
+      // Higher than the max Number for JS
+      const bigNumber = '123456789012345678901234567890123456789';
+      expect(formatNumber.compactNumberWithUnit(bigNumber)).toEqual('123,456,789,012,345,678,901,234.56Q');
+      // Number() loses significant digits after the 18th one
+      expect(formatNumber.compactNumberWithUnit(Number(bigNumber))).toEqual('123,456,789,012,345,680,000,000.00Q');
+    });
   });
-  test('should return proper cursor position in case of integer value', () => {
-    expect(
-      formatNumber.getCaretPositionForFormattedCurrency({
-        currentDisplayValue: '12,4',
-        displayValue: '124',
-        currentCursorPosition: 4
-      })
-    ).toEqual(3);
+
+  describe('formatNumberForDisplay', () => {
+    test('returns zero if value is undefined, an empty string or there are no digits', () => {
+      expect(formatNumber.formatNumberForDisplay('')).toEqual('0');
+      expect(formatNumber.formatNumberForDisplay('no numbers')).toEqual('0');
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      expect(formatNumber.formatNumberForDisplay(undefined)).toEqual('0');
+    });
+    describe('removes non-number digits except dots from the number string before formatting', () => {
+      test('formats a string with no dots or decimal parts', () => {
+        expect(formatNumber.formatNumberForDisplay('a1b2c3d4e5f6')).toEqual('123,456');
+        expect(formatNumber.formatNumberForDisplay('123456')).toEqual('123,456');
+        expect(formatNumber.formatNumberForDisplay('123')).toEqual('123');
+        expect(formatNumber.formatNumberForDisplay('abc')).toEqual('0');
+      });
+      test('only returns the integer part when a string with one or more dots and no max decimals are provided', () => {
+        // default max decimals = 0
+        expect(formatNumber.formatNumberForDisplay('123.abc')).toEqual('123');
+        expect(formatNumber.formatNumberForDisplay('abc.1234')).toEqual('0');
+        expect(formatNumber.formatNumberForDisplay('abc.def')).toEqual('0');
+        expect(formatNumber.formatNumberForDisplay('1a2b3.c4d56e')).toEqual('123');
+        expect(formatNumber.formatNumberForDisplay('1a2b3.c4d56e.f78g')).toEqual('123');
+      });
+      test('returns the whole formatted number when a string with one dot and max decimals > 0 are provided', () => {
+        // No numbers in decimal part -> Formats the integer part, keeps the dot and leaves the decimal part empty
+        expect(formatNumber.formatNumberForDisplay('123.abc', 3)).toEqual('123.');
+        // No numbers in integer part -> Replaces the integer part with 0, keeps the dot and formats the decimals
+        expect(formatNumber.formatNumberForDisplay('abc.1234', 3)).toEqual('0.123');
+        // Previous cases combined -> Replaces the integer part with 0, keeps the dot and leaves the decimal part empty
+        expect(formatNumber.formatNumberForDisplay('abc.def', 2)).toEqual('0.');
+        // Formats both parts
+        expect(formatNumber.formatNumberForDisplay('1a2b3.c4d56e', 2)).toEqual('123.45');
+      });
+      test('removes all extra dots when a string with more than one dot is provided', () => {
+        expect(formatNumber.formatNumberForDisplay('1.234.567', 6)).toEqual('1.234567');
+        expect(formatNumber.formatNumberForDisplay('1a2b3.c4d56e.f78g', 5)).toEqual('123.45678');
+        // Shortens the decimal part
+        expect(formatNumber.formatNumberForDisplay('123.456.789', 5)).toEqual('123.45678');
+        expect(formatNumber.formatNumberForDisplay('1.2.3.4.5.6.7', 4)).toEqual('1.2345');
+      });
+    });
   });
-  test('should return proper cursor position in case of integer value', () => {
-    expect(
-      formatNumber.getCaretPositionForFormattedCurrency({
-        currentDisplayValue: '1234',
-        displayValue: '123,4',
-        currentCursorPosition: 4
-      })
-    ).toEqual(5);
-  });
-  test('should return proper cursor position in case of decimal value', () => {
-    expect(
-      formatNumber.getCaretPositionForFormattedCurrency({
-        currentDisplayValue: '1234.567',
-        displayValue: '123,4.567',
-        currentCursorPosition: 4
-      })
-    ).toEqual(5);
+
+  describe('handleFormattedValueChange', () => {
+    test(
+      'if the difference between the new and the old formatted value is just one comma ' +
+        'then returns the value without the number before the comma and -1 as character offset',
+      () => {
+        expect(
+          formatNumber.handleFormattedValueChange({
+            newFormattedValue: '123456,789',
+            previousFormattedValue: '123,456,789'
+          })
+        ).toEqual({ formattedValue: '12,456,789', value: '12456789', characterOffset: -1 });
+      }
+    );
+
+    test(
+      'if there is no difference between the new and the old formatted value ' +
+        'then returns the new value formatted and zero as character offset',
+      () => {
+        expect(
+          formatNumber.handleFormattedValueChange({
+            newFormattedValue: '123,456,789',
+            previousFormattedValue: '123,456,789'
+          })
+        ).toEqual({ formattedValue: '123,456,789', value: '123456789', characterOffset: 0 });
+      }
+    );
+
+    test(
+      'if the difference between the new and the old formatted value is not just one comma ' +
+        'then returns the new value formatted and the difference in length between formatted values as offset',
+      () => {
+        expect(
+          formatNumber.handleFormattedValueChange({
+            newFormattedValue: '123,56,789', // missing a number (4)
+            previousFormattedValue: '123,456,789'
+          })
+        ).toEqual({ formattedValue: '12,356,789', value: '12356789', characterOffset: 0 });
+
+        expect(
+          formatNumber.handleFormattedValueChange({
+            newFormattedValue: '123456789', // missing both commas
+            previousFormattedValue: '123,456,789'
+          })
+        ).toEqual({ formattedValue: '123,456,789', value: '123456789', characterOffset: 2 });
+
+        expect(
+          formatNumber.handleFormattedValueChange({
+            newFormattedValue: '123456,78', // missing a comma and a number (9)
+            previousFormattedValue: '123,456,789'
+          })
+        ).toEqual({ formattedValue: '12,345,678', value: '12345678', characterOffset: 1 });
+      }
+    );
+
+    test('when comma deletion occurs at index 0 returns the new value formatted and 0 as the new cursor position', () => {
+      expect(
+        formatNumber.handleFormattedValueChange({ newFormattedValue: '123,456', previousFormattedValue: ',123,456' })
+      ).toEqual({ formattedValue: '123,456', value: '123456', characterOffset: 0 });
+    });
+
+    test('works properly if one of the values or both are empty strings', () => {
+      expect(
+        formatNumber.handleFormattedValueChange({ newFormattedValue: '', previousFormattedValue: '123,456,789' })
+      ).toEqual({ formattedValue: '', value: '', characterOffset: 0 });
+
+      expect(
+        formatNumber.handleFormattedValueChange({ newFormattedValue: '123,456,789', previousFormattedValue: '' })
+      ).toEqual({ formattedValue: '123,456,789', value: '123456789', characterOffset: 0 });
+
+      expect(formatNumber.handleFormattedValueChange({ newFormattedValue: '', previousFormattedValue: '' })).toEqual({
+        formattedValue: '',
+        value: '',
+        characterOffset: 0
+      });
+
+      // Old value is just a comma, new value is an empty string. Deletes comma and returns 0 as character offset
+      expect(formatNumber.handleFormattedValueChange({ newFormattedValue: '', previousFormattedValue: ',' })).toEqual({
+        formattedValue: '',
+        value: '',
+        characterOffset: 0
+      });
+    });
   });
 });

--- a/apps/browser-extension-wallet/src/utils/__tests__/get-number-unit.test.ts
+++ b/apps/browser-extension-wallet/src/utils/__tests__/get-number-unit.test.ts
@@ -1,48 +1,121 @@
 /* eslint-disable no-magic-numbers */
 import '@testing-library/jest-dom';
 import BigNumber from 'bignumber.js';
-import { unitsMap } from '../constants';
-import { getNumberUnit } from '../get-number-unit';
+import { getNumberUnit, UnitSymbol, UnitThreshold } from '../get-number-unit';
 
-describe('Testing getNumberUnit component', () => {
-  test('should return empty string if it is less than 1000', async () => {
-    const keys = unitsMap.keys();
-    const result = getNumberUnit(new BigNumber('100'), keys);
-
-    expect(JSON.stringify(result)).toBe(JSON.stringify({ unit: '', unitThreshold: new BigNumber(0) }));
+describe('get-number-unit', () => {
+  describe('returns no unit and 0 as threshold', () => {
+    test('when absolute value is exactly 0', () => {
+      expect(getNumberUnit(0)).toEqual({ unit: UnitSymbol.ZERO, unitThreshold: UnitThreshold.ZERO });
+      expect(getNumberUnit('0')).toEqual({ unit: UnitSymbol.ZERO, unitThreshold: UnitThreshold.ZERO });
+      expect(getNumberUnit(UnitSymbol.ZERO)).toEqual({ unit: UnitSymbol.ZERO, unitThreshold: UnitThreshold.ZERO });
+    });
+    test('when absolute value is greater than 0 and less than 1000', () => {
+      expect(getNumberUnit(500)).toEqual({ unit: UnitSymbol.ZERO, unitThreshold: UnitThreshold.ZERO });
+      expect(getNumberUnit(-500)).toEqual({ unit: UnitSymbol.ZERO, unitThreshold: UnitThreshold.ZERO });
+      expect(getNumberUnit('999.99')).toEqual({ unit: UnitSymbol.ZERO, unitThreshold: UnitThreshold.ZERO });
+      expect(getNumberUnit('-999')).toEqual({ unit: UnitSymbol.ZERO, unitThreshold: UnitThreshold.ZERO });
+    });
+    test('when value is not a valid number', () => {
+      expect(getNumberUnit('NaN')).toEqual({ unit: UnitSymbol.ZERO, unitThreshold: UnitThreshold.ZERO });
+      expect(getNumberUnit(new BigNumber('something'))).toEqual({
+        unit: UnitSymbol.ZERO,
+        unitThreshold: UnitThreshold.ZERO
+      });
+    });
   });
 
-  test('should handle last iteration', async () => {
-    const keys = new Map().keys();
-    const result = getNumberUnit(new BigNumber('100'), keys);
-
-    expect(JSON.stringify(result)).toBe(JSON.stringify({ unit: 'B', unitThreshold: unitsMap.get('B').gt }));
+  describe('returns K as unit and 1000 as threshold', () => {
+    test('when absolute value is exactly 1000', () => {
+      expect(getNumberUnit(1000)).toEqual({ unit: UnitSymbol.THOUSAND, unitThreshold: UnitThreshold.THOUSAND });
+      expect(getNumberUnit(-1000)).toEqual({ unit: UnitSymbol.THOUSAND, unitThreshold: UnitThreshold.THOUSAND });
+      expect(getNumberUnit('1000')).toEqual({ unit: UnitSymbol.THOUSAND, unitThreshold: UnitThreshold.THOUSAND });
+    });
+    test('when absolute value is greater than 1000 and less than 1000000', () => {
+      expect(getNumberUnit(500_000)).toEqual({ unit: UnitSymbol.THOUSAND, unitThreshold: UnitThreshold.THOUSAND });
+      expect(getNumberUnit(-500_000)).toEqual({ unit: UnitSymbol.THOUSAND, unitThreshold: UnitThreshold.THOUSAND });
+      expect(getNumberUnit('999999.99')).toEqual({ unit: UnitSymbol.THOUSAND, unitThreshold: UnitThreshold.THOUSAND });
+      expect(getNumberUnit('-999999')).toEqual({ unit: UnitSymbol.THOUSAND, unitThreshold: UnitThreshold.THOUSAND });
+    });
   });
 
-  test('should return K when is greater-equal 1000 less 1000000', async () => {
-    const keys = unitsMap.keys();
-    const result = getNumberUnit(new BigNumber('10000'), keys);
-
-    expect(JSON.stringify(result)).toBe(JSON.stringify({ unit: 'K', unitThreshold: new BigNumber(1e3) }));
+  describe('returns M as unit and 1_000_000 as threshold', () => {
+    test('when absolute value is exactly 1_000_000', () => {
+      expect(getNumberUnit(1_000_000)).toEqual({ unit: UnitSymbol.MILLION, unitThreshold: UnitThreshold.MILLION });
+      expect(getNumberUnit(-1_000_000)).toEqual({ unit: UnitSymbol.MILLION, unitThreshold: UnitThreshold.MILLION });
+      expect(getNumberUnit('1000000')).toEqual({ unit: UnitSymbol.MILLION, unitThreshold: UnitThreshold.MILLION });
+    });
+    test('when absolute value is greater than 1_000_000 and less than 1_000_000_000', () => {
+      expect(getNumberUnit(500_000_000)).toEqual({ unit: UnitSymbol.MILLION, unitThreshold: UnitThreshold.MILLION });
+      expect(getNumberUnit(-500_000_000)).toEqual({ unit: UnitSymbol.MILLION, unitThreshold: UnitThreshold.MILLION });
+      expect(getNumberUnit('999999999.99')).toEqual({ unit: UnitSymbol.MILLION, unitThreshold: UnitThreshold.MILLION });
+      expect(getNumberUnit('-999999999')).toEqual({ unit: UnitSymbol.MILLION, unitThreshold: UnitThreshold.MILLION });
+    });
   });
 
-  test('should return M is greater-equal 1000000 less 1000000000', async () => {
-    const keys = unitsMap.keys();
-    const result = getNumberUnit(new BigNumber('10000000'), keys);
-
-    expect(JSON.stringify(result)).toBe(JSON.stringify({ unit: 'M', unitThreshold: new BigNumber(1e6) }));
+  describe('returns B as unit and 1_000_000_000 as threshold', () => {
+    test('when absolute value is exactly 1_000_000_000', () => {
+      expect(getNumberUnit(1e9)).toEqual({ unit: UnitSymbol.BILLION, unitThreshold: UnitThreshold.BILLION });
+      expect(getNumberUnit(-1e9)).toEqual({ unit: UnitSymbol.BILLION, unitThreshold: UnitThreshold.BILLION });
+      expect(getNumberUnit('1000000000')).toEqual({ unit: UnitSymbol.BILLION, unitThreshold: UnitThreshold.BILLION });
+    });
+    test('when absolute value is greater than 1_000_000_000 and less than 1_000_000_000_000', () => {
+      expect(getNumberUnit(5e11)).toEqual({ unit: UnitSymbol.BILLION, unitThreshold: UnitThreshold.BILLION });
+      expect(getNumberUnit(-5e11)).toEqual({ unit: UnitSymbol.BILLION, unitThreshold: UnitThreshold.BILLION });
+      expect(getNumberUnit('999999999999.99')).toEqual({
+        unit: UnitSymbol.BILLION,
+        unitThreshold: UnitThreshold.BILLION
+      });
+      expect(getNumberUnit('-999999999999')).toEqual({
+        unit: UnitSymbol.BILLION,
+        unitThreshold: UnitThreshold.BILLION
+      });
+    });
   });
 
-  test('should return B greater-equal than 1000000000', async () => {
-    const keys = unitsMap.keys();
-    const result = getNumberUnit(new BigNumber('10000000000'), keys);
-
-    expect(JSON.stringify(result)).toBe(JSON.stringify({ unit: 'B', unitThreshold: new BigNumber(1e9) }));
+  describe('returns T as unit and 1_000_000_000_000 as threshold', () => {
+    test('when absolute value is exactly 1_000_000_000_000', () => {
+      expect(getNumberUnit(1e12)).toEqual({ unit: UnitSymbol.TRILLION, unitThreshold: UnitThreshold.TRILLION });
+      expect(getNumberUnit(-1e12)).toEqual({ unit: UnitSymbol.TRILLION, unitThreshold: UnitThreshold.TRILLION });
+      expect(getNumberUnit('1000000000000')).toEqual({
+        unit: UnitSymbol.TRILLION,
+        unitThreshold: UnitThreshold.TRILLION
+      });
+    });
+    test('when absolute value is greater than 1_000_000_000_000 and less than 1_000_000_000_000_000', () => {
+      expect(getNumberUnit(5e14)).toEqual({ unit: UnitSymbol.TRILLION, unitThreshold: UnitThreshold.TRILLION });
+      expect(getNumberUnit(-5e14)).toEqual({ unit: UnitSymbol.TRILLION, unitThreshold: UnitThreshold.TRILLION });
+      expect(getNumberUnit('999999999999999.99')).toEqual({
+        unit: UnitSymbol.TRILLION,
+        unitThreshold: UnitThreshold.TRILLION
+      });
+      expect(getNumberUnit('-999999999999999')).toEqual({
+        unit: UnitSymbol.TRILLION,
+        unitThreshold: UnitThreshold.TRILLION
+      });
+    });
   });
 
-  test('should return T greater-equal than 10000000000000', async () => {
-    const keys = unitsMap.keys();
-    const result2 = getNumberUnit(new BigNumber('10000000000000'), keys);
-    expect(JSON.stringify(result2)).toBe(JSON.stringify({ unit: 'T', unitThreshold: new BigNumber(1e12) }));
+  describe('returns Q as unit and 1_000_000_000_000_000 as threshold', () => {
+    test('when absolute value is exactly 1_000_000_000_000_000', () => {
+      expect(getNumberUnit(1e15)).toEqual({ unit: UnitSymbol.QUADRILLION, unitThreshold: UnitThreshold.QUADRILLION });
+      expect(getNumberUnit(-1e15)).toEqual({ unit: UnitSymbol.QUADRILLION, unitThreshold: UnitThreshold.QUADRILLION });
+      expect(getNumberUnit('1000000000000000')).toEqual({
+        unit: UnitSymbol.QUADRILLION,
+        unitThreshold: UnitThreshold.QUADRILLION
+      });
+    });
+    test('when absolute value is greater than 1_000_000_000_000_000', () => {
+      expect(getNumberUnit(5e20)).toEqual({ unit: UnitSymbol.QUADRILLION, unitThreshold: UnitThreshold.QUADRILLION });
+      expect(getNumberUnit(-5e20)).toEqual({ unit: UnitSymbol.QUADRILLION, unitThreshold: UnitThreshold.QUADRILLION });
+      expect(getNumberUnit('1000000000000000000.999')).toEqual({
+        unit: UnitSymbol.QUADRILLION,
+        unitThreshold: UnitThreshold.QUADRILLION
+      });
+      expect(getNumberUnit('-1000000000000000000')).toEqual({
+        unit: UnitSymbol.QUADRILLION,
+        unitThreshold: UnitThreshold.QUADRILLION
+      });
+    });
   });
 });

--- a/apps/browser-extension-wallet/src/utils/assets-transformers.ts
+++ b/apps/browser-extension-wallet/src/utils/assets-transformers.ts
@@ -7,7 +7,7 @@ import { Wallet } from '@lace/cardano';
 
 import CardanoLogo from '../assets/icons/browser-view/cardano-logo.svg';
 import { AssetSortBy, IAssetDetails } from '@views/browser/features/assets/types';
-import { compactNumber, formatLocaleNumber, isNumeric } from '@src/utils/format-number';
+import { compactNumberWithUnit, formatLocaleNumber, isNumeric } from '@src/utils/format-number';
 import { addEllipsis, getRandomIcon } from '@lace/common';
 import { getAssetImageUrl } from '@src/utils/get-asset-image-url';
 import isNumber from 'lodash/isNumber';
@@ -106,7 +106,7 @@ export const assetTransformer = (params: {
     ticker,
     price,
     variation,
-    balance: areBalancesVisible ? compactNumber(tokenBalance, decimals) : balancesPlaceholder,
+    balance: areBalancesVisible ? compactNumberWithUnit(tokenBalance, decimals) : balancesPlaceholder,
     fiatBalance: areBalancesVisible ? formattedFiatBalance : balancesPlaceholder,
     sortBy: {
       fiatBalance: fiatBalance?.toNumber(),

--- a/apps/browser-extension-wallet/src/utils/constants.ts
+++ b/apps/browser-extension-wallet/src/utils/constants.ts
@@ -1,24 +1,6 @@
-/* eslint-disable no-magic-numbers */
 import { Wallet } from '@lace/cardano';
-import BigNumber from 'bignumber.js';
 
 export const LACE_APP_ID = 'lace-app';
-
-export const zero = new BigNumber(0);
-export const thousand = new BigNumber(1e3);
-export const million = new BigNumber(1e6);
-export const billion = new BigNumber(1e9);
-export const trillion = new BigNumber(1e12);
-export const quadrillion = new BigNumber(1e15);
-
-export const unitsMap = new Map([
-  ['', { gt: zero, lt: thousand }],
-  ['K', { gt: thousand, lt: million }],
-  ['M', { gt: million, lt: billion }],
-  ['B', { gt: billion, lt: trillion }],
-  ['T', { gt: trillion, lt: quadrillion }],
-  ['Q', { gt: quadrillion, lt: new BigNumber(1e18) }]
-]);
 
 type ADAEnumType = 'ADA' | 'tADA';
 

--- a/apps/browser-extension-wallet/src/utils/format-number.ts
+++ b/apps/browser-extension-wallet/src/utils/format-number.ts
@@ -1,59 +1,20 @@
 /* eslint-disable no-magic-numbers */
 import { DEFAULT_DECIMALS } from '@lace/common';
 import BigNumber from 'bignumber.js';
-import { unitsMap } from './constants';
-import { getNumberUnit } from './get-number-unit';
+import { getNumberUnit, UnitThreshold } from './get-number-unit';
 
-type GetCaretPositionForFormattedCurrencyProps = {
-  // current partially formatted value
-  currentDisplayValue: string;
-  // cursor position for current partially formatted value
-  currentCursorPosition: number;
-  // new formatted value
-  displayValue: string;
+type FormattedValueChange = {
+  // new value formatted by formatNumberForDisplay
+  newFormattedValue: string;
+  // previous value formatted by formatNumberForDisplay
+  previousFormattedValue: string;
 };
 
-type PlaceValue = 'unit' | 'ten' | 'hundred' | 'thousand' | 'million' | 'billion' | 'trillion' | 'quadrillion';
-
-const MILLION = 1e6;
-const BILLION = 1e9;
-const TRILLION = 1e12;
-const QUADRILLION = 1e15;
-
-// Number(value) would limit to 15 chars anyway
-const MAX_FRACTION_DIGIT_RANGE = 15;
-
-/**
- * Returns the place value of a given number with the order of magnitude and whether it has decimals.
- *
- * @param num The number for which to calculate the place value.
- * @returns An object containing the order of magnitude, whether it has decimals, and the place value.
- */
-const getPlaceValue = (num: number): { orderOfMagnitude: number; hasDecimals: boolean; placeValue: PlaceValue } => {
-  // Remove decimals
-  const roundedNumber = Math.round(Math.abs(num));
-
-  // Calculate the order of magnitude for the rounded number
-  const orderOfMagnitude = roundedNumber > 0 ? Math.floor(Math.log10(roundedNumber)) : 0;
-  const zeroes = { orderOfMagnitude, hasDecimals: roundedNumber !== num };
-
-  if (orderOfMagnitude < 1) return { ...zeroes, placeValue: 'unit' };
-  if (orderOfMagnitude === 1) return { ...zeroes, placeValue: 'ten' };
-  if (orderOfMagnitude === 2) return { ...zeroes, placeValue: 'hundred' };
-  if (orderOfMagnitude < 6) return { ...zeroes, placeValue: 'thousand' };
-  if (orderOfMagnitude < 9) return { ...zeroes, placeValue: 'million' };
-  if (orderOfMagnitude < 12) return { ...zeroes, placeValue: 'billion' };
-  if (orderOfMagnitude < 15) return { ...zeroes, placeValue: 'trillion' };
-
-  return { ...zeroes, placeValue: 'quadrillion' };
-};
-
-/**
- * Truncates a number to two decimals places
- * @param num The number to truncate
- * @returns The truncated number as a string
- */
-const truncateNumber = (num: number) => num.toString().match(/^-?\d+(?:\.\d{0,2})?/)[0];
+interface HandleFormattedValueChangeResponse {
+  formattedValue: string;
+  value: string;
+  characterOffset: number;
+}
 
 /**
  * Shortens a number to a desired length
@@ -62,7 +23,7 @@ const truncateNumber = (num: number) => num.toString().match(/^-?\d+(?:\.\d{0,2}
  * @returns The shortened number as a string
  */
 export const shortenNumber = (str: string, length: number): string =>
-  str.length > length ? `${str.slice(0, Math.max(0, length))}` : str;
+  length > 0 && str?.length > length ? `${str.slice(0, length)}` : str;
 
 /**
  * Checks if a given string is a valid numeric value.
@@ -70,29 +31,7 @@ export const shortenNumber = (str: string, length: number): string =>
  * @param str The string to be checked.
  * @returns `true` if the string is a valid numeric value, `false` otherwise.
  */
-export const isNumeric = (str: string): boolean => !Number.isNaN(str) && !Number.isNaN(Number.parseFloat(str));
-
-/**
- * Converts a value to a locale string.
- *
- * @param value The value to format.
- * @param maximumFractionDigits The maximum number of decimal digits to display. (between 2 and 15)
- * @returns The formatted currency value.
- */
-export const formatValueToLocale = (value: number | string, maximumFractionDigits?: number): string => {
-  // Make sure that maximumFractionDigits is not less than DEFAULT_DECIMALS, which is the minimum
-  const defaultMaxFraction = maximumFractionDigits >= DEFAULT_DECIMALS ? maximumFractionDigits : DEFAULT_DECIMALS;
-  // Make sure that maximumFractionDigits is never greater than MAX_FRACTION_DIGIT_RANGE (15)
-  // -> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
-  const maximumFraction =
-    defaultMaxFraction <= MAX_FRACTION_DIGIT_RANGE ? defaultMaxFraction : MAX_FRACTION_DIGIT_RANGE;
-
-  // TODO: get browser locale [LW-6089]
-  return Number(value).toLocaleString('en-US', {
-    minimumFractionDigits: DEFAULT_DECIMALS,
-    maximumFractionDigits: maximumFraction
-  });
-};
+export const isNumeric = (str: string): boolean => !new BigNumber(str).isNaN();
 
 /**
  * Formats a numeric string value with the specified decimal places.
@@ -102,8 +41,9 @@ export const formatValueToLocale = (value: number | string, maximumFractionDigit
  * @returns The formatted number string.
  */
 export const formatLocaleNumber = (value: string, decimalPlaces: number = DEFAULT_DECIMALS): string =>
-  new BigNumber(value).toFormat(decimalPlaces, {
+  new BigNumber(value).toFormat(decimalPlaces, BigNumber.ROUND_DOWN, {
     groupSize: 3,
+    // TODO: get from locale [LW-6089]
     groupSeparator: ',',
     decimalSeparator: '.'
   });
@@ -115,138 +55,93 @@ export const formatLocaleNumber = (value: string, decimalPlaces: number = DEFAUL
  * @param maxDecimals The maximum number of decimal places to include. Default is 0.
  * @returns The formatted number string.
  */
-export const getInlineCurrencyFormat = (value: string, maxDecimals = 0): string => {
+export const formatNumberForDisplay = (value: string, maxDecimals = 0): string => {
   if (!value) return '0';
   // Remove any character that is not a dot or a number
   const parsedStringValue = value.replace(/[^\d.]/g, '');
 
-  // If the value has not decimal part then format to locale string with grouping
-  if (!parsedStringValue.includes('.')) {
-    return BigInt(parsedStringValue).toLocaleString('fullwide', { useGrouping: true });
-  }
-
   // Split the integer and the decimal parts
   const numParts = parsedStringValue.split('.');
   // Format the integer part to locale string with grouping
-  const integerPart = BigInt(numParts[0]).toLocaleString('fullwide', {
-    useGrouping: true
-  });
+  const integerPart = formatLocaleNumber(numParts[0] || '0', 0);
 
-  // If there is more than one dot, remove all but the first one.
-  // Otherwise, shorten the decimals to the maxDecimals parameter
-  //   For example:
-  //     123.456.78.9 -> 123.456789 (regardless of maxDecimals)
-  //     123.456 -> 123.4 (with maxDecimals = 1)
-  const decimalPart = numParts.length > 2 ? numParts.slice(1).join('') : shortenNumber(numParts[1], maxDecimals);
-  return maxDecimals > 0 ? `${integerPart}.${decimalPart}` : integerPart;
+  // If there is more than one dot, keep the first and remove the rest joining the numbers.
+  const decimalPart = numParts.length > 2 ? numParts.slice(1).join('') : numParts[1];
+
+  // Shorten the decimal part to the provided maxDecimals and concat to the integer part
+  //   or just return the integer part if there is no decimal part or maxDecimals is <= 0
+  return numParts.length > 1 && maxDecimals > 0
+    ? `${integerPart}.${shortenNumber(decimalPart, maxDecimals)}`
+    : integerPart;
 };
 
 /**
  * Checks if the user tries to remove a comma from the previous value and also removes the character before it.
+ * Otherwise, returns the new value as it is.
  *
- * Otherwise, returns the new value as it is
+ * It also returns an offset to indicate the difference between the characters of
+ * the new formatted value received as parameter and the formatted value returned by this function
  */
-export const getChangedValue = ({
-  currentCursorPosition,
-  currentDisplayValue: newValue,
-  displayValue: previousValue
-}: GetCaretPositionForFormattedCurrencyProps): {
-  currentDisplayValue: string;
-  value: string;
-  currentCursorPosition: number;
-} => {
-  // Finds first different character between old and new value
-  const lastChangedIndex = [...previousValue].findIndex((el, index) => el !== [...newValue][index]);
+export const handleFormattedValueChange = (
+  { newFormattedValue, previousFormattedValue }: FormattedValueChange,
+  maxDecimals = 0
+): HandleFormattedValueChangeResponse => {
+  // Finds first different character between previous and new value
+  const firstChangedCharIndex = [...previousFormattedValue].findIndex(
+    (char, index) => char !== [...newFormattedValue][index]
+  );
 
-  // Check if the change is a deletion of a ','
-  if (previousValue[lastChangedIndex] === ',' && previousValue.length - newValue.length === 1) {
+  // Check if there was only one change between new and previous value, if it is a comma and if it was deleted by comparing their lengths
+  if (
+    firstChangedCharIndex !== -1 &&
+    previousFormattedValue[firstChangedCharIndex] === ',' &&
+    previousFormattedValue.length - newFormattedValue.length === 1
+  ) {
+    if (firstChangedCharIndex === 0) {
+      // If the deleted comma was the first character, then don't try to delete any other character
+      const value = newFormattedValue.split(',').join('');
+      return { formattedValue: value ? formatNumberForDisplay(value, maxDecimals) : '', value, characterOffset: 0 };
+    }
+
     // If a comma was deleted in the new value then also delete the character before the comma
-    const newDisplayValue = `${newValue.slice(0, lastChangedIndex - 1)}${newValue.slice(
-      lastChangedIndex,
-      newValue.length
+    const afterCommaDeletionValue = `${newFormattedValue.slice(0, firstChangedCharIndex - 1)}${newFormattedValue.slice(
+      firstChangedCharIndex,
+      newFormattedValue.length
     )}`;
 
+    // New value without any commas
+    const value = afterCommaDeletionValue.split(',').join('');
     return {
-      currentDisplayValue: newDisplayValue, // new value without the deleted comma and the character before it, still has all other commas
-      value: newDisplayValue.split(',').join(''), // new value without any comma
-      currentCursorPosition: currentCursorPosition - 1 // reposition the cursor to where the deleted character was
+      // New formatted value without the deleted comma and the character before it, still has all other commas
+      formattedValue: value ? formatNumberForDisplay(value, maxDecimals) : '',
+      value,
+      characterOffset: -1 // Reposition cursor one extra character besides the comma was deleted
     };
   }
 
+  const value = newFormattedValue.split(',').join('');
+  const formattedValue = value ? formatNumberForDisplay(value, maxDecimals) : '';
   // If the change was not the deletion of a comma then return the new value as it is
-  return { currentDisplayValue: newValue, value: newValue.split(',').join(''), currentCursorPosition };
+  return {
+    formattedValue,
+    value,
+    // Reposition cursor depending on changes to newFormattedValue after formatNumberForDisplay
+    characterOffset: formattedValue.length - newFormattedValue.length
+  };
 };
 
 /**
- * Calculates the proper cursor position for formatted numbers with group separators and decimals
- */
-export const getCaretPositionForFormattedCurrency = ({
-  currentDisplayValue: displayValueWithCommas,
-  displayValue: valueWithoutCommas,
-  currentCursorPosition
-}: GetCaretPositionForFormattedCurrencyProps): number => {
-  const reversedValue = [...displayValueWithCommas].reverse();
-  // Index of "." char in case of decimal value
-  const decimalIndex = reversedValue.indexOf('.');
-  // Index of the last "changed" character, determined by the current cursor position
-  const lastChangedCharIndex = displayValueWithCommas.length - currentCursorPosition;
-
-  // Check that there is no decimal part or that the last changed character is before the decimal part
-  if (decimalIndex === -1 || lastChangedCharIndex > decimalIndex) {
-    // Array of characters in the integer part until the last changed char index
-    // eg: with displayValueWithCommas = 12,345.67 and currentCursorPosition = 1 (index of '2' in displayValueWithCommas)
-    //          reversedValue = [ '7', '6', '.', '5', '4', '3', ',', '2', '1' ]
-    //          lastChangedCharIndex = 8 (index of '2'  in reversedValue + 1)
-    //          decimalIndex = 2 (index of  '.' in reversedValue)
-    //          Sliced reversed from 2 to 8 = ['.', '5', '4', '3', ',', '2']
-    const reversedIntegerPartTillLastChangedCharArray = reversedValue.slice(
-      Math.max(decimalIndex, 0),
-      lastChangedCharIndex
-    );
-    // Remove commas and join the sliced reversedValue to get the integer part of the number starting from the last changed character
-    // eg: from ['.', '5', '4', '3', ',', '2'] to '.5432'
-    const reversedIntegerPartTillLastChangedCharWithoutCommas = reversedIntegerPartTillLastChangedCharArray
-      .join('')
-      .split(',')
-      .join('');
-
-    // Get the number of commas in the reversedIntegerPartTillLastChangedCharArray slice
-    // by calculating the length difference between the sliced reversed value and the joined version without commas
-    const numberOfCommasInPartiallyFormattedValue =
-      reversedIntegerPartTillLastChangedCharArray.length - reversedIntegerPartTillLastChangedCharWithoutCommas.length;
-
-    // Put comma every 3 characters (getInlineCurrencyFormat)
-    const groups = 3;
-    // Number of possible ',' that could be placed by getInlineCurrencyFormat
-    // eg: for 12345 -> 12,345 it would be 1 comma char
-    const numberOfCommas = Math.max(
-      Math.floor((reversedIntegerPartTillLastChangedCharWithoutCommas.length - 1) / groups),
-      0
-    );
-
-    // Get proper cursor position (not for the reversed value)
-    return (
-      valueWithoutCommas.length - (lastChangedCharIndex - numberOfCommasInPartiallyFormattedValue + numberOfCommas)
-    );
-  }
-
-  return currentCursorPosition;
-};
-
-/**
- * Formats a numeric string to have two decimal places and its corresponding unit.
+ * Formats a numeric string to have a maximum of two decimal places and returns its corresponding unit.
  *
  * @param number The number string to be formatted and to get its unit
  * @returns An object with the formatted number and its corresponding unit
  */
-export const formatNumber = (number: string): { number: string; unit?: string } => {
+export const getNumberWithUnit = (number: string): { number: string; unit?: string } => {
   const bigNumber = new BigNumber(number);
   if (bigNumber.isNaN()) return { number };
 
-  const iterableUnitKeys = unitsMap.keys();
-  const { unit, unitThreshold } = getNumberUnit(bigNumber, iterableUnitKeys);
-
-  const threshold = unitThreshold.isZero() ? 1 : unitThreshold;
+  const { unit, unitThreshold } = getNumberUnit(bigNumber);
+  const threshold = unitThreshold === UnitThreshold.ZERO ? 1 : unitThreshold;
   return { number: bigNumber.div(threshold).decimalPlaces(2).toString(), unit };
 };
 
@@ -258,23 +153,13 @@ export const formatNumber = (number: string): { number: string; unit?: string } 
  * @param decimals The desired decimal places (default = 2)
  * @returns The formatted value with the desired decimals and the unit as a string
  */
-export const compactNumber = (value: number | string, decimals = DEFAULT_DECIMALS): string => {
-  const numericValue = value ? Number(value) : 0;
+export const compactNumberWithUnit = (value: number | string, decimals = DEFAULT_DECIMALS): string => {
+  const bigNumberValue = value ? new BigNumber(value) : new BigNumber(0);
 
-  if (Number.isNaN(numericValue)) return '0';
+  if (bigNumberValue.isNaN()) return formatLocaleNumber('0', decimals);
+  const { unit, unitThreshold } = getNumberUnit(bigNumberValue);
+  if (unitThreshold < UnitThreshold.MILLION) return formatLocaleNumber(bigNumberValue.toString(), decimals);
 
-  const notationsMap = new Map([
-    ['million', { notation: 'M', integerValue: MILLION }],
-    ['billion', { notation: 'B', integerValue: BILLION }],
-    ['trillion', { notation: 'T', integerValue: TRILLION }],
-    ['quadrillion', { notation: 'Q', integerValue: QUADRILLION }]
-  ]);
-
-  const valueInfo = getPlaceValue(numericValue);
-  if (valueInfo.orderOfMagnitude < 6) return formatValueToLocale(numericValue, decimals);
-
-  const valueNotation = notationsMap.get(valueInfo.placeValue);
-  const valueToFormat = numericValue / valueNotation.integerValue;
-  if (valueInfo.orderOfMagnitude > 18) return `${formatValueToLocale(valueToFormat)}${valueNotation.notation}`;
-  return `${formatValueToLocale(truncateNumber(valueToFormat))}${valueNotation.notation}`;
+  const valueToFormat = bigNumberValue.dividedBy(unitThreshold);
+  return `${formatLocaleNumber(valueToFormat.toString(), decimals)}${unit}`;
 };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetsPortfolio/AssetsPortfolio.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetsPortfolio/AssetsPortfolio.tsx
@@ -6,7 +6,7 @@ import { AssetTable, IRow, SendReceive } from '@lace/core';
 import { CONTENT_LAYOUT_ID } from '@components/Layout/ContentLayout';
 import { SectionTitle } from '@components/Layout/SectionTitle';
 import { APP_MODE_POPUP, AppMode, LACE_APP_ID } from '@src/utils/constants';
-import { compactNumber } from '@src/utils/format-number';
+import { compactNumberWithUnit } from '@src/utils/format-number';
 import { FundWalletBanner, PortfolioBalance } from '@src/views/browser-view/components';
 import { useCurrencyStore } from '@providers/currency';
 import { useWalletStore } from '@src/stores';
@@ -96,7 +96,7 @@ export const AssetsPortfolio = ({
       <div className={styles.portfolio}>
         <PortfolioBalance
           loading={isPortfolioBalanceLoading}
-          balance={compactNumber(portfolioBalanceAsBigNumber.toString())}
+          balance={compactNumberWithUnit(portfolioBalanceAsBigNumber.toString())}
           currencyCode={fiatCurrency.code}
           label={t('browserView.assets.totalWalletBalance')}
           isPriceOutdatedBannerVisible={isPriceOutdated}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/CoinInput/__tests__/useSelectedCoins.test.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/CoinInput/__tests__/useSelectedCoins.test.ts
@@ -138,7 +138,7 @@ describe('useSelectedCoin', () => {
             value: '100',
             maxDecimals: 5,
             prevValue: '',
-            element: { setSelectionRange: jest.fn(), value: '10000.123456789', selectionEnd: 10 }
+            element: { setSelectionRange: jest.fn(), value: '10000.123456789', selectionEnd: 15 }
           };
           result.current.selectedCoins[0].onChange(params);
           expect(mockCoinStateSelector.setCoinValue).toHaveBeenCalledWith('bundleId', {
@@ -146,7 +146,7 @@ describe('useSelectedCoin', () => {
             displayValue: '10,000.12345'
           });
           await waitFor(() => {
-            expect(params.element.setSelectionRange).toHaveBeenCalledWith(10, 10);
+            expect(params.element.setSelectionRange).toHaveBeenCalledWith(12, 12);
           });
         });
         test('onBlur function formats compact and display values', () => {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/store/store.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/store/store.ts
@@ -10,7 +10,7 @@ import { v4 as uuid } from 'uuid';
 import omit from 'lodash/omit';
 import { useWalletStore } from '@src/stores';
 import { isValidAddress, isValidAddressPerNetwork } from '@src/utils/validators';
-import { compactNumber, getInlineCurrencyFormat } from '@src/utils/format-number';
+import { compactNumberWithUnit, formatNumberForDisplay } from '@src/utils/format-number';
 
 // ====== initial values ======
 
@@ -284,7 +284,7 @@ const useStore = create<Store>((set, get) => ({
         [defaultOutputKey]: {
           address: '',
           assets: value
-            ? [{ id, value, compactValue: compactNumber(value), displayValue: getInlineCurrencyFormat(value) }]
+            ? [{ id, value, compactValue: compactNumberWithUnit(value), displayValue: formatNumberForDisplay(value) }]
             : [{ id }]
         }
       }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/MultiDelegationStaking.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/MultiDelegationStaking.tsx
@@ -9,7 +9,7 @@ import { useBalances, useDelegationDetails, useFetchCoinPrice, useStakingRewards
 import { stakePoolDetailsSelector, useDelegationStore } from '@src/features/delegation/stores';
 import { usePassword, useSubmitingState } from '@views/browser/features/send-transaction';
 import { useWalletStore } from '@stores';
-import { compactNumber } from '@utils/format-number';
+import { compactNumberWithUnit } from '@utils/format-number';
 
 export const MultiDelegationStaking = (): JSX.Element => {
   const { theme } = useTheme();
@@ -84,7 +84,7 @@ export const MultiDelegationStaking = (): JSX.Element => {
         walletStoreNetworkInfo: networkInfo,
         walletStoreBlockchainProvider: blockchainProvider,
         // TODO: LW-7575 make compactNumber reusable and not pass it here.
-        compactNumber
+        compactNumber: compactNumberWithUnit
       }}
     >
       <Staking theme={theme.name} />


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7442
- [x] Proper tests implemented

---

## Proposed solution

Refactor util functions in `format-number.ts` file:
- Remove redundant code and functions
- Try to simplify over-complicated code
- Improve names and readability
- Try to make the functions less dependent on the UI
- Write more useful test cases

## Testing

Impacts number formatting (units, commas, dots, decimals).
Everything should be working as it was before, especially the inputs for the send transaction screen.

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1150/5670103686/index.html) for [9124fcf2](https://github.com/input-output-hk/lace/pull/299/commits/9124fcf23c89b9909e960e72f07dc46541c904ab)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->