### PR TITLE
Feat/LW-7489,LW-7636

### DIFF
--- a/packages/staking/src/features/browse-pools/BrowsePools.tsx
+++ b/packages/staking/src/features/browse-pools/BrowsePools.tsx
@@ -1,13 +1,14 @@
-import { StakePoolItemBrowserProps, Wallet } from '@lace/cardano';
+import { Wallet } from '@lace/cardano';
 import { useEffect, useMemo } from 'react';
 import { StateStatus, useOutsideHandles } from '../outside-handles-provider';
+import { PortfolioBar } from '../staking/PortfolioBar';
 import { useStakePoolDetails } from '../store';
 import { StakePoolsTable } from './stake-pools-table';
 
 const LACE_APP_ID = 'lace-app';
 
 type BrowsePoolsProps = {
-  onStake: (id: StakePoolItemBrowserProps['id']) => void;
+  onStake: () => void;
 };
 
 export const BrowsePools = ({ onStake }: BrowsePoolsProps) => {
@@ -52,5 +53,10 @@ export const BrowsePools = ({ onStake }: BrowsePoolsProps) => {
     fetchStakePools,
   ]);
 
-  return <StakePoolsTable scrollableTargetId={LACE_APP_ID} onStake={onStake} />;
+  return (
+    <>
+      <PortfolioBar onStake={onStake} />
+      <StakePoolsTable scrollableTargetId={LACE_APP_ID} onStake={onStake} />
+    </>
+  );
 };

--- a/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.module.scss
+++ b/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.module.scss
@@ -72,10 +72,14 @@
     background-color: var(--bg-color-body, #ffffff);
     border: 1px solid var(--light-mode-light-grey-plus, var(--dark-mode-light-grey));
     height: size_unit(6);
+    margin-left: 4px;
     min-height: size_unit(6);
     min-width: size_unit(6);
     padding: size_unit(0.5);
     width: size_unit(6);
+  }
+  .imageSelected {
+    box-shadow: 0 0 0 3px var(--bg-color-body), 0 0 0 4px var(--lace-yellow);
   }
 
   > div {

--- a/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.module.scss
+++ b/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.module.scss
@@ -2,6 +2,7 @@
 
 .row {
   align-items: center;
+  justify-content: space-between;
   background: var(--bg-color-body, #ffffff);
   border-radius: size_unit(2);
   cursor: pointer;
@@ -10,9 +11,16 @@
   min-height: size_unit(8);
   width: 100%;
   &:hover {
+    display: flex;
     background: var(--light-mode-light-grey, var(--dark-mode-mid-grey));
+    .apy {
+      display: none;
+    }
+    .saturation {
+      display: none;
+    }
     .actions {
-      opacity: 1;
+      display: flex;
     }
   }
 
@@ -40,7 +48,17 @@
   }
 
   .apy {
+    display: flex;
     padding-left: size_unit(0.5);
+  }
+
+  .saturation {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .actions {
+    display: none;
   }
 
   .cost {

--- a/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.tsx
+++ b/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.tsx
@@ -5,6 +5,7 @@ import { Button } from '@lace/ui';
 import cn from 'classnames';
 import isNil from 'lodash/isNil';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDelegationPortfolioStore } from '../../../store';
 import styles from './StakePoolItemBrowser.module.scss';
 
@@ -48,6 +49,7 @@ export const StakePoolItemBrowser = ({
   addToDraft,
   removeFromDraft,
 }: StakePoolItemBrowserProps): React.ReactElement => {
+  const { t } = useTranslation();
   let title = name;
   let subTitle: string | React.ReactElement = ticker || '-';
   if (!name) {
@@ -59,7 +61,11 @@ export const StakePoolItemBrowser = ({
   const includedInDraft = useDelegationPortfolioStore((state) => state.poolIncludedInDraft(hexId));
 
   const StakeButtonComponent = includedInDraft ? Button.Secondary : Button.CallToAction;
-  const stakePoolStateLabel = includedInDraft ? 'Unselect' : draftPortfolioExists ? 'Add pool' : 'Stake';
+  const stakePoolStateLabel = includedInDraft
+    ? t('browsePools.stakePoolTableBrowser.unselect')
+    : draftPortfolioExists
+    ? t('browsePools.stakePoolTableBrowser.addPool')
+    : t('browsePools.stakePoolTableBrowser.stake');
 
   return (
     <div data-testid="stake-pool-table-item" className={styles.row} onClick={() => onClick(id)}>

--- a/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.tsx
+++ b/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable no-magic-numbers */
+import { Wallet } from '@lace/cardano';
 import { Ellipsis } from '@lace/common';
+import { Button } from '@lace/ui';
 import cn from 'classnames';
 import isNil from 'lodash/isNil';
 import React from 'react';
@@ -7,13 +9,16 @@ import styles from './StakePoolItemBrowser.module.scss';
 
 export interface StakePoolItemBrowserProps {
   id: string;
+  hexId: Wallet.Cardano.PoolIdHex;
+  includedInDraft: boolean;
   name?: string;
   ticker?: string;
   apy?: number | string;
   saturation?: number | string;
   cost?: number | string;
   logo: string;
-  onClick: (id: StakePoolItemBrowserProps['id']) => unknown;
+  onClick: (id: string) => unknown;
+  onStakingSelect: () => void;
 }
 
 export const getSaturationLevel = (saturation: number): string => {
@@ -33,11 +38,13 @@ export const getSaturationLevel = (saturation: number): string => {
 export const StakePoolItemBrowser = ({
   id,
   name,
+  includedInDraft,
   ticker,
   saturation,
   logo,
   apy,
   onClick,
+  onStakingSelect,
 }: StakePoolItemBrowserProps): React.ReactElement => {
   let title = name;
   let subTitle: string | React.ReactElement = ticker || '-';
@@ -60,7 +67,7 @@ export const StakePoolItemBrowser = ({
       <div className={styles.apy}>
         <p data-testid="stake-pool-list-apy">{apy ?? '-'}%</p>
       </div>
-      <div>
+      <div className={styles.saturation}>
         <p data-testid="stake-pool-list-saturation">
           {!isNil(saturation) ? (
             <>
@@ -71,6 +78,15 @@ export const StakePoolItemBrowser = ({
             '-'
           )}
         </p>
+      </div>
+      <div className={styles.actions}>
+        <Button.CallToAction
+          label={includedInDraft ? 'Unselect' : 'Add pool'}
+          onClick={(event) => {
+            event.stopPropagation();
+            onStakingSelect();
+          }}
+        />
       </div>
     </div>
   );

--- a/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolsTable.tsx
+++ b/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolsTable.tsx
@@ -32,7 +32,6 @@ export const StakePoolsTable = ({ onStake, scrollableTargetId }: StakePoolsTable
   const [stakePools, setStakePools] = useState<Wallet.StakePoolSearchResults['pageResults']>([]);
   const [skip, setSkip] = useState<number>(0);
   const { addPoolToDraft, removePoolFromDraft } = useDelegationPortfolioStore((state) => state.mutators);
-  const poolIncludedInDraft = useDelegationPortfolioStore((state) => state.poolIncludedInDraft);
 
   const { setIsDrawerVisible } = useStakePoolDetails();
 
@@ -99,13 +98,12 @@ export const StakePoolsTable = ({ onStake, scrollableTargetId }: StakePoolsTable
         const stakePool = Wallet.util.stakePoolTransformer({ cardanoCoin, stakePool: pool });
         const logo = getRandomIcon({ id: pool.id.toString(), size: 30 });
         const hexId = Wallet.Cardano.PoolIdHex(stakePool.hexId);
-        const includedInDraft = poolIncludedInDraft(hexId);
 
         return {
           logo,
           ...stakePool,
+          addToDraft: () => addPoolToDraft({ displayData: stakePool, id: hexId, weight: 1 }),
           hexId,
-          includedInDraft,
           onClick: (): void => {
             setSelectedStakePool({ logo, ...pool });
             setIsDrawerVisible(true);
@@ -115,13 +113,10 @@ export const StakePoolsTable = ({ onStake, scrollableTargetId }: StakePoolsTable
             setSelectedStakePool(pool);
             onStake(poolId);
           },
-          onStakingSelect: () => {
-            if (includedInDraft) return removePoolFromDraft({ id: hexId });
-            return addPoolToDraft({ displayData: stakePool, id: hexId, weight: 1 });
-          },
+          removeFromDraft: () => removePoolFromDraft({ id: hexId }),
         };
       }) || [],
-    [stakePools, cardanoCoin, setSelectedStakePool, setIsDrawerVisible, onStake]
+    [stakePools, cardanoCoin, setSelectedStakePool, setIsDrawerVisible, onStake, removePoolFromDraft, addPoolToDraft]
   );
 
   return (

--- a/packages/staking/src/features/i18n/translations/en.ts
+++ b/packages/staking/src/features/i18n/translations/en.ts
@@ -1,12 +1,15 @@
 import { Translations } from '../types';
 
 export const en: Translations = {
+  'browsePools.stakePoolTableBrowser.addPool': 'Add pool',
   'browsePools.stakePoolTableBrowser.emptyMessage': 'No results matching your search',
   'browsePools.stakePoolTableBrowser.searchInputPlaceholder': 'Search by type, token name or ID',
+  'browsePools.stakePoolTableBrowser.stake': 'Stake',
   'browsePools.stakePoolTableBrowser.tableHeader.cost': 'Cost',
   'browsePools.stakePoolTableBrowser.tableHeader.poolName': 'Pool name',
   'browsePools.stakePoolTableBrowser.tableHeader.ros': 'ROS',
   'browsePools.stakePoolTableBrowser.tableHeader.saturation': 'Saturation',
+  'browsePools.stakePoolTableBrowser.unselect': 'Unselect',
   'drawer.confirmation.button.confirm': 'Next',
   'drawer.confirmation.button.confirmWithDevice': 'Confirm with {{hardwareWallet}}',
   'drawer.confirmation.button.continueInAdvancedView': 'Continue in Advanced View',

--- a/packages/staking/src/features/i18n/types.ts
+++ b/packages/staking/src/features/i18n/types.ts
@@ -25,6 +25,9 @@ type KeysStructure = {
         saturation: '';
       };
       emptyMessage: '';
+      stake: '';
+      unselect: '';
+      addPool: '';
     };
   };
   drawer: {

--- a/packages/staking/src/features/staking/StakingView.tsx
+++ b/packages/staking/src/features/staking/StakingView.tsx
@@ -7,7 +7,6 @@ import { useOutsideHandles } from '../outside-handles-provider';
 import { Overview } from '../overview';
 import { Sections, useStakePoolDetails } from '../store';
 import { Navigation, Page } from './Navigation';
-import { PortfolioBar } from './PortfolioBar';
 
 const stepsWithBackBtn = new Set([Sections.CONFIRMATION, Sections.SIGN]);
 
@@ -50,7 +49,6 @@ export const StakingView = () => {
           </Box>
         )}
       </Navigation>
-      <PortfolioBar onStake={onStake} />
       <StakePoolDetails
         showCloseIcon
         showBackIcon={(section: Sections): boolean => stepsWithBackBtn.has(section)}

--- a/packages/staking/src/features/store/delegationPortfolio.ts
+++ b/packages/staking/src/features/store/delegationPortfolio.ts
@@ -10,7 +10,7 @@ const defaultState: DelegationPortfolioState = {
 
 export const MAX_POOLS_COUNT = 5;
 
-export const useDelegationPortfolioStore = create<DelegationPortfolioStore>((set) => ({
+export const useDelegationPortfolioStore = create<DelegationPortfolioStore>((set, get) => ({
   ...defaultState,
   mutators: {
     addPoolToDraft: (poolData) =>
@@ -54,6 +54,10 @@ export const useDelegationPortfolioStore = create<DelegationPortfolioStore>((set
           poolEntry.weight = weight;
         })
       ),
+  },
+  poolIncludedInDraft: (id) => {
+    const { draftPortfolio } = get();
+    return !!draftPortfolio?.find((pool) => pool.id === id);
   },
 }));
 

--- a/packages/staking/src/features/store/types.ts
+++ b/packages/staking/src/features/store/types.ts
@@ -49,6 +49,10 @@ export type DelegationPortfolioState = Immutable<{
   draftPortfolio: DelegationPortfolioStakePool[];
 }>;
 
+export type DelegationPortfolioQueries = {
+  poolIncludedInDraft: (id: Wallet.Cardano.PoolIdHex) => boolean;
+};
+
 type DelegationPortfolioMutators = {
   setCurrentPortfolio: (params: {
     rewardAccountInfo?: Wallet.Cardano.RewardAccountInfo[];
@@ -60,6 +64,7 @@ type DelegationPortfolioMutators = {
   clearDraft: () => void;
 };
 
-export type DelegationPortfolioStore = DelegationPortfolioState & {
-  mutators: DelegationPortfolioMutators;
-};
+export type DelegationPortfolioStore = DelegationPortfolioState &
+  DelegationPortfolioQueries & {
+    mutators: DelegationPortfolioMutators;
+  };


### PR DESCRIPTION
# Checklist

- [x] JIRA
  - https://input-output.atlassian.net/browse/LW-7489
  - https://input-output.atlassian.net/browse/LW-7636
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

- Moved portfolio floating bar to Browser Pools view.
- Added hover buttons for adding stake pool to draft portfolio.
- Added yellow borders for stake pools selected for draft.

## Screenshots

<img width="758" alt="image" src="https://github.com/input-output-hk/lace/assets/16132011/475b5133-6e07-44e6-954e-f9149c109ac3">



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1098/5623270629/index.html) for [ec1d108b](https://github.com/input-output-hk/lace/pull/303/commits/ec1d108b3a6ba716faa2700ef21d9962deb21037)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->