### PR TITLE
chore(extension): set drawer title visible

### DIFF
--- a/packages/common/src/ui/components/Drawer/DrawerNavigation.module.scss
+++ b/packages/common/src/ui/components/Drawer/DrawerNavigation.module.scss
@@ -32,7 +32,6 @@
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: -1;
   @media (max-width: $breakpoint-popup) {
     display: none;
   }


### PR DESCRIPTION
# Checklist

- [ ] JIRA https://input-output.atlassian.net/browse/LW-7416

---

## Proposed solution

Drawer title has prop "z-index: -1" which effectively hides it and is nowhere visible.
![CleanShot 2023-07-25 at 10 05 26@2x](https://github.com/input-output-hk/lace/assets/16414517/b0cf977d-e338-45d6-9abe-4aa8a2f6d2b4)




<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1113/5654100294/index.html) for [7e0a3e4e](https://github.com/input-output-hk/lace/pull/310/commits/7e0a3e4eb8718897d497dbe477b5d34728de2759)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->