### PR TITLE
test(extension): downgrade wdio to 8.11

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -30,14 +30,14 @@
     "@types/flat": "5.0.2",
     "@typescript-eslint/eslint-plugin": "6.0.0",
     "@typescript-eslint/parser": "6.0.0",
-    "@wdio/allure-reporter": "8.12.3",
-    "@wdio/cli": "8.13.1",
-    "@wdio/config": "8.12.1",
-    "@wdio/cucumber-framework": "8.12.1",
-    "@wdio/devtools-service": "8.13.1",
-    "@wdio/local-runner": "8.13.1",
-    "@wdio/selenium-standalone-service": "8.12.1",
-    "@wdio/spec-reporter": "8.12.2",
+    "@wdio/allure-reporter": "8.11.3",
+    "@wdio/cli": "8.11.4",
+    "@wdio/config": "8.11.3",
+    "@wdio/cucumber-framework": "8.11.3",
+    "@wdio/devtools-service": "8.11.3",
+    "@wdio/local-runner": "8.11.3",
+    "@wdio/selenium-standalone-service": "8.11.3",
+    "@wdio/spec-reporter": "8.11.2",
     "@wdio/types": "8.10.4",
     "allure-commandline": "2.23.0",
     "clipboardy": "2.3.0",
@@ -50,6 +50,6 @@
     "ts-node": "10.9.1",
     "typescript": "4.9.5",
     "wdio-intercept-service": "4.4.0",
-    "webdriverio": "8.13.1"
+    "webdriverio": "8.11.3"
   }
 }

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -30,7 +30,7 @@
     "@types/flat": "5.0.2",
     "@typescript-eslint/eslint-plugin": "6.0.0",
     "@typescript-eslint/parser": "6.0.0",
-    "@wdio/allure-reporter": "8.11.3",
+    "@wdio/allure-reporter": "8.12.3",
     "@wdio/cli": "8.11.4",
     "@wdio/config": "8.11.3",
     "@wdio/cucumber-framework": "8.11.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11436,30 +11436,30 @@
     loupe "^2.3.6"
     pretty-format "^27.5.1"
 
-"@wdio/allure-reporter@8.12.3":
-  version "8.12.3"
-  resolved "https://registry.yarnpkg.com/@wdio/allure-reporter/-/allure-reporter-8.12.3.tgz#73ab06caf67ae1615c3ea94e8f5ff527d2098c12"
-  integrity sha512-H+ocM3CeQvkMvKt6El7iEGaEp4igNkzqcvCezCo2ijgczpdqn1B9MhuoAdIwUW8/tI8gWsN7/SD93BWC4eH85w==
+"@wdio/allure-reporter@8.11.3":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@wdio/allure-reporter/-/allure-reporter-8.11.3.tgz#136fc077b1d7afd0a045e229f844daac96e2a87a"
+  integrity sha512-H6RMuqsZU/FwU/y9TRblnUY0jzUPj7W23oJVaszDmybUDkBR2y4kbJjtHJuCfSRetDE9hYxUcuYG6v6ddyzjBg==
   dependencies:
     "@types/node" "^20.1.0"
-    "@wdio/reporter" "8.12.2"
+    "@wdio/reporter" "8.11.0"
     "@wdio/types" "8.10.4"
     allure-js-commons "^2.0.0"
     csv-stringify "^6.0.4"
     strip-ansi "^7.1.0"
 
-"@wdio/cli@8.13.1":
-  version "8.13.1"
-  resolved "https://registry.yarnpkg.com/@wdio/cli/-/cli-8.13.1.tgz#af137aa82478508cd5511552d7f65d860aeea46b"
-  integrity sha512-W2EA2BhtKAXNzBWaqGBuTX4GOfNZYTeC0dKqR+g15IVvi1JYJoM2zmLezjNXvWFgtvMd8d/pHIghUKoDEUN9nA==
+"@wdio/cli@8.11.4":
+  version "8.11.4"
+  resolved "https://registry.yarnpkg.com/@wdio/cli/-/cli-8.11.4.tgz#d6d8f098fa248b33a3e155b857d05c0f7ab33634"
+  integrity sha512-BRXwRXHUyi9ii2tmJIFUyOfQ67+wjkhTo8OjIT/DjhNJ0MOTupjqlMYqrc7tiLf0kmcacKimPEfW8cU91OpveQ==
   dependencies:
     "@types/node" "^20.1.1"
-    "@wdio/config" "8.12.1"
-    "@wdio/globals" "8.13.1"
+    "@wdio/config" "8.11.3"
+    "@wdio/globals" "8.11.3"
     "@wdio/logger" "8.11.0"
     "@wdio/protocols" "8.11.0"
     "@wdio/types" "8.10.4"
-    "@wdio/utils" "8.12.1"
+    "@wdio/utils" "8.11.0"
     async-exit-hook "^2.0.1"
     chalk "^5.2.0"
     chokidar "^3.5.3"
@@ -11473,9 +11473,23 @@
     lodash.union "^4.6.0"
     read-pkg-up "9.1.0"
     recursive-readdir "^2.2.3"
-    webdriverio "8.13.1"
+    webdriverio "8.11.3"
     yargs "^17.7.2"
     yarn-install "^1.0.0"
+
+"@wdio/config@8.11.3":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@wdio/config/-/config-8.11.3.tgz#370deeb72e15a58313fefab52d317cf9cd7f57e1"
+  integrity sha512-5He50FYHp3MQAcpHQjVWuIRQtaiWeyMDLuzEEll0Y4cqYmleYAEJ54QJzmDCUvDDS66WhtzJCLdELdj/87tCYg==
+  dependencies:
+    "@wdio/logger" "8.11.0"
+    "@wdio/types" "8.10.4"
+    "@wdio/utils" "8.11.0"
+    decamelize "^6.0.0"
+    deepmerge-ts "^5.0.0"
+    glob "^10.2.2"
+    import-meta-resolve "^3.0.0"
+    read-pkg-up "^9.1.0"
 
 "@wdio/config@8.12.1":
   version "8.12.1"
@@ -11491,10 +11505,10 @@
     import-meta-resolve "^3.0.0"
     read-pkg-up "^9.1.0"
 
-"@wdio/cucumber-framework@8.12.1":
-  version "8.12.1"
-  resolved "https://registry.yarnpkg.com/@wdio/cucumber-framework/-/cucumber-framework-8.12.1.tgz#9fc47c3d0b88cbc3014289bbf6f203d29ed7b684"
-  integrity sha512-TrTp8wenzqARC1ZlpJC+o4jMPHv90bTY1S2mYvKrczBHoVkNR85WZrRwSRVEetbvSyPMxPAA2maYm/46A/n4DQ==
+"@wdio/cucumber-framework@8.11.3":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@wdio/cucumber-framework/-/cucumber-framework-8.11.3.tgz#69c8c4dfbf7230e7ff782ad2d3a1b91baa65859e"
+  integrity sha512-X1JU8DtenOHE/bie3vyvQwdhsYqmXksDghEm2K8bXXBHMVI8Ui/f5GgqjOUnzaBsixUNcYLTP5L8JdF7AflYvg==
   dependencies:
     "@cucumber/cucumber" "8.11.1"
     "@cucumber/gherkin" "26.2.0"
@@ -11504,15 +11518,15 @@
     "@types/node" "^20.1.0"
     "@wdio/logger" "8.11.0"
     "@wdio/types" "8.10.4"
-    "@wdio/utils" "8.12.1"
+    "@wdio/utils" "8.11.0"
     glob "^10.2.2"
     is-glob "^4.0.0"
     mockery "^2.1.0"
 
-"@wdio/devtools-service@8.13.1":
-  version "8.13.1"
-  resolved "https://registry.yarnpkg.com/@wdio/devtools-service/-/devtools-service-8.13.1.tgz#67f2d69ede89e8e2277f0ded16d6166cacfcff10"
-  integrity sha512-QJIJtmC9heVT9zYWZgaQIeGG3rsPQQ62vAi251WFq94h3oCAKYD6OzMa2E/sWdJJ0iXQABFze8SO29mW+wyOgA==
+"@wdio/devtools-service@8.11.3":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@wdio/devtools-service/-/devtools-service-8.11.3.tgz#3487811fa5000189e7dec16a060e98574738ce6b"
+  integrity sha512-Yu91uQ4OmeQtA4XhMJyHlF9nuLPPyBrQnLIkxyODrKjXYv+Umr/AIhQNN5TnVhNxbRJPrkNjWt8kM6VvmmpdVA==
   dependencies:
     "@babel/core" "^7.18.0"
     "@tracerbench/trace-event" "^8.0.0"
@@ -11528,15 +11542,15 @@
     puppeteer-core "20.3.0"
     speedline "^1.4.3"
     stable "^0.1.8"
-    webdriverio "8.13.1"
+    webdriverio "8.11.3"
 
-"@wdio/globals@8.13.1":
-  version "8.13.1"
-  resolved "https://registry.yarnpkg.com/@wdio/globals/-/globals-8.13.1.tgz#e57150f47b46f6b77e8b01be00a41c649986563a"
-  integrity sha512-dtG6VG8MKCgpqH5XJ4+QoPlGIhdsQraNYrpfijfOxyTkge9Mm7hsJN9ztB95HAHTK4e6YXvDZUH0472fnD/saQ==
+"@wdio/globals@8.11.3":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@wdio/globals/-/globals-8.11.3.tgz#7d3613e75d0a6421febcf8be28895362e26519dd"
+  integrity sha512-fBTebV6peml9XMYlUYATR4RbPRZ732/GQERLMYJm2Erj6QQjwxgZWz07f95u5cULMLLHmf0dA3QgQW4RxdeErg==
   optionalDependencies:
     expect-webdriverio "^4.2.5"
-    webdriverio "8.13.1"
+    webdriverio "8.11.3"
 
 "@wdio/globals@^8.13.1":
   version "8.13.4"
@@ -11546,15 +11560,15 @@
     expect-webdriverio "^4.2.5"
     webdriverio "8.13.4"
 
-"@wdio/local-runner@8.13.1":
-  version "8.13.1"
-  resolved "https://registry.yarnpkg.com/@wdio/local-runner/-/local-runner-8.13.1.tgz#e588358cd60a8433669f82d00f57566e4f9c40e0"
-  integrity sha512-e6ervGM2Zm0DydmjnbuvBev/9nW9XSXWF7h80KzaRd9Pe0nkKN8CUFH+jcTUYICpCdbDgFQMEjOao3E2x7KhkQ==
+"@wdio/local-runner@8.11.3":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@wdio/local-runner/-/local-runner-8.11.3.tgz#64a3b0ec7869452f33a61392b55834e77d4b0570"
+  integrity sha512-Yz/7UsDQ/bsSrHxRabx5OrcM0U1VAQFWN+L1ZYk6T6u+WWwrRJU2+IIvLGkTH2chSIM26f1tzsnWIDcN3/BpRA==
   dependencies:
     "@types/node" "^20.1.0"
     "@wdio/logger" "8.11.0"
     "@wdio/repl" "8.10.1"
-    "@wdio/runner" "8.13.1"
+    "@wdio/runner" "8.11.3"
     "@wdio/types" "8.10.4"
     async-exit-hook "^2.0.1"
     split2 "^4.1.0"
@@ -11582,52 +11596,52 @@
   dependencies:
     "@types/node" "^20.1.0"
 
-"@wdio/reporter@8.12.2":
-  version "8.12.2"
-  resolved "https://registry.yarnpkg.com/@wdio/reporter/-/reporter-8.12.2.tgz#c494985a3f2936179c3bf57ba41f486e20cc081c"
-  integrity sha512-xCbppY74dm9jZIgC3Oo5eSMM6pnCXIytol4lFZV1l6LkqWl9WdhBj38cU3Y65XX6gwW+rGnFo36yitxvAXnTaA==
+"@wdio/reporter@8.11.0":
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/@wdio/reporter/-/reporter-8.11.0.tgz#03ce4e6f414ec1789d1b4877c7045fc504241ea2"
+  integrity sha512-eNQxzaTzouyCGRT8ljSzdOf5oJnQxgiKwOs9Cw/j4r5eqd5JQs+GCFP6tFVNjGtPpVIbfsfTb7yI+xmvjNRXhw==
   dependencies:
     "@types/node" "^20.1.0"
     "@wdio/logger" "8.11.0"
     "@wdio/types" "8.10.4"
     diff "^5.0.0"
     object-inspect "^1.12.0"
-    supports-color "9.4.0"
+    supports-color "9.3.1"
 
-"@wdio/runner@8.13.1":
-  version "8.13.1"
-  resolved "https://registry.yarnpkg.com/@wdio/runner/-/runner-8.13.1.tgz#5362c9ca8e9feba5501b11d93cf80e36221e8754"
-  integrity sha512-61g16KrA/uTK0ror87nykvMRtUG1yTxgPYgPLZtLLboAnxHcrFLBp42AZwQI9RqJJmcInJxvHiMqr+soNz57mA==
+"@wdio/runner@8.11.3":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@wdio/runner/-/runner-8.11.3.tgz#e31714fdf39195811e45e7c759438df5629d0574"
+  integrity sha512-QR7H/+QbUSL0tssdlh1Zi4s7JxZoKeN9by1HWnUdA9j9p3Nze1DGKnVooDxF4gsRnVOp0yQikFRseiWsM/Ezjg==
   dependencies:
     "@types/node" "^20.1.0"
-    "@wdio/config" "8.12.1"
-    "@wdio/globals" "8.13.1"
+    "@wdio/config" "8.11.3"
+    "@wdio/globals" "8.11.3"
     "@wdio/logger" "8.11.0"
     "@wdio/types" "8.10.4"
-    "@wdio/utils" "8.12.1"
+    "@wdio/utils" "8.11.0"
     deepmerge-ts "^5.0.0"
     expect-webdriverio "^4.2.5"
     gaze "^1.1.2"
-    webdriver "8.13.1"
-    webdriverio "8.13.1"
+    webdriver "8.11.3"
+    webdriverio "8.11.3"
 
-"@wdio/selenium-standalone-service@8.12.1":
-  version "8.12.1"
-  resolved "https://registry.yarnpkg.com/@wdio/selenium-standalone-service/-/selenium-standalone-service-8.12.1.tgz#8c81b4b23b2ded3437bd717f4df5fe78509a89b0"
-  integrity sha512-f4BAQw/QQoaGsVzrD+QWDjQTDhmvQjrdOC98S0Lx9SY37BtRSnWPjIOeZxZkR/MTFnmx/5/g30XPxc30YAe4YQ==
+"@wdio/selenium-standalone-service@8.11.3":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@wdio/selenium-standalone-service/-/selenium-standalone-service-8.11.3.tgz#61727bd94e4f9f7564c48dd810d0d8f1d4bfa899"
+  integrity sha512-lajW1wRFOd3IfcGLItFaOoL5zOnsWPG3rHtnUAhlSc/Wdr8CgkbmDYO18IDYjhJXPKeTZ1Nmq8694hf3wwHKqA==
   dependencies:
     "@types/node" "^20.1.0"
-    "@wdio/config" "8.12.1"
+    "@wdio/config" "8.11.3"
     "@wdio/logger" "8.11.0"
     "@wdio/types" "8.10.4"
     selenium-standalone "^8.2.1"
 
-"@wdio/spec-reporter@8.12.2":
-  version "8.12.2"
-  resolved "https://registry.yarnpkg.com/@wdio/spec-reporter/-/spec-reporter-8.12.2.tgz#471d20d85a0389ec50ad82adbcc04466d4d5e59e"
-  integrity sha512-0rAXiclTnaHU9tg3cFimA5vErT3z+ytnhFMTKjH/OxS0gWUliX6LcLz111uoiv8ux39iQ+SDmMgZBEx3Sn3mkQ==
+"@wdio/spec-reporter@8.11.2":
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/@wdio/spec-reporter/-/spec-reporter-8.11.2.tgz#9c39ed120f3389154989c26df7f66ef02689d1a3"
+  integrity sha512-ylhxICgen4eEMXgGBEAN6lYs/UnQ4WUYy2ld/4978vRObXy7pGINz96pIPZHAMn01ENU0+gWr8edwawfZyrqLw==
   dependencies:
-    "@wdio/reporter" "8.12.2"
+    "@wdio/reporter" "8.11.0"
     "@wdio/types" "8.10.4"
     chalk "^5.1.2"
     easy-table "^1.2.0"
@@ -11639,6 +11653,16 @@
   integrity sha512-aLJ1QQW+hhALeRK3bvMLjIrlUVyhOs3Od+91pR4Z4pLwyeNG1bJZCJRD5bAJK/mm7CnFa0NsdixPS9jJxZcRrw==
   dependencies:
     "@types/node" "^20.1.0"
+
+"@wdio/utils@8.11.0":
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-8.11.0.tgz#0390c37528f359e8a20b8d7e9f3f792559658952"
+  integrity sha512-XBl1zalk5UPu8QKZ7LZIA82Ad363fpNHZHP5uI5OxUFnk4ZPWgY9eCWpeD+4f9a0DS0w2Dro15E4PORNX84pIw==
+  dependencies:
+    "@wdio/logger" "8.11.0"
+    "@wdio/types" "8.10.4"
+    import-meta-resolve "^3.0.0"
+    p-iteration "^1.1.8"
 
 "@wdio/utils@8.12.1":
   version "8.12.1"
@@ -16597,6 +16621,26 @@ devtools-protocol@^0.0.1170846:
   version "0.0.1170846"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1170846.tgz#e5822c62c56a8aff7c937bb04e69823f4235fc42"
   integrity sha512-GFZiHgvL4JW7+8hIMQgwYNUaIRRCsqfXd11ZbOTdu2VzDeu0Le4l1c3u4FFRWCSvMg82OFip9k/sYyz4M/PJIA==
+
+devtools@8.11.3:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/devtools/-/devtools-8.11.3.tgz#09b7fae3c8c3db2d2b64a56e624d53237366826f"
+  integrity sha512-FaditRJFdCzVsNKBNbl0WI+R8jqnvTHIDeFEZmoGwFXildvw4bm38Aw16O7jj8mHJA7iJ1EKEfzgDxZ0E/M1JA==
+  dependencies:
+    "@types/node" "^20.1.0"
+    "@wdio/config" "8.11.3"
+    "@wdio/logger" "8.11.0"
+    "@wdio/protocols" "8.11.0"
+    "@wdio/types" "8.10.4"
+    "@wdio/utils" "8.11.0"
+    chrome-launcher "^0.15.0"
+    edge-paths "^3.0.5"
+    import-meta-resolve "^3.0.0"
+    puppeteer-core "20.3.0"
+    query-selector-shadow-dom "^1.0.0"
+    ua-parser-js "^1.0.1"
+    uuid "^9.0.0"
+    which "^3.0.0"
 
 devtools@8.12.1:
   version "8.12.1"
@@ -32063,10 +32107,10 @@ suffix@^0.1.0:
   resolved "https://registry.yarnpkg.com/suffix/-/suffix-0.1.1.tgz#cc58231646a0ef1102f79478ef3a9248fd9c842f"
   integrity sha512-j5uf6MJtMCfC4vBe5LFktSe4bGyNTBk7I2Kdri0jeLrcv5B9pWfxVa5JQpoxgtR8vaVB7bVxsWgnfQbX5wkhAA==
 
-supports-color@9.4.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.4.0.tgz#17bfcf686288f531db3dea3215510621ccb55954"
-  integrity sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==
+supports-color@9.3.1:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.3.1.tgz#34e4ad3c71c9a39dae3254ecc46c9b74e89e15a6"
+  integrity sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -34252,6 +34296,23 @@ webassembly-loader-sw@^1.1.0:
     schema-utils "^1.0.0"
     typescript-json-schema "^0.40.0"
 
+webdriver@8.11.3:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-8.11.3.tgz#f1b10dd2308b6c59412a9532910b4a39f68ffe2f"
+  integrity sha512-MtT6R0FWS2Ye7McTihQhPhmB5CoktYVgCjjmoK3CmVEcu/0SPWmDi/uIJH0VHSTddwmr7FcHvLFIf75suorykw==
+  dependencies:
+    "@types/node" "^20.1.0"
+    "@types/ws" "^8.5.3"
+    "@wdio/config" "8.11.3"
+    "@wdio/logger" "8.11.0"
+    "@wdio/protocols" "8.11.0"
+    "@wdio/types" "8.10.4"
+    "@wdio/utils" "8.11.0"
+    deepmerge-ts "^5.0.0"
+    got "^ 12.6.1"
+    ky "^0.33.0"
+    ws "^8.8.0"
+
 webdriver@8.13.1:
   version "8.13.1"
   resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-8.13.1.tgz#c673763bc3a8aa2b3a0b7515eab36f9ba258f9d5"
@@ -34269,23 +34330,23 @@ webdriver@8.13.1:
     ky "^0.33.0"
     ws "^8.8.0"
 
-webdriverio@8.13.1:
-  version "8.13.1"
-  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-8.13.1.tgz#1036f1ba385f35e09edd826583c4631905e1981e"
-  integrity sha512-7+nYYe3+SpMXszyzMi9VS8ynTMXgnWMwuHWfrIuNieVmHGqAF8S3nLa4/5POpegNOJwOXNE6dEucf5l9MLxC/Q==
+webdriverio@8.11.3:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-8.11.3.tgz#a9cf27fbd96a165ecf873e8be477a34acc20809d"
+  integrity sha512-UmpzFrZd8bSNOWGZ7HkrCphZvXOwsHsLYHGhs9uh/Ty29mVmlvNSCpv6v18tKi0sRNvvwqWpSoN4q1bfLI58WQ==
   dependencies:
     "@types/node" "^20.1.0"
-    "@wdio/config" "8.12.1"
+    "@wdio/config" "8.11.3"
     "@wdio/logger" "8.11.0"
     "@wdio/protocols" "8.11.0"
     "@wdio/repl" "8.10.1"
     "@wdio/types" "8.10.4"
-    "@wdio/utils" "8.12.1"
+    "@wdio/utils" "8.11.0"
     archiver "^5.0.0"
     aria-query "^5.0.0"
     css-shorthand-properties "^1.1.1"
     css-value "^0.0.1"
-    devtools "8.12.1"
+    devtools "8.11.3"
     devtools-protocol "^0.0.1161598"
     grapheme-splitter "^1.0.2"
     import-meta-resolve "^3.0.0"
@@ -34298,7 +34359,7 @@ webdriverio@8.13.1:
     resq "^1.9.1"
     rgb2hex "0.2.5"
     serialize-error "^8.0.0"
-    webdriver "8.13.1"
+    webdriver "8.11.3"
 
 webdriverio@8.13.4, webdriverio@^8.13.1:
   version "8.13.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11436,13 +11436,13 @@
     loupe "^2.3.6"
     pretty-format "^27.5.1"
 
-"@wdio/allure-reporter@8.11.3":
-  version "8.11.3"
-  resolved "https://registry.yarnpkg.com/@wdio/allure-reporter/-/allure-reporter-8.11.3.tgz#136fc077b1d7afd0a045e229f844daac96e2a87a"
-  integrity sha512-H6RMuqsZU/FwU/y9TRblnUY0jzUPj7W23oJVaszDmybUDkBR2y4kbJjtHJuCfSRetDE9hYxUcuYG6v6ddyzjBg==
+"@wdio/allure-reporter@8.12.3":
+  version "8.12.3"
+  resolved "https://registry.yarnpkg.com/@wdio/allure-reporter/-/allure-reporter-8.12.3.tgz#73ab06caf67ae1615c3ea94e8f5ff527d2098c12"
+  integrity sha512-H+ocM3CeQvkMvKt6El7iEGaEp4igNkzqcvCezCo2ijgczpdqn1B9MhuoAdIwUW8/tI8gWsN7/SD93BWC4eH85w==
   dependencies:
     "@types/node" "^20.1.0"
-    "@wdio/reporter" "8.11.0"
+    "@wdio/reporter" "8.12.2"
     "@wdio/types" "8.10.4"
     allure-js-commons "^2.0.0"
     csv-stringify "^6.0.4"
@@ -11607,6 +11607,18 @@
     diff "^5.0.0"
     object-inspect "^1.12.0"
     supports-color "9.3.1"
+
+"@wdio/reporter@8.12.2":
+  version "8.12.2"
+  resolved "https://registry.yarnpkg.com/@wdio/reporter/-/reporter-8.12.2.tgz#c494985a3f2936179c3bf57ba41f486e20cc081c"
+  integrity sha512-xCbppY74dm9jZIgC3Oo5eSMM6pnCXIytol4lFZV1l6LkqWl9WdhBj38cU3Y65XX6gwW+rGnFo36yitxvAXnTaA==
+  dependencies:
+    "@types/node" "^20.1.0"
+    "@wdio/logger" "8.11.0"
+    "@wdio/types" "8.10.4"
+    diff "^5.0.0"
+    object-inspect "^1.12.0"
+    supports-color "9.4.0"
 
 "@wdio/runner@8.11.3":
   version "8.11.3"
@@ -32111,6 +32123,11 @@ supports-color@9.3.1:
   version "9.3.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.3.1.tgz#34e4ad3c71c9a39dae3254ecc46c9b74e89e15a6"
   integrity sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==
+
+supports-color@9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.4.0.tgz#17bfcf686288f531db3dea3215510621ccb55954"
+  integrity sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION


## Proposed solution
Resolving issue with local test debugging.




<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1108/5646330647/index.html) for [5d9df0c8](https://github.com/input-output-hk/lace/pull/308/commits/5d9df0c8b05b78046d38806429b87f7910129f85)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->