### PR TITLE
test(extension): e2e - add e2e select nfts page search and clear

### DIFF
--- a/packages/e2e-tests/src/assert/nftSelectNftsAssert.ts
+++ b/packages/e2e-tests/src/assert/nftSelectNftsAssert.ts
@@ -18,6 +18,20 @@ class NftSelectNftsAssert {
     await NftSelectNftsPage.counter.waitForDisplayed();
     expect(await NftSelectNftsPage.counter.getText()).to.equal(String(counter));
   }
+
+  async assertSeeNFTsWithSearchPhrase(searchPhrase: string) {
+    const displayedNfts = await NftSelectNftsPage.nfts;
+    const displayedNftNames: string[] = [];
+    const displayedNftNamesMatched: string[] = [];
+
+    for (const nft of displayedNfts) {
+      displayedNftNames.push(await nft.getText());
+      if ((await nft.getText()).toLowerCase().includes(searchPhrase.toLowerCase())) {
+        displayedNftNamesMatched.push(await nft.getText());
+      }
+    }
+    expect(displayedNftNamesMatched).to.have.ordered.members(displayedNftNames);
+  }
 }
 
 export default new NftSelectNftsAssert();

--- a/packages/e2e-tests/src/assert/nftSelectNftsAssert.ts
+++ b/packages/e2e-tests/src/assert/nftSelectNftsAssert.ts
@@ -20,17 +20,13 @@ class NftSelectNftsAssert {
   }
 
   async assertSeeNFTsWithSearchPhrase(searchPhrase: string) {
-    const displayedNfts = await NftSelectNftsPage.nfts;
-    const displayedNftNames: string[] = [];
-    const displayedNftNamesMatched: string[] = [];
-
-    for (const nft of displayedNfts) {
-      displayedNftNames.push(await nft.getText());
-      if ((await nft.getText()).toLowerCase().includes(searchPhrase.toLowerCase())) {
-        displayedNftNamesMatched.push(await nft.getText());
-      }
-    }
-    expect(displayedNftNamesMatched).to.have.ordered.members(displayedNftNames);
+    const displayedNFTNames = await Promise.all(
+      await NftSelectNftsPage.nfts.map(async (nft) => (await nft.getText()).toLowerCase())
+    );
+    expect(
+      displayedNFTNames.every((name) => name.includes(searchPhrase.toLowerCase())),
+      `All displayed NFT names [${displayedNFTNames}] should contain phrase "${searchPhrase.toLowerCase()}"`
+    ).to.be.true;
   }
 }
 

--- a/packages/e2e-tests/src/elements/NFTs/nftSelectNftsPage.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftSelectNftsPage.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef */
 import CommonDrawerElements from '../CommonDrawerElements';
 import SearchInput from '../searchInput';
-import { expect } from 'chai';
 
 class NftSelectNftsPage extends CommonDrawerElements {
   private COUNTER = '[data-testid="assets-counter"]';
@@ -46,10 +45,6 @@ class NftSelectNftsPage extends CommonDrawerElements {
     return this.assetSelectorContainer.$$(this.NFT_CONTAINER);
   }
 
-  get nftName() {
-    return this.assetSelectorContainer.$(this.NFT_NAME);
-  }
-
   async enterSearchPhrase(searchPhrase: string) {
     await this.searchInput.input.waitForClickable();
     await this.searchInput.input.setValue(searchPhrase);
@@ -66,16 +61,6 @@ class NftSelectNftsPage extends CommonDrawerElements {
       await this.nfts[i].waitForClickable();
       await this.nfts[i].click();
     }
-  }
-
-  async assertSeeNFTsWithSearchPhrase(searchPhrase: string) {
-    let total = 0;
-    for await (const nft of this.nfts) {
-      if ((await nft.$(this.NFT_NAME).getText()).toLowerCase() === searchPhrase) {
-        total++;
-      }
-    }
-    expect(await this.nfts.length).to.equal(total);
   }
 
   async clearSearchBarInput() {

--- a/packages/e2e-tests/src/elements/NFTs/nftSelectNftsPage.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftSelectNftsPage.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import CommonDrawerElements from '../CommonDrawerElements';
 import SearchInput from '../searchInput';
+import { expect } from 'chai';
 
 class NftSelectNftsPage extends CommonDrawerElements {
   private COUNTER = '[data-testid="assets-counter"]';
@@ -45,6 +46,10 @@ class NftSelectNftsPage extends CommonDrawerElements {
     return this.assetSelectorContainer.$$(this.NFT_CONTAINER);
   }
 
+  get nftName() {
+    return this.assetSelectorContainer.$(this.NFT_NAME);
+  }
+
   async enterSearchPhrase(searchPhrase: string) {
     await this.searchInput.input.waitForClickable();
     await this.searchInput.input.setValue(searchPhrase);
@@ -61,6 +66,21 @@ class NftSelectNftsPage extends CommonDrawerElements {
       await this.nfts[i].waitForClickable();
       await this.nfts[i].click();
     }
+  }
+
+  async assertSeeNFTsWithSearchPhrase(searchPhrase: string) {
+    let total = 0;
+    for await (const nft of this.nfts) {
+      if ((await nft.$(this.NFT_NAME).getText()).toLowerCase() === searchPhrase) {
+        total++;
+      }
+    }
+    expect(await this.nfts.length).to.equal(total);
+  }
+
+  async clearSearchBarInput() {
+    await this.searchInput.clearButton.waitForClickable();
+    await this.searchInput.clearButton.click();
   }
 }
 

--- a/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
@@ -140,3 +140,12 @@ Feature: NFT - Folders - Extended view
     And I do not see NFTs counter
     When I select 5 NFTs
     Then I see NFTs counter showing 5 selected NFTs
+
+  @LW-7258
+  Scenario: Extended-view - NFT Folders - Select NFTs page - search for existing NFTs and clear
+    Given I navigate to "Select NFTs" page in extended mode
+    And I save all NFTs that I have
+    When I enter "coin" into the search bar
+    Then I see NFTs containing "coin" on the "Select NFTs" page
+    When I press "Clear" button in search bar
+    And "Select NFTs" page is showing all NFTs that I have

--- a/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
@@ -126,3 +126,12 @@ Feature: NFT - Folders - Popup view
     And I do not see NFTs counter
     When I select 5 NFTs
     Then I see NFTs counter showing 5 selected NFTs
+
+  @LW-7275
+  Scenario: Popup-view - NFT Folders - Select NFTs page - search for existing NFTs and clear
+    Given I navigate to "Select NFTs" page in popup mode
+    And I save all NFTs that I have
+    When I enter "coin" into the search bar
+    Then I see NFTs containing "coin" on the "Select NFTs" page
+    When I press "Clear" button in search bar
+    And "Select NFTs" page is showing all NFTs that I have

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -184,3 +184,15 @@ When(/^I click "Clear" button next to NFTs counter$/, async () => {
   await NftSelectNftsPage.clearButton.waitForClickable();
   await NftSelectNftsPage.clearButton.click();
 });
+
+When(/^I enter "([^"]*)" into the search bar$/, async (searchPhrase: string) => {
+  await NftSelectNftsPage.enterSearchPhrase(searchPhrase);
+});
+
+Then(/^I see NFTs containing "([^"]*)" on the "Select NFTs" page$/, async (searchPhrase: string) => {
+  await NftSelectNftsAssert.assertSeeNFTsWithSearchPhrase(searchPhrase);
+});
+
+Then(/^I press "Clear" button in search bar$/, async () => {
+  await NftSelectNftsPage.clearSearchBarInput();
+});


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1097/5622867112/index.html) for [31bf6187](https://github.com/input-output-hk/lace/pull/300/commits/31bf61877fc942d63517b7bd0b822eddb4dac9e5)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->