### PR TITLE
[LW-7659] lace-blockchain-services: integrate Mithril into the UI (triggering fast resync)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,6 +198,30 @@
         "type": "github"
       }
     },
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "mithril",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1687310026,
+        "narHash": "sha256-20RHFbrnC+hsG4Hyeg/58LvQAK7JWfFItTPFAFamu8E=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "116b32c30b5ff28e49f4fcbeeb1bbe3544593204",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "customConfig": {
       "locked": {
         "lastModified": 1630400035,
@@ -246,6 +270,40 @@
         "type": "github"
       }
     },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1678379998,
+        "narHash": "sha256-TZdfNqftHhDuIFwBcN9MUThx5sQXCTeZk9je5byPKRw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c13d60b89adea3dc20704c045ec4d50dd964d447",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1659877975,
@@ -268,6 +326,24 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -428,6 +504,28 @@
         "type": "github"
       }
     },
+    "mithril": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_4",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1689774350,
+        "narHash": "sha256-XBWz61dMzsZhX0dtbXm/5WfdYUZ7Z1hpq7vlw5d9mq0=",
+        "owner": "input-output-hk",
+        "repo": "mithril",
+        "rev": "e79232fcbd1600a5a1798b933127da286b2b8d8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "2329.0",
+        "repo": "mithril",
+        "type": "github"
+      }
+    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
@@ -576,6 +674,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1678375444,
+        "narHash": "sha256-XIgHfGvjFvZQ8hrkfocanCDxMefc/77rXeHvYdzBMc8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "130fa0baaa2b93ec45523fdcde942f6844ee9f6e",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-nsis": {
       "flake": false,
       "locked": {
@@ -654,6 +770,22 @@
       }
     },
     "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1687886075,
+        "narHash": "sha256-PeayJDDDy+uw1Ats4moZnRdL1OFuZm1Tj+KiHlD67+o=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a565059a348422af5af9026b5174dc5c0dcefdae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1682566018,
         "narHash": "sha256-HPzPRFiy2o/7k7mtnwfM1E6NVZHiFbPdmYCMoIpkHO4=",
@@ -741,11 +873,39 @@
         "cardano-js-sdk": "cardano-js-sdk",
         "cardano-node": "cardano-node",
         "cardano-world": "cardano-world",
+        "mithril": "mithril",
         "nix-bundle-exe": "nix-bundle-exe",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-nsis": "nixpkgs-nsis",
         "ogmios": "ogmios",
         "ogmios-CHaP": "ogmios-CHaP"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "mithril",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "mithril",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685759304,
+        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "stackage": {
@@ -761,6 +921,42 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "mithril",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1678901796,
+        "narHash": "sha256-9myDjq948gHbiv16HnFQZaswQEpNodE/CuGCfDNnv/g=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "0f560a84215e79facd2833b20bfdc2033266f126",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,8 @@
     ogmios-CHaP.url = "github:input-output-hk/cardano-haskell-packages/316e0a626fed1a928e659c7fc2577c7773770f7f";
     ogmios-CHaP.flake = false;
 
+    mithril.url = "github:input-output-hk/mithril/2329.0";
+
     nix-bundle-exe.url = "github:3noch/nix-bundle-exe";
     nix-bundle-exe.flake = false;
 

--- a/nix/lace-blockchain-services/internal/any-darwin.nix
+++ b/nix/lace-blockchain-services/internal/any-darwin.nix
@@ -111,7 +111,7 @@ in rec {
       cp cardano.png tray-icon
       cp ${common.openApiJson} openapi.json
       go-bindata -pkg assets -o assets/assets.go tray-icon openapi.json
-      mkdir -p versions && cp ${common.hardcodedVersions} versions/versions.go
+      mkdir -p constants && cp ${common.constants} constants/constants.go
     '';
   };
 

--- a/nix/lace-blockchain-services/internal/any-darwin.nix
+++ b/nix/lace-blockchain-services/internal/any-darwin.nix
@@ -526,4 +526,15 @@ in rec {
     echo "file binary-dist \"$target\"" >$out/nix-support/hydra-build-products
   '';
 
+  mithril-client = pkgs.runCommand "mithril-client-${common.mithril-bin.version}" {} ''
+    mkdir -p $out/bin
+    cp ${common.mithril-bin}/${
+      if targetSystem == "aarch64-darwin"
+      then "bin/mithril-client"
+      else "mithril-client"
+    } $out/bin/
+    chmod +x $out/bin/mithril-client
+    $out/bin/mithril-client --version
+  '';
+
 }

--- a/nix/lace-blockchain-services/internal/any-darwin.nix
+++ b/nix/lace-blockchain-services/internal/any-darwin.nix
@@ -179,6 +179,7 @@ in rec {
     ln -s ${cardano-node}/bin/cardano-node "$app"/MacOS/
     ln -s ${ogmios}/bin/ogmios "$app"/MacOS/
     ln -s ${cardano-js-sdk.nodejs}/bin/node "$app"/MacOS/
+    ln -s ${mithril-client}/bin/mithril-client "$app"/MacOS/
 
     ln -s ${cardano-js-sdk} "$app"/Resources/cardano-js-sdk
     ln -s ${common.networkConfigs} "$app"/Resources/cardano-node-config

--- a/nix/lace-blockchain-services/internal/common.nix
+++ b/nix/lace-blockchain-services/internal/common.nix
@@ -110,7 +110,7 @@ in rec {
     aarch64-darwin = cardanoNodeFlake.packages.aarch64-darwin.cardano-node;
   }.${targetSystem};
 
-  lace-blockchain-services-exe-vendorHash = "sha256-kEFdxqSs3nY1a6maUSPkc30uENePhcmYkkV1Q0fF/Io=";
+  lace-blockchain-services-exe-vendorHash = "sha256-3Dy7M2lU2jbTozI81i/Pg/jgcuHLrU1wBWwlM9RFnz4=";
 
   constants = pkgs.writeText "constants.go" ''
     package constants

--- a/nix/lace-blockchain-services/internal/common.nix
+++ b/nix/lace-blockchain-services/internal/common.nix
@@ -124,6 +124,8 @@ in rec {
       OgmiosRevision = ${__toJSON inputs.ogmios.rev}
       ProviderServerVersion = ${__toJSON ((__fromJSON (__readFile (inputs.cardano-js-sdk + "/packages/cardano-services/package.json"))).version)}
       ProviderServerRevision = ${__toJSON inputs.cardano-js-sdk.sourceInfo.rev}
+      MithrilClientRevision = ${__toJSON mithril-bin.version}
+      MithrilClientVersion = ${__toJSON mithril-bin.version}
     )
   '';
 

--- a/nix/lace-blockchain-services/internal/common.nix
+++ b/nix/lace-blockchain-services/internal/common.nix
@@ -185,4 +185,36 @@ in rec {
     }} $out/highlight.js/default.min.css
   '';
 
+  # FIXME: build from source (Linux, and Darwins are available in their flake.nix, but Windows not)
+  mithril-bin = let
+    ver = "2329.0";
+  in {
+    x86_64-linux = pkgs.fetchzip {
+      url = "https://github.com/input-output-hk/mithril/releases/download/${ver}/mithril-${ver}-linux-x64.tar.gz";
+      hash = "sha256-oyBhhSG/kvZge3tpZfheGHtD1ivY56+jYgSAH09rswE=";
+      stripRoot = false;
+    };
+    x86_64-windows = pkgs.fetchzip {
+      url = "https://github.com/input-output-hk/mithril/releases/download/${ver}/mithril-${ver}-windows-x64.tar.gz";
+      hash = "sha256-SWPk9zTlmRElOe3l7Ic+jeqo3VNST6wuXfiFogkcrA4=";
+    };
+    x86_64-darwin = pkgs.fetchzip {
+      url = "https://github.com/input-output-hk/mithril/releases/download/${ver}/mithril-${ver}-macos-x64.tar.gz";
+      hash = "sha256-u0S9ClTE38Uv5uyFO4dlS0P/O1cAjeUwl3zarhwk9no=";
+    };
+    aarch64-darwin = (flake-compat {
+      src = let
+        raw = pkgs.fetchFromGitHub {
+          owner = "input-output-hk"; repo = "mithril";
+          rev = ver;
+          hash = "sha256-XBWz61dMzsZhX0dtbXm/5WfdYUZ7Z1hpq7vlw5d9mq0=";
+        };
+      in {
+        outPath = toString raw;
+        inherit (raw) rev lastModified lastModifiedDate;
+        shortRev = lib.substring 0 7 raw.rev;
+      };
+    }).defaultNix.packages.aarch64-darwin.mithril-client;
+  }.${targetSystem} // { version = ver; };
+
 }

--- a/nix/lace-blockchain-services/internal/common.nix
+++ b/nix/lace-blockchain-services/internal/common.nix
@@ -112,8 +112,8 @@ in rec {
 
   lace-blockchain-services-exe-vendorHash = "sha256-kEFdxqSs3nY1a6maUSPkc30uENePhcmYkkV1Q0fF/Io=";
 
-  hardcodedVersions = pkgs.writeText "version.go" ''
-    package versions
+  constants = pkgs.writeText "constants.go" ''
+    package constants
 
     const (
       LaceBlockchainServicesVersion = ${__toJSON laceVersion}
@@ -126,6 +126,9 @@ in rec {
       ProviderServerRevision = ${__toJSON inputs.cardano-js-sdk.sourceInfo.rev}
       MithrilClientRevision = ${__toJSON mithril-bin.version}
       MithrilClientVersion = ${__toJSON mithril-bin.version}
+      MithrilGVKPreview = ${__toJSON mithrilGenesisVerificationKeys.preview}
+      MithrilGVKPreprod = ${__toJSON mithrilGenesisVerificationKeys.preprod}
+      MithrilGVKMainnet = ${__toJSON mithrilGenesisVerificationKeys.mainnet}
     )
   '';
 
@@ -186,6 +189,27 @@ in rec {
       hash = "sha256-+94KwJIdhsNWxBUy5zGciHojvRuP8ABgyrRHJJ8Dx88=";
     }} $out/highlight.js/default.min.css
   '';
+
+  mithrilGenesisVerificationKeys = {
+    preview = builtins.readFile (pkgs.fetchurl {
+      url =
+        "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration"
+        + "/pre-release-preview/genesis.vkey";
+        hash = "sha256-kNqbbOdx5lm34zhiBaM6TzIs+J0MsuANCkhwp43LiN8=";
+    });
+    preprod = builtins.readFile (pkgs.fetchurl {
+      url =
+        "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration"
+        + "/release-preprod/genesis.vkey";
+        hash = "sha256-kNqbbOdx5lm34zhiBaM6TzIs+J0MsuANCkhwp43LiN8=";
+    });
+    mainnet = builtins.readFile (pkgs.fetchurl {
+      url =
+        "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration"
+        + "/release-mainnet/genesis.vkey";
+        hash = "sha256-Fdav0t8HG3XTfn6EUTYphrOETShXUaOuwjwaKWkJZwY=";
+    });
+  };
 
   # FIXME: build from source (Linux, and Darwins are available in their flake.nix, but Windows not)
   mithril-bin = let

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-cardano-node.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-cardano-node.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 
 	"lace.io/lace-blockchain-services/ourpaths"
-	"lace.io/lace-blockchain-services/versions"
+	"lace.io/lace-blockchain-services/constants"
 
 	"github.com/acarl005/stripansi"
 )
@@ -53,9 +53,9 @@ func childCardanoNode(shared SharedState, statusCh chan<- StatusAndUrl) ManagedC
 	return ManagedChild{
 		ServiceName: "cardano-node",
 		ExePath: ourpaths.LibexecDir + sep + "cardano-node" + ourpaths.ExeSuffix,
-		Version: versions.CardanoNodeVersion,
-		Revision: versions.CardanoNodeRevision,
-		MkArgv: func() []string {
+		Version: constants.CardanoNodeVersion,
+		Revision: constants.CardanoNodeRevision,
+		MkArgv: func() ([]string, error) {
 			return []string {
 				"run",
 				"--topology", shared.CardanoNodeConfigDir + sep + "topology.json",
@@ -66,7 +66,7 @@ func childCardanoNode(shared SharedState, statusCh chan<- StatusAndUrl) ManagedC
 				"--config", shared.CardanoNodeConfigDir + sep + "config.json",
 				"--socket-path", shared.CardanoNodeSocket,
 				"--shutdown-ipc=3",
-			}
+			}, nil
 		},
 		MkExtraEnv: func() []string { return []string{} },
 		StatusCh: statusCh,

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-cardano-node.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-cardano-node.go
@@ -69,6 +69,7 @@ func childCardanoNode(shared SharedState, statusCh chan<- StatusAndUrl) ManagedC
 			}, nil
 		},
 		MkExtraEnv: func() []string { return []string{} },
+		AllocatePTY: false,
 		StatusCh: statusCh,
 		HealthProbe: func(prev HealthStatus) HealthStatus {
 			tmout := 1 * time.Second

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-cardano-node.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-cardano-node.go
@@ -147,5 +147,6 @@ func childCardanoNode(shared SharedState, statusCh chan<- StatusAndUrl) ManagedC
 		},
 		TerminateGracefullyByInheritedFd3: true,
 		ForceKillAfter: 10 * time.Second,
+		AfterExit: func() error { return nil },
 	}
 }

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-cardano-node.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-cardano-node.go
@@ -100,26 +100,34 @@ func childCardanoNode(shared SharedState, statusCh chan<- StatusAndUrl) ManagedC
 				if (*shared.SyncProgress == 1.0) {
 					textual = "synced"
 				}
-				statusCh <- StatusAndUrl { Status: textual, Progress: pr }
+				statusCh <- StatusAndUrl { Status: textual, Progress: pr,
+					TaskSize: -1, SecondsLeft: -1 }
 			}
 
 			if ms := reValidatingChunk.FindStringSubmatch(line); len(ms) > 0 {
 				pr, _ := strconv.ParseFloat(ms[1], 64)
-				statusCh <- StatusAndUrl { Status: "validating chunks", Progress: pr/100 }
+				statusCh <- StatusAndUrl { Status: "validating chunks", Progress: pr/100,
+					TaskSize: -1, SecondsLeft: -1 }
 			} else if strings.Index(line, "Started opening Volatile DB") != -1 {
-				statusCh <- StatusAndUrl { Status: "opening volatile DB", Progress: -1 }
+				statusCh <- StatusAndUrl { Status: "opening volatile DB", Progress: -1,
+					TaskSize: -1, SecondsLeft: -1 }
 			} else if strings.Index(line, "Started opening Ledger DB") != -1 {
-				statusCh <- StatusAndUrl { Status: "opening ledger DB", Progress: -1 }
+				statusCh <- StatusAndUrl { Status: "opening ledger DB", Progress: -1,
+					TaskSize: -1, SecondsLeft: -1 }
 			} else if ms :=reReplayingLedger.FindStringSubmatch(line);len(ms)>0 {
 				pr, _ := strconv.ParseFloat(ms[1], 64)
-				statusCh <- StatusAndUrl { Status: "replaying ledger", Progress: pr/100 }
+				statusCh <- StatusAndUrl { Status: "replaying ledger", Progress: pr/100,
+					TaskSize: -1, SecondsLeft: -1 }
 			} else if strings.Index(line, "Opened lgr db") != -1 {
-				statusCh <- StatusAndUrl { Status: "replaying ledger", Progress: 1.0 }
+				statusCh <- StatusAndUrl { Status: "replaying ledger", Progress: 1.0,
+					TaskSize: -1, SecondsLeft: -1 }
 			} else if ms := rePushingLedger.FindStringSubmatch(line); len(ms)>0 {
 				pr, _ := strconv.ParseFloat(ms[1], 64)
-				statusCh <- StatusAndUrl { Status: "pushing ledger", Progress: pr/100 }
+				statusCh <- StatusAndUrl { Status: "pushing ledger", Progress: pr/100,
+					TaskSize: -1, SecondsLeft: -1 }
 			} else if strings.Index(line, "Initial chain selected") != -1 {
-				statusCh <- StatusAndUrl { Status: "syncing", Progress: -1 }
+				statusCh <- StatusAndUrl { Status: "syncing", Progress: -1,
+					TaskSize: -1, SecondsLeft: -1 }
 			} else if ms := reSyncingInit.FindStringSubmatch(line); len(ms) > 0 {
 				reportSyncing(ms[1])
 			} else if ms := reSyncing.FindStringSubmatch(line); len(ms) > 0 {

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
@@ -1,26 +1,97 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
-	"lace.io/lace-blockchain-services/versions"
+	"github.com/sqweek/dialog"
+
+	"lace.io/lace-blockchain-services/constants"
 	"lace.io/lace-blockchain-services/ourpaths"
+	"lace.io/lace-blockchain-services/mainthread"
 )
 
 func childMithril(shared SharedState, statusCh chan<- StatusAndUrl) ManagedChild {
 	sep := string(filepath.Separator)
 
+	extraEnv := map[string][]string {
+		"preview": []string{
+			"NETWORK=preview",
+			"AGGREGATOR_ENDPOINT=https://aggregator.pre-release-preview.api.mithril.network/aggregator",
+			"GENESIS_VERIFICATION_KEY=" + constants.MithrilGVKPreview,
+		},
+		"preprod": []string{
+			"NETWORK=preprod",
+			"AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator",
+			"GENESIS_VERIFICATION_KEY=" + constants.MithrilGVKPreprod,
+		},
+		"mainnet": []string{
+			"NETWORK=mainnet",
+			"AGGREGATOR_ENDPOINT=https://aggregator.release-mainnet.api.mithril.network/aggregator",
+			"GENESIS_VERIFICATION_KEY=" + constants.MithrilGVKMainnet,
+		},
+	}
+
+	serviceName := "mithril-client"
+	exePath := ourpaths.LibexecDir + sep + "mithril-client" + ourpaths.ExeSuffix
+	snapshotsDir := ourpaths.WorkDir + sep + "mithril-snapshots"
+
 	return ManagedChild{
-		ServiceName: "mithril-client",
-		ExePath: ourpaths.LibexecDir + sep + "mithril-client" + ourpaths.ExeSuffix,
-		Version: versions.MithrilClientVersion,
-		Revision: versions.MithrilClientRevision,
-		MkArgv: func() []string {
-			return []string{}
+		ServiceName: serviceName,
+		ExePath: exePath,
+		Version: constants.MithrilClientVersion,
+		Revision: constants.MithrilClientRevision,
+		MkArgv: func() ([]string, error) {
+			stdout, stderr, err, pid := runCommandWithTimeout(
+				exePath,
+				[]string{"snapshot", "list", "--json"},
+				extraEnv[shared.Network],
+				10 * time.Second,
+			)
+
+			if err != nil {
+				fmt.Printf("%s[%d]: fetching snapshots failed: %v (stderr: %v) (stdout: %v)\n",
+					serviceName, pid, err, string(stdout), string(stderr))
+				mainthread.Schedule(func() {
+					dialog.Message("Fetching Mithril snapshots failed: %v." +
+						"\n\nMore details in the log file.", err).
+						Title("Mithril error").Error()
+				})
+				return nil, err  // restart in normal mode
+			}
+
+			var snapshots []map[string]interface{}
+			err = json.Unmarshal(stdout, &snapshots)
+			if err != nil { return nil, err }
+			if len(snapshots) == 0 { return nil, fmt.Errorf("empty snapshot array") }
+			snapshotRaw, ok := snapshots[0]["digest"]
+			if !ok { return nil, fmt.Errorf("missing ‘digest’ in first snapshot") }
+			snapshot, ok := snapshotRaw.(string)
+			if !ok { return nil, fmt.Errorf("‘digest’ in first snapshot is not a string") }
+
+			downloadDir := snapshotsDir + sep + snapshot
+			err = os.MkdirAll(downloadDir, 0755)
+			if err != nil { return nil, err }
+
+			fmt.Printf("%s[%d]: will download snapshot %v to %v\n",
+				serviceName, pid, snapshot, downloadDir)
+
+			return []string{
+				"snapshot",
+				"download",
+				snapshot,
+				"--download-dir",
+				downloadDir,
+			}, nil
 		},
 		MkExtraEnv: func() []string {
-			return []string{}
+			return extraEnv[shared.Network]
 		},
 		StatusCh: statusCh,
 		HealthProbe: func(prev HealthStatus) HealthStatus {
@@ -40,4 +111,40 @@ func childMithril(shared SharedState, statusCh chan<- StatusAndUrl) ManagedChild
 		TerminateGracefullyByInheritedFd3: false,
 		ForceKillAfter: 5 * time.Second,
 	}
+}
+
+func runCommandWithTimeout(
+	command string,
+	args []string,
+	extraEnv []string,
+	timeout time.Duration,
+) ([]byte, []byte, error, int) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, command, args...)
+
+	// Against possible orphaned child processes during timeout, but so far Mithril doesn’t have them:
+	cmd.WaitDelay =	1 * time.Second
+
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	var rerr error
+
+	if ctx.Err() == context.DeadlineExceeded {
+		rerr = fmt.Errorf("timed out")
+		//return "", "", fmt.Errorf("timed out")
+	} else if err != nil {
+		rerr = fmt.Errorf("failed: %s", err)
+		//return "", "", fmt.Errorf("failed: %s", err)
+	}
+
+	return stdoutBuf.Bytes(), stderrBuf.Bytes(), rerr, cmd.Process.Pid
 }

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"path/filepath"
+	"time"
+
+	"lace.io/lace-blockchain-services/versions"
+	"lace.io/lace-blockchain-services/ourpaths"
+)
+
+func childMithril(shared SharedState, statusCh chan<- StatusAndUrl) ManagedChild {
+	sep := string(filepath.Separator)
+
+	return ManagedChild{
+		ServiceName: "mithril-client",
+		ExePath: ourpaths.LibexecDir + sep + "mithril-client" + ourpaths.ExeSuffix,
+		Version: versions.MithrilClientVersion,
+		Revision: versions.MithrilClientRevision,
+		MkArgv: func() []string {
+			return []string{}
+		},
+		MkExtraEnv: func() []string {
+			return []string{}
+		},
+		StatusCh: statusCh,
+		HealthProbe: func(prev HealthStatus) HealthStatus {
+			return HealthStatus {
+				Initialized: true,
+				DoRestart: false,
+				NextProbeIn: 10 * time.Second,
+				LastErr: nil,
+			}
+		},
+		LogMonitor: func(line string) {
+
+			// TODO: parse statuses & progress
+
+		},
+		LogModifier: func(line string) string { return line },
+		TerminateGracefullyByInheritedFd3: false,
+		ForceKillAfter: 5 * time.Second,
+	}
+}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-ogmios.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-ogmios.go
@@ -31,6 +31,7 @@ func childOgmios(syncProgressCh chan<- float64) func(SharedState, chan<- StatusA
 			}, nil
 		},
 		MkExtraEnv: func() []string { return []string{} },
+		AllocatePTY: false,
 		StatusCh: statusCh,
 		HealthProbe: func(prev HealthStatus) HealthStatus {
 			ogmiosUrl := fmt.Sprintf("http://127.0.0.1:%d", *shared.OgmiosPort)

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-ogmios.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-ogmios.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"regexp"
 
-	"lace.io/lace-blockchain-services/versions"
+	"lace.io/lace-blockchain-services/constants"
 	"lace.io/lace-blockchain-services/ourpaths"
 )
 
@@ -19,16 +19,16 @@ func childOgmios(syncProgressCh chan<- float64) func(SharedState, chan<- StatusA
 	return ManagedChild{
 		ServiceName: "ogmios",
 		ExePath: ourpaths.LibexecDir + sep + "ogmios" + ourpaths.ExeSuffix,
-		Version: versions.OgmiosVersion,
-		Revision: versions.OgmiosRevision,
-		MkArgv: func() []string {
+		Version: constants.OgmiosVersion,
+		Revision: constants.OgmiosRevision,
+		MkArgv: func() ([]string, error) {
 			*shared.OgmiosPort = getFreeTCPPort()
 			return []string{
 				"--host", "127.0.0.1",
 				"--port", fmt.Sprintf("%d", *shared.OgmiosPort),
 				"--node-config", shared.CardanoNodeConfigDir + sep + "config.json",
 				"--node-socket", shared.CardanoNodeSocket,
-			}
+			}, nil
 		},
 		MkExtraEnv: func() []string { return []string{} },
 		StatusCh: statusCh,

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-ogmios.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-ogmios.go
@@ -66,5 +66,6 @@ func childOgmios(syncProgressCh chan<- float64) func(SharedState, chan<- StatusA
 		LogModifier: func(line string) string { return line },
 		TerminateGracefullyByInheritedFd3: false,
 		ForceKillAfter: 5 * time.Second,
+		AfterExit: func() error { return nil },
 	}
 }}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-ogmios.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-ogmios.go
@@ -41,6 +41,8 @@ func childOgmios(syncProgressCh chan<- float64) func(SharedState, chan<- StatusA
 				statusCh <- StatusAndUrl {
 					Status: "listening",
 					Progress: -1,
+					TaskSize: -1,
+					SecondsLeft: -1,
 					Url: ogmiosUrl,
 					OmitUrl: false,
 				}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-provider-server.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-provider-server.go
@@ -49,6 +49,7 @@ func childProviderServer(shared SharedState, statusCh chan<- StatusAndUrl) Manag
 					fmt.Sprintf("%d", *shared.OgmiosPort),
 			}
 		},
+		AllocatePTY: false,
 		StatusCh: statusCh,
 		HealthProbe: func(prev HealthStatus) HealthStatus {
 			backendUrl := fmt.Sprintf("http://127.0.0.1:%d",

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-provider-server.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-provider-server.go
@@ -60,6 +60,8 @@ func childProviderServer(shared SharedState, statusCh chan<- StatusAndUrl) Manag
 				statusCh <- StatusAndUrl {
 					Status: "listening",
 					Progress: -1,
+					TaskSize: -1,
+					SecondsLeft: -1,
 					Url: backendUrl,
 					OmitUrl: false,
 				}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-provider-server.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-provider-server.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"lace.io/lace-blockchain-services/versions"
+	"lace.io/lace-blockchain-services/constants"
 	"lace.io/lace-blockchain-services/ourpaths"
 )
 
@@ -22,14 +22,14 @@ func childProviderServer(shared SharedState, statusCh chan<- StatusAndUrl) Manag
 	return ManagedChild{
 		ServiceName: "provider-server",
 		ExePath: ourpaths.LibexecDir + sep + "node" + ourpaths.ExeSuffix,
-		Version: versions.ProviderServerVersion,
-		Revision: versions.ProviderServerRevision,
-		MkArgv: func() []string {
+		Version: constants.ProviderServerVersion,
+		Revision: constants.ProviderServerRevision,
+		MkArgv: func() ([]string, error) {
 			return []string{
 				ourpaths.CardanoServicesDir + sep + "dist" + sep + "cjs" +
 					sep + "cli.js",
 				"start-provider-server",
-			}
+			}, nil
 		},
 		MkExtraEnv: func() []string {
 			providerServerPort = getFreeTCPPort()

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-provider-server.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-provider-server.go
@@ -78,5 +78,6 @@ func childProviderServer(shared SharedState, statusCh chan<- StatusAndUrl) Manag
 		LogModifier: func(line string) string { return line },
 		TerminateGracefullyByInheritedFd3: false,
 		ForceKillAfter: 5 * time.Second,
+		AfterExit: func() error { return nil },
 	}
 }

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child.go
@@ -36,10 +36,12 @@ type ManagedChild struct {
 }
 
 type StatusAndUrl struct {
-	Status   string
-	Progress float64
-	Url      string
-	OmitUrl  bool
+	Status      string
+	Progress    float64
+	TaskSize    float64
+	SecondsLeft float64
+	Url         string
+	OmitUrl     bool
 }
 
 type HealthStatus struct {
@@ -131,6 +133,8 @@ func manageChildren(comm CommChannels_Manager) {
 			initialStatus := StatusAndUrl{
 				Status: "off",
 				Progress: -1,
+				TaskSize: -1,
+				SecondsLeft: -1,
 				Url: "",
 			}
 			statusCh <- initialStatus
@@ -149,9 +153,13 @@ func manageChildren(comm CommChannels_Manager) {
 					// lessen refreshing, too often causes glitching tray UI on Windows
 					if upd.Status != fullStatus.Status ||
 						upd.Progress != fullStatus.Progress ||
+						upd.TaskSize != fullStatus.TaskSize ||
+						upd.SecondsLeft != fullStatus.SecondsLeft ||
 						(!upd.OmitUrl && upd.Url != fullStatus.Url) {
 						fullStatus.Status = upd.Status
 						fullStatus.Progress = upd.Progress
+						fullStatus.TaskSize = upd.TaskSize
+						fullStatus.SecondsLeft = upd.SecondsLeft
 						if !upd.OmitUrl {
 							fullStatus.Url = upd.Url
 						}
@@ -178,6 +186,8 @@ func manageChildren(comm CommChannels_Manager) {
 				cardanoNodeStatusCh <- StatusAndUrl {
 					Status: textual,
 					Progress: syncProgress,
+					TaskSize: -1,
+					SecondsLeft: -1,
 					OmitUrl: true,
 				}
 			}
@@ -197,6 +207,8 @@ func manageChildren(comm CommChannels_Manager) {
 				child.StatusCh <- StatusAndUrl{
 					Status: "off",
 					Progress: -1,
+					TaskSize: -1,
+					SecondsLeft: -1,
 					Url: "",
 					OmitUrl: false,
 				}
@@ -223,11 +235,20 @@ func manageChildren(comm CommChannels_Manager) {
 				dependant.StatusCh <- StatusAndUrl{
 					Status: fmt.Sprintf("waiting for %s", child.ServiceName),
 					Progress: -1,
+					TaskSize: -1,
+					SecondsLeft: -1,
 					Url: "",
 					OmitUrl: true,
 				}
 			}
-			child.StatusCh <- StatusAndUrl { Status: "starting…", Progress: -1, Url: "", OmitUrl: true }
+			child.StatusCh <- StatusAndUrl {
+				Status: "starting…",
+				Progress: -1,
+				TaskSize: -1,
+				SecondsLeft: -1,
+				Url: "",
+				OmitUrl: true,
+			}
 			outputLines := make(chan string)
 			terminateCh := make(chan struct{}, 1)
 			childDidExit := false
@@ -245,6 +266,8 @@ func manageChildren(comm CommChannels_Manager) {
 					child.StatusCh <- StatusAndUrl {
 						Status: "terminating…",
 						Progress: -1,
+						TaskSize: -1,
+						SecondsLeft: -1,
 						Url: "",
 						OmitUrl: true,
 					}
@@ -265,6 +288,8 @@ func manageChildren(comm CommChannels_Manager) {
 				child.StatusCh <- StatusAndUrl{
 					Status: "off",
 					Progress: -1,
+					TaskSize: -1,
+					SecondsLeft: -1,
 					Url: "",
 					OmitUrl: false,
 				}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child.go
@@ -290,6 +290,9 @@ func manageChildren(comm CommChannels_Manager) {
 				if err != nil {
 					fmt.Printf("%s[%d]: AfterExit of %s[%d] returned an error: %v\n",
 						OurLogPrefix, os.Getpid(), child.ServiceName, childPid, err)
+				} else if child.ServiceName == "mithril-client" {
+					// don’t wait after a successful Mithril resync
+					omitSleep = true
 				}
 				child.StatusCh <- StatusAndUrl{
 					Status: "off",

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/go.mod
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf // indirect
+	github.com/creack/pty v1.1.18 // indirect
 	github.com/getlantern/context v0.0.0-20190109183933-c447772a6520 // indirect
 	github.com/getlantern/errors v0.0.0-20190325191628-abdb3e3e36f7 // indirect
 	github.com/getlantern/golog v0.0.0-20190830074920-4ef2e798c2d7 // indirect

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/go.sum
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/go.sum
@@ -6,6 +6,8 @@ github.com/allan-simon/go-singleinstance v0.0.0-20210120080615-d0997106ab37 h1:2
 github.com/allan-simon/go-singleinstance v0.0.0-20210120080615-d0997106ab37/go.mod h1:6AXRstqK+32jeFmw89QGL2748+dj34Av4xc/I9oo9BY=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
@@ -109,6 +109,8 @@ func main() {
 		networkToHttp := make(chan t.NetworkMagic)
 		networkToManager := make(chan string)
 
+		triggerMithril := make(chan struct{})
+
 		go func(){
 			reverseNetworks := map[string]t.NetworkMagic{}
 			for a, b := range networks { reverseNetworks[b] = a }
@@ -142,11 +144,13 @@ func main() {
 			HttpSwitchesNetwork: networkFromHttp,
 			NetworkSwitch: networkFromUI,
 			InitiateShutdownCh: initiateShutdownCh,
+			TriggerMithril: triggerMithril,
 		}, CommChannels_Manager {
 			ServiceUpdate: serviceUpdateFromManager,
 			BlockRestartUI: blockRestartUI,
 			NetworkSwitch: networkToManager,
 			InitiateShutdownCh: initiateShutdownCh,
+			TriggerMithril: triggerMithril,
 		}, httpapi.CommChannels {
 			SwitchNetwork: networkFromHttp,
 			SwitchedNetwork: networkToHttp,
@@ -202,6 +206,7 @@ type CommChannels_UI struct {
 
 	NetworkSwitch        chan<- string
 	InitiateShutdownCh   chan<- struct{}
+	TriggerMithril       chan<- struct{}
 }
 
 type CommChannels_Manager struct {
@@ -210,6 +215,7 @@ type CommChannels_Manager struct {
 
 	NetworkSwitch        <-chan string
 	InitiateShutdownCh   <-chan struct{}
+	TriggerMithril       <-chan struct{}
 }
 
 func logSystemHealth() {

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
@@ -13,7 +13,7 @@ import (
 	"encoding/json"
 
 	t "lace.io/lace-blockchain-services/types"
-	"lace.io/lace-blockchain-services/versions"
+	"lace.io/lace-blockchain-services/constants"
 	"lace.io/lace-blockchain-services/ourpaths"
 	"lace.io/lace-blockchain-services/appconfig"
 	"lace.io/lace-blockchain-services/httpapi"
@@ -132,8 +132,8 @@ func main() {
 			Status: "listening",
 			Progress: -1,
 			Url: fmt.Sprintf("http://127.0.0.1:%d", appConfig.ApiPort),
-			Version: versions.LaceBlockchainServicesVersion,
-			Revision: versions.LaceBlockchainServicesRevision,
+			Version: constants.LaceBlockchainServicesVersion,
+			Revision: constants.LaceBlockchainServicesRevision,
 		}
 
 		initiateShutdownCh := make(chan struct{}, 1)

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
@@ -131,6 +131,8 @@ func main() {
 			ServiceName: "lace-blockchain-services",
 			Status: "listening",
 			Progress: -1,
+			TaskSize: -1,
+			SecondsLeft: -1,
 			Url: fmt.Sprintf("http://127.0.0.1:%d", appConfig.ApiPort),
 			Version: constants.LaceBlockchainServicesVersion,
 			Revision: constants.LaceBlockchainServicesRevision,

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread.go
@@ -7,6 +7,9 @@ import (
 /*
 #cgo linux pkg-config: gtk+-3.0
 
+#cgo darwin CFLAGS: -DDARWIN -x objective-c -fobjc-arc
+#cgo darwin LDFLAGS: -framework Cocoa -framework Webkit
+
 void lbs__mainthread__schedule();
 */
 import "C"

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread_darwin.m
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread_darwin.m
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+extern void lbs__mainthread__call_current_function();
+
+void lbs__mainthread__schedule() {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        lbs__mainthread__call_current_function();
+    });
+}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread_linux.c
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread_linux.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+#include <gtk/gtk.h>
+
+extern void lbs__mainthread__call_current_function();
+
+gboolean lbs__mainthread__schedule_wrapper(gpointer plain_func) {
+  lbs__mainthread__call_current_function();
+  return FALSE;  // run it only once
+}
+
+void lbs__mainthread__schedule() {
+  g_idle_add(lbs__mainthread__schedule_wrapper, NULL);
+}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread_linux.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread_linux.go
@@ -1,0 +1,35 @@
+package mainthread
+
+import (
+	"sync"
+)
+
+/*
+#cgo linux pkg-config: gtk+-3.0
+
+void lbs__mainthread__schedule();
+*/
+import "C"
+
+// XXX: we can’t pass Go function pointers to C, so let’s use a synchronized global variable instead
+
+var mu sync.Mutex
+var currentFunction *func()
+
+func Schedule(f func()) {
+	mu.Lock()
+	currentFunction = &f
+	C.lbs__mainthread__schedule()
+}
+
+func freeCurrentFunction() {
+	currentFunction = nil
+}
+
+//export lbs__mainthread__call_current_function
+func lbs__mainthread__call_current_function() {
+	defer mu.Unlock()
+	defer freeCurrentFunction()
+	(*currentFunction)()
+}
+

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread_windows.c
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/mainthread/mainthread_windows.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+extern void lbs__mainthread__call_current_function();
+
+void lbs__mainthread__schedule() {
+  // FIXME: fill this in – but how?
+}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/openapi.json
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/openapi.json
@@ -182,6 +182,18 @@
             "description": "Progress of the `status` – usually between 0.0 and 1.0",
             "example": 0.53778
           },
+          "taskSize": {
+            "type": "number",
+            "format": "double",
+            "description": "Size of the current task, e.g. with Mithril it’s the size of the blockchain",
+            "example": 2619930050.0
+          },
+          "secondsLeft": {
+            "type": "number",
+            "format": "double",
+            "description": "Estimated time remaining to completion in seconds",
+            "example": 244.3
+          },
           "version": {
             "type": "string",
             "description": "Version (release)",

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/setup_systray.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/setup_systray.go
@@ -146,12 +146,12 @@ func setupTrayUI(
 
 	mMithrilStatus := systray.AddMenuItem("", "")
 	mMithrilStatus.Hide()
+	mMithrilStatusETA := mMithrilStatus.AddSubMenuItem("", "")
+	mMithrilStatusETA.Disable()
 	mMithrilStatusDledSize := mMithrilStatus.AddSubMenuItem("", "")
 	mMithrilStatusDledSize.Disable()
 	mMithrilStatusTotalSize := mMithrilStatus.AddSubMenuItem("", "")
 	mMithrilStatusTotalSize.Disable()
-	mMithrilStatusETA := mMithrilStatus.AddSubMenuItem("", "")
-	mMithrilStatusETA.Disable()
 	go func(){
 		for upd := range chMithrilStatus {
 			if upd.Status == "off" {
@@ -166,6 +166,10 @@ func setupTrayUI(
 			}
 			mMithrilStatus.SetTitle("mithril · " + formatted)
 
+			eta := "—"
+			if upd.SecondsLeft >= 0 { eta = "in " + secondsToHuman(upd.SecondsLeft) }
+			mMithrilStatusETA.SetTitle("ETA: " + eta)
+
 			downloaded := "—                 "  // extra spaces to accomodate future value in UI
 			if upd.Progress >= 0 && upd.TaskSize >= 0 {
 				downloaded = bytesToHuman(upd.Progress * upd.TaskSize)
@@ -175,10 +179,6 @@ func setupTrayUI(
 			total := "—"
 			if upd.TaskSize >= 0 { total = bytesToHuman(upd.TaskSize) }
 			mMithrilStatusTotalSize.SetTitle("Total: " + total)
-
-			eta := "—"
-			if upd.SecondsLeft >= 0 { eta = "in " + secondsToHuman(upd.SecondsLeft) }
-			mMithrilStatusETA.SetTitle("ETA: " + eta)
 		}
 	}()
 

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/setup_systray.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/setup_systray.go
@@ -208,13 +208,15 @@ func setupTrayUI(
 			mainthread.Schedule(func() {
 				fmt.Printf("%s[%d]: info: Mithril from goroutine %v\n",
 					OurLogPrefix, os.Getpid(), goid())
-				dialog.Message(
+				ans := dialog.Message(
 					"Resync the entire blockchain from scratch with Mithril?\n\n" +
 					"This will delete your current cardano-node DB.\n\n" +
-					"Estimated time: %s",
+					"Estimated time: %s.",
 					eta[currentNetwork]).Title("Resync with Mithril?").YesNo()
+				if ans {
+					comm.TriggerMithril <- struct{}{}
+				}
 			})
-
 		}
 	}()
 

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/setup_systray.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/setup_systray.go
@@ -154,7 +154,11 @@ func setupTrayUI(
 	mMithrilStatusETA.Disable()
 	go func(){
 		for upd := range chMithrilStatus {
-			if upd.Status == "off" { mMithrilStatus.Hide() } else {	mMithrilStatus.Show() }
+			if upd.Status == "off" {
+				mainthread.Schedule(mMithrilStatus.Hide)
+			} else {
+				mainthread.Schedule(mMithrilStatus.Show)
+			}
 
 			formatted := upd.Status
 			if upd.Progress >= 0 && upd.Progress <= 1 {

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/types/types.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/types/types.go
@@ -6,6 +6,8 @@ type ServiceStatus struct {
 	ServiceName string  `json:"serviceName"`
 	Status      string  `json:"status"`
 	Progress    float64 `json:"progress"`
+	TaskSize    float64 `json:"taskSize"`
+	SecondsLeft float64 `json:"secondsLeft"`
 	Url         string  `json:"url"`
 	Version     string  `json:"version"`
 	Revision    string  `json:"revision"`

--- a/nix/lace-blockchain-services/internal/x86_64-linux.nix
+++ b/nix/lace-blockchain-services/internal/x86_64-linux.nix
@@ -48,6 +48,7 @@ in rec {
     cp ${lace-blockchain-services-exe}/bin/* $out/bin/
     ln -s ${cardano-node}/bin/* $out/libexec/
     ln -s ${ogmios}/bin/* $out/libexec/
+    ln -s ${mithril-client}/bin/* $out/libexec/
     ln -s ${cardano-js-sdk.nodejs}/bin/node $out/libexec
     ln -s ${pkgs.xclip}/bin/xclip $out/libexec
 

--- a/nix/lace-blockchain-services/internal/x86_64-linux.nix
+++ b/nix/lace-blockchain-services/internal/x86_64-linux.nix
@@ -37,7 +37,7 @@ in rec {
       cp cardano.png tray-icon
       cp ${common.openApiJson} openapi.json
       go-bindata -pkg assets -o assets/assets.go tray-icon openapi.json
-      mkdir -p versions && cp ${common.hardcodedVersions} versions/versions.go
+      mkdir -p constants && cp ${common.constants} constants/constants.go
     '';
   };
 

--- a/nix/lace-blockchain-services/internal/x86_64-linux.nix
+++ b/nix/lace-blockchain-services/internal/x86_64-linux.nix
@@ -137,4 +137,17 @@ in rec {
     ${lib.getExe pkgs.python3} -m http.server ${toString port}
   '';
 
+  mithril-client = pkgs.runCommand "mithril-client-${common.mithril-bin.version}" {} ''
+    cp ${common.mithril-bin}/mithril-client ./
+
+    chmod +wx mithril-client
+    patchelf --set-interpreter ${pkgs.stdenv.cc.bintools.dynamicLinker} \
+      --set-rpath ${with pkgs; lib.makeLibraryPath [ /* pkgs.stdenv.cc.cc */ openssl_1_1 ]} \
+      mithril-client
+
+    mkdir -p $out/bin
+    cp mithril-client $out/bin
+    $out/bin/mithril-client --version
+  '';
+
 }

--- a/nix/lace-blockchain-services/internal/x86_64-windows.nix
+++ b/nix/lace-blockchain-services/internal/x86_64-windows.nix
@@ -162,6 +162,7 @@ in rec {
   mkPackage = { withJS }: pkgs.runCommand "lace-blockchain-services" {} ''
     mkdir -p $out/libexec
     cp -Lr ${lace-blockchain-services-exe-with-icon}/* $out/
+    cp -L ${mithril-client}/*.{exe,dll} $out/libexec
     cp -L ${ogmios}/bin/*.{exe,dll} $out/libexec/
     cp -L ${cardano-js-sdk.target.nodejs}/node.exe $out/libexec/
     cp -Lf ${cardano-node}/bin/*.{exe,dll} $out/libexec/

--- a/nix/lace-blockchain-services/internal/x86_64-windows.nix
+++ b/nix/lace-blockchain-services/internal/x86_64-windows.nix
@@ -649,4 +649,10 @@ in rec {
     };
   };
 
+  mithril-client = pkgs.runCommand "mithril-client-${common.mithril-bin.version}" {} ''
+    mkdir -p $out
+    cp ${common.mithril-bin}/mithril-client.exe $out/
+    cp ${cardano-js-sdk.msvc-installed}/VC/Tools/MSVC/*/bin/Hostx64/arm/vcruntime140.dll $out/
+  '';
+
 }

--- a/nix/lace-blockchain-services/internal/x86_64-windows.nix
+++ b/nix/lace-blockchain-services/internal/x86_64-windows.nix
@@ -44,7 +44,7 @@ in rec {
       cp ${icon} tray-icon
       cp ${common.openApiJson} openapi.json
       go-bindata -pkg assets -o assets/assets.go tray-icon openapi.json
-      mkdir -p versions && cp ${common.hardcodedVersions} versions/versions.go
+      mkdir -p constants && cp ${common.constants} constants/constants.go
       go build ${if noConsoleWindow then "-ldflags -H=windowsgui" else ""}
     '';
     installPhase = ''


### PR DESCRIPTION
# Checklist

- [ ] JIRA - https://input-output.atlassian.net/browse/LW-7659
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Since currently Mithril cannot do incremental sync, we only add a button to force resync from scratch using Mithril

* [x] ~Requires #306 to be merged first~
* [ ] Requires #319 to be merged first

## Testing

**Note**: it currently only works on Linux and macOS

Windows support is in PR #368

1. Click on this menu item in the system tray area: “**Resync with Mithril**”
2. Wait for the download and verification, watch the status in the tray menu
3. And also watch the status in “**Dashboard**”
4. `cardano-node` will be started automatically after that – wait for it to verify the new `chain` directory and start syncing by itself where Mithril left off

## Screenshots

![image](https://github.com/input-output-hk/lace/assets/4366292/3772ffbb-46da-4499-a32e-af82622b5778)


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1109/5647533090/index.html) for [af09b7c6](https://github.com/input-output-hk/lace/pull/307/commits/af09b7c6fc6c9392db0c17e987d69d44d4e272fd)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->

[LW-7774]: https://input-output.atlassian.net/browse/LW-7774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ