### PR TITLE
ci: update e2e tests upload bucket

### DIFF
--- a/.github/workflows/e2e-tests-linux.yml
+++ b/.github/workflows/e2e-tests-linux.yml
@@ -103,11 +103,11 @@ jobs:
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.E2E_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_AWS_SECRET_ACCESS_KEY }}
         with:
           storageType: s3
           resultsGlob: './packages/e2e-tests/reports/allure/results/*'
-          bucket: lightwallet
+          bucket: lace-e2e-test-results
           prefix: 'linux/${BROWSER}/${RUN}'
           copyLatest: true
           ignoreMissingResults: true


### PR DESCRIPTION
# Context
Lace has been using catalyst infra for a while and now we need to migrate everything to our own infra

# Proposed solution
Created s3/cloudfront/authlambda with identical configuration as our old one and this PR changes upload location

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1171/5678713630/index.html) for [ef8d1674](https://github.com/input-output-hk/lace/pull/318/commits/ef8d16749d430351aa21c5f645720573a1ae5353)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->