### PR TITLE
Feat/posthog event properties

### DIFF
--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.ts
@@ -1,4 +1,4 @@
-import { EnhancedAnalyticsOptInStatus, MatomoSendEventProps, PostHogAction } from './types';
+import { EnhancedAnalyticsOptInStatus, ExtensionViews, MatomoSendEventProps, PostHogAction } from './types';
 import { Wallet } from '@lace/cardano';
 import { MatomoClient } from '../matomo';
 import { POSTHOG_ENABLED, PostHogClient } from '../postHog';
@@ -10,13 +10,20 @@ export class AnalyticsTracker {
   protected postHogClient?: PostHogClient;
   protected userIdService?: UserIdService;
 
-  constructor(chain: Wallet.Cardano.ChainId, analyticsDisabled = false, isPostHogEnabled = POSTHOG_ENABLED) {
+  constructor(
+    extensionParams: {
+      chain: Wallet.Cardano.ChainId;
+      view?: ExtensionViews;
+    },
+    analyticsDisabled = false,
+    isPostHogEnabled = POSTHOG_ENABLED
+  ) {
     if (analyticsDisabled) return;
     this.userIdService = getUserIdService();
-    this.matomoClient = new MatomoClient(chain, this.userIdService);
+    this.matomoClient = new MatomoClient(extensionParams.chain, this.userIdService);
 
     if (isPostHogEnabled) {
-      this.postHogClient = new PostHogClient(chain, this.userIdService);
+      this.postHogClient = new PostHogClient(extensionParams.chain, this.userIdService, extensionParams?.view);
     }
   }
 

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 export enum MatomoEventActions {
   CLICK_EVENT = 'click-event',
   HOVER_EVENT = 'hover-event'
@@ -103,8 +104,8 @@ export type PostHogActionsKeys =
 export type PostHogOnboardingActionsValueType = Partial<Record<PostHogActionsKeys, PostHogAction>>;
 export type PostHogOnboardingActionsType = Partial<Record<OnboardingFlows, PostHogOnboardingActionsValueType>>;
 export type PostHogMetadata = {
-  // eslint-disable-next-line camelcase
   distinct_id?: string;
   url: string;
   view: ExtensionViews;
+  sent_at_local: string;
 };

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
@@ -3,8 +3,9 @@ import { useWalletStore } from '@src/stores';
 import debounce from 'lodash/debounce';
 import React, { createContext, useContext, useEffect, useMemo } from 'react';
 import { AnalyticsTracker } from './analyticsTracker';
-import { EnhancedAnalyticsOptInStatus } from './analyticsTracker/types';
+import { EnhancedAnalyticsOptInStatus, ExtensionViews } from './analyticsTracker/types';
 import { ENHANCED_ANALYTICS_OPT_IN_STATUS_LS_KEY } from './matomo/config';
+import shallow from 'zustand/shallow';
 
 interface AnalyticsProviderProps {
   children: React.ReactNode;
@@ -33,14 +34,22 @@ export const AnalyticsProvider = ({
   tracker,
   analyticsDisabled
 }: AnalyticsProviderProps): React.ReactElement => {
-  const { currentChain } = useWalletStore();
+  const { currentChain, view } = useWalletStore(
+    (state) => ({ currentChain: state?.currentChain, view: state.walletUI.appMode }),
+    shallow
+  );
   const [optedInForEnhancedAnalytics] = useLocalStorage(
     ENHANCED_ANALYTICS_OPT_IN_STATUS_LS_KEY,
     EnhancedAnalyticsOptInStatus.OptedOut
   );
 
   const analyticsTracker = useMemo(
-    () => tracker || new AnalyticsTracker(currentChain, analyticsDisabled),
+    () =>
+      tracker ||
+      new AnalyticsTracker(
+        { chain: currentChain, view: view === 'popup' ? ExtensionViews.Popup : ExtensionViews.Extended },
+        analyticsDisabled
+      ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [tracker, analyticsDisabled]
   );

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.test.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.test.ts
@@ -1,6 +1,6 @@
 import { Wallet } from '@lace/cardano';
 import { UserIdService } from '@lib/scripts/types';
-import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
+import { ExtensionViews, PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 import { DEV_NETWORK_ID_TO_POSTHOG_TOKEN_MAP } from '@providers/AnalyticsProvider/postHog/config';
 import { PostHogClient } from '@providers/AnalyticsProvider/postHog/PostHogClient';
 import { userIdServiceMock } from '@src/utils/mocks/test-helpers';
@@ -17,9 +17,13 @@ describe('PostHogClient', () => {
     getId: () => Promise.resolve(userId)
   };
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should initialize posthog on construction', () => {
     // eslint-disable-next-line no-new
-    new PostHogClient(chain, mockUserIdService, publicPosthogHost);
+    new PostHogClient(chain, mockUserIdService, undefined, publicPosthogHost);
     expect(posthog.init).toHaveBeenCalledWith(
       expect.stringContaining(DEV_NETWORK_ID_TO_POSTHOG_TOKEN_MAP[chain.networkMagic]),
       expect.objectContaining({
@@ -29,20 +33,21 @@ describe('PostHogClient', () => {
     );
   });
 
-  it('should send page navigation events with distinct id', async () => {
-    const client = new PostHogClient(chain, mockUserIdService, publicPosthogHost);
+  it('should send page navigation events with distinct id and view = extended as default', async () => {
+    const client = new PostHogClient(chain, mockUserIdService, undefined, publicPosthogHost);
     await client.sendPageNavigationEvent();
     expect(posthog.capture).toHaveBeenCalledWith(
       '$pageview',
       expect.objectContaining({
         // eslint-disable-next-line camelcase
-        distinct_id: userId
+        distinct_id: userId,
+        view: 'extended'
       })
     );
   });
 
   it('should send events with distinct id', async () => {
-    const client = new PostHogClient(chain, mockUserIdService, publicPosthogHost);
+    const client = new PostHogClient(chain, mockUserIdService, undefined, publicPosthogHost);
     const event = PostHogAction.OnboardingCreateClick;
     const extraProps = { some: 'prop', another: 'test' };
 
@@ -60,12 +65,40 @@ describe('PostHogClient', () => {
 
   it('should be possible to change the chain', () => {
     const previewChain = Wallet.Cardano.ChainIds.Preview;
-    const client = new PostHogClient(chain, mockUserIdService, publicPosthogHost);
+    const client = new PostHogClient(chain, mockUserIdService, undefined, publicPosthogHost);
     expect(posthog.set_config).not.toHaveBeenCalled();
     client.setChain(previewChain);
     expect(posthog.set_config).toHaveBeenCalledWith(
       expect.objectContaining({
         token: DEV_NETWORK_ID_TO_POSTHOG_TOKEN_MAP[previewChain.networkMagic]
+      })
+    );
+  });
+
+  it('should send events with property view = popup', async () => {
+    const client = new PostHogClient(chain, mockUserIdService, ExtensionViews.Popup, publicPosthogHost);
+    const event = PostHogAction.OnboardingCreateClick;
+
+    await client.sendEvent(event);
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      event,
+      expect.objectContaining({
+        view: 'popup'
+      })
+    );
+  });
+
+  it('should send events with property view = extended', async () => {
+    const client = new PostHogClient(chain, mockUserIdService, ExtensionViews.Extended, publicPosthogHost);
+    const event = PostHogAction.OnboardingCreateClick;
+
+    await client.sendEvent(event);
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      event,
+      expect.objectContaining({
+        view: 'extended'
       })
     );
   });

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -35,7 +35,8 @@ export class PostHogClient {
       // Disables PostHog user ID persistence - we manage ID ourselves with userIdService
       disable_persistence: true,
       disable_cookie: true,
-      persistence: 'memory'
+      persistence: 'memory',
+      property_blacklist: ['$autocapture_disabled_server_side', '$device_id', '$time']
     });
   }
 

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import posthog from 'posthog-js';
+import dayjs from 'dayjs';
 import { Wallet } from '@lace/cardano';
 import { ExtensionViews, PostHogAction, PostHogMetadata } from '../analyticsTracker';
 import {
@@ -74,7 +75,8 @@ export class PostHogClient {
     return {
       url: window.location.href,
       distinct_id: await this.userIdService.getId(),
-      view: this.view
+      view: this.view,
+      sent_at_local: dayjs().format()
     };
   }
 }

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -36,7 +36,8 @@ export class PostHogClient {
       disable_persistence: true,
       disable_cookie: true,
       persistence: 'memory',
-      property_blacklist: ['$autocapture_disabled_server_side', '$device_id', '$time']
+      property_blacklist: ['$autocapture_disabled_server_side', '$device_id', '$time'],
+      ip: true
     });
   }
 

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -18,6 +18,7 @@ export class PostHogClient {
   constructor(
     private chain: Wallet.Cardano.ChainId,
     private userIdService: UserIdService,
+    private view: ExtensionViews = ExtensionViews.Extended,
     private publicPostHogHost: string = PUBLIC_POSTHOG_HOST
   ) {
     if (!this.publicPostHogHost) throw new Error('PUBLIC_POSTHOG_HOST url has not been provided');
@@ -73,9 +74,7 @@ export class PostHogClient {
     return {
       url: window.location.href,
       distinct_id: await this.userIdService.getId(),
-      // TODO: Since we only have onboarding flow event implemented, we hardcoded this to extended view,
-      // once we implement other flows, we'll need to make this dependable on the current user view (popup or extended) JIRA (TBD)
-      view: ExtensionViews.Extended
+      view: this.view
     };
   }
 }


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-7647](https://input-output.atlassian.net/browse/LW-7647)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR implements `view` and `sent_at_local` properties, also, removes `$autocapture_disabled_server_side`, `$device_id` and `$time` properties

## Testing

Send any event to Post Hog, `view` and `sent_at_local` should be visible in the event property list,
For the `view` property, depending on where the event was sent from, should be equal to `popup` for events sent from popup view or `extended` for events sent from browser tab view
The `sent at local` should have the local time of the user system.

`$autocapture_disabled_server_side`, `$device_id` and `$time` properties should not be visible in the property list of new events.

To test this, new events can be compared with older events, where the older event will have these properties and the new event will not

## Screenshots



[LW-7647]: https://input-output.atlassian.net/browse/LW-7647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ