### PR TITLE
chore(extension): update release notes for 1.3.1

### DIFF
--- a/apps/browser-extension-wallet/src/release-notes/1_3_1.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_3_1.tsx
@@ -5,7 +5,6 @@ const ReleaseNote_1_3_1 = (): React.ReactElement => (
   <>
     <p>Introducing Lace 1.3.1 This hotfix version solves:</p>
     <ul style={{ listStyleType: 'disc', margin: 0 }}>
-      <li>Intermittent issue with Restoring HW wallet</li>
       <li>Issues with HD wallets interacting with dApps</li>
     </ul>
     <p>


### PR DESCRIPTION
Post release cherry-pick 3/3

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1120/5658476171/index.html) for [8c216b02](https://github.com/input-output-hk/lace/pull/314/commits/8c216b02ba0ce722fa912d6033b9fb8bbcd90d88)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->