### PR TITLE
test(extension): e2e - fix typo for create-folder related elements

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/CreateFolderDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/CreateFolderDrawer.tsx
@@ -274,12 +274,12 @@ export const NFTFolderDrawer = withNftsFoldersContext(
           actions={[
             {
               body: t('browserView.nfts.exitModal.cancel'),
-              dataTestId: 'create-foler-modal-cancel',
+              dataTestId: 'create-folder-modal-cancel',
               color: 'secondary',
               onClick: () => setIsExitModalVisible(false)
             },
             {
-              dataTestId: 'create-foler-modal-confirm',
+              dataTestId: 'create-folder-modal-confirm',
               onClick: onCloseDrawerConfirm,
               body: t('browserView.nfts.exitModal.confirm')
             }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftFolderConfirmationModal.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftFolderConfirmationModal.tsx
@@ -42,13 +42,13 @@ export const NftFolderConfirmationModal = ({
     visible={visible}
     width={popupView ? popupModalWidth : extendedModalWidth}
   >
-    <div data-testid="create-foler-modal-title" className={styles.header}>
+    <div data-testid="create-folder-modal-title" className={styles.header}>
       {title}
     </div>
-    <div data-testid="create-foler-modal-description" className={styles.content}>
+    <div data-testid="create-folder-modal-description" className={styles.content}>
       {description}
     </div>
-    <div data-testid="create-foler-modal-actions" className={styles.footer}>
+    <div data-testid="create-folder-modal-actions" className={styles.footer}>
       {actions.map(
         ({ dataTestId, body, ...action }: actionProps): React.ReactElement => (
           <Button key={dataTestId} data-testid={dataTestId} {...action} block>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/RenameFolderDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/RenameFolderDrawer.tsx
@@ -105,12 +105,12 @@ export const RenameFolderDrawer = withNftsFoldersContext(
           actions={[
             {
               body: t('browserView.nfts.exitModal.cancel'),
-              dataTestId: 'create-foler-modal-cancel',
+              dataTestId: 'create-folder-modal-cancel',
               color: 'secondary',
               onClick: () => setIsExitModalVisible(false)
             },
             {
-              dataTestId: 'create-foler-modal-confirm',
+              dataTestId: 'create-folder-modal-confirm',
               onClick: onCloseDrawerConfirm,
               body: t('browserView.nfts.exitModal.confirm')
             }

--- a/packages/e2e-tests/src/elements/NFTs/DeleteFolderModal.ts
+++ b/packages/e2e-tests/src/elements/NFTs/DeleteFolderModal.ts
@@ -1,7 +1,7 @@
 class DeleteFolderModal {
   private CONTAINER = '.ant-modal-content';
-  private TITLE = '[data-testid="create-foler-modal-title"]';
-  private DESCRIPTION = '[data-testid="create-foler-modal-description"]';
+  private TITLE = '[data-testid="create-folder-modal-title"]';
+  private DESCRIPTION = '[data-testid="create-folder-modal-description"]';
   private CANCEL_BUTTON = '[data-testid="delete-folder-modal-cancel"]';
   private CONFIRM_BUTTON = '[data-testid="delete-folder-modal-confirm"]';
 

--- a/packages/e2e-tests/src/elements/NFTs/youllHaveToStartAgainModal.ts
+++ b/packages/e2e-tests/src/elements/NFTs/youllHaveToStartAgainModal.ts
@@ -3,10 +3,10 @@ import { ChainablePromiseElement } from 'webdriverio';
 
 class YoullHaveToStartAgainModal {
   private CONTAINER = '.ant-modal-content';
-  private TITLE = '[data-testid="create-foler-modal-title"]';
-  private DESCRIPTION = '[data-testid="create-foler-modal-description"]';
-  private CANCEL_BUTTON = '[data-testid="create-foler-modal-cancel"]';
-  private AGREE_BUTTON = '[data-testid="create-foler-modal-confirm"]';
+  private TITLE = '[data-testid="create-folder-modal-title"]';
+  private DESCRIPTION = '[data-testid="create-folder-modal-description"]';
+  private CANCEL_BUTTON = '[data-testid="create-folder-modal-cancel"]';
+  private AGREE_BUTTON = '[data-testid="create-folder-modal-confirm"]';
 
   get container(): ChainablePromiseElement<WebdriverIO.Element> {
     return $(this.CONTAINER);


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1152/5670528664/index.html) for [39a836c1](https://github.com/input-output-hk/lace/pull/322/commits/39a836c1d0eb4863b1141dd28651da4964e57cc3)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->