### PR TITLE
test(extension): e2e - add tests for NFT folders ordering

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -23,7 +23,9 @@
   },
   "dependencies": {
     "@types/chai": "4.3.5",
-    "chai": "4.3.7"
+    "@types/chai-sorted": "0.2.0",
+    "chai": "4.3.7",
+    "chai-sorted": "0.2.0"
   },
   "devDependencies": {
     "@rpii/wdio-report-events": "8.0.2",

--- a/packages/e2e-tests/src/assert/nftAssert.ts
+++ b/packages/e2e-tests/src/assert/nftAssert.ts
@@ -3,9 +3,12 @@ import { TestnetPatterns } from '../support/patterns';
 import NftsPage from '../elements/NFTs/nftsPage';
 import NftDetails from '../elements/NFTs/nftDetails';
 import { t } from '../utils/translationService';
-import { expect } from 'chai';
+import { expect, use } from 'chai';
 import { browser } from '@wdio/globals';
 import { TokenSelectionPage } from '../elements/newTransaction/tokenSelectionPage';
+import chaiSorted from 'chai-sorted';
+
+use(chaiSorted);
 
 class NftAssert {
   async assertSeeTitleWithCounter() {
@@ -126,6 +129,11 @@ class NftAssert {
     if (shouldBeDisplayed) {
       await expect(await NftDetails.sendNFTButton.getText()).to.equal(await t('core.nftDetail.sendNFT'));
     }
+  }
+
+  async assertSeeFoldersInAlphabeticalOrder() {
+    const folderNames = await NftsPage.folderContainers.map((folder) => folder.getText());
+    await expect(folderNames).to.be.ascending;
   }
 }
 

--- a/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
@@ -273,3 +273,11 @@ Feature: NFT - Folders - Extended view
     Then I see NFTs containing "coin" on the "Select NFTs" page
     When I press "Clear" button in search bar
     And "Select NFTs" page is showing all NFTs that I have
+
+  @LW-7259
+  Scenario: Extended-view - NFT Folders - NFT folders sorted alphabetically
+    Given I navigate to NFTs extended page
+    When I create folder with name: "abc" and first available NFT
+    And I create folder with name: "bcd" and first available NFT
+    And I create folder with name: "cde" and first available NFT
+    Then I see folders on the NFTs page in the alphabetical order

--- a/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
@@ -254,3 +254,11 @@ Feature: NFT - Folders - Popup view
     Then I see NFTs containing "coin" on the "Select NFTs" page
     When I press "Clear" button in search bar
     And "Select NFTs" page is showing all NFTs that I have
+
+  @LW-7276
+  Scenario: Popup-view - NFT Folders - NFT folders sorted alphabetically
+    Given I navigate to NFTs popup page
+    When I create folder with name: "abc" and first available NFT
+    And I create folder with name: "bcd" and first available NFT
+    And I create folder with name: "cde" and first available NFT
+    Then I see folders on the NFTs page in the alphabetical order

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -16,6 +16,7 @@ import NftRenameFolderAsserts from '../assert/NftRenameFolderAsserts';
 import NftRenameFolderPage from '../elements/NFTs/NftRenameFolderPage';
 import { browser } from '@wdio/globals';
 import DeleteFolderModal from '../elements/NFTs/DeleteFolderModal';
+import NftAssert from '../assert/nftAssert';
 
 Given(/^all NFT folders are removed$/, async () => {
   await IndexedDB.clearNFTFolders();
@@ -314,4 +315,20 @@ When(/^I click "(Cancel|Confirm)" button in delete folder modal$/, async (button
     default:
       throw new Error(`Unsupported button name: ${button}`);
   }
+});
+
+When(/^I create folder with name: "([^"]*)" and first available NFT$/, async (folderName: string) => {
+  await NftsPage.createFolderButton.click();
+  await NftCreateFolderPage.setFolderNameInput(folderName);
+  await NftCreateFolderPage.nextButton.waitForClickable();
+  await NftCreateFolderPage.nextButton.click();
+  await NftSelectNftsPage.selectNFTs(1);
+  await NftSelectNftsPage.nextButton.waitForClickable();
+  await NftSelectNftsPage.nextButton.click();
+  await NftsPage.createFolderButton.waitForClickable();
+  await nftCreateFolderAssert.assertSeeFolderOnNftsList(folderName, true);
+});
+
+Then(/^I see folders on the NFTs page in the alphabetical order$/, async () => {
+  await NftAssert.assertSeeFoldersInAlphabeticalOrder();
 });

--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -10,6 +10,7 @@
       "@wdio/cucumber-framework",
       "expect-webdriverio",
       "chai",
+      "@types/chai-sorted",
       "@wdio/devtools-service",
       "wdio-intercept-service"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -10012,6 +10012,13 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
+"@types/chai-sorted@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/chai-sorted/-/chai-sorted-0.2.0.tgz#1f53204a05fdccf5f8063d8ebfb8e641818b6717"
+  integrity sha512-YDeysIUTg6ig2Y949ehUsmOszcxagjp2GZfpk5aYhtIPB4Lud7ukJ66f6mXV+0tNSMyHFLIUmpzXFUMTW4mWQQ==
+  dependencies:
+    "@types/chai" "*"
+
 "@types/chai-subset@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
@@ -14461,6 +14468,11 @@ chacha@^2.1.0:
     readable-stream "^1.0.33"
   optionalDependencies:
     chacha-native "^2.0.0"
+
+chai-sorted@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/chai-sorted/-/chai-sorted-0.2.0.tgz#1fee8f07fef4b0043bdff9e07022a0812c12ef55"
+  integrity sha512-mSDz4v2CpSZcuR9dFbK6D0t+KGVGTFTlqo8mL4eesL7mMcIEeLYNTrjx2cs/5NtCnRPawDv3TB1fBuEsf+dGBw==
 
 chai@4.3.7, chai@^4.3.7:
   version "4.3.7"


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@d1terqjryk7mu9.cloudfront.net/linux/chrome/1154/5671373206/index.html) for [e44861f5](https://github.com/input-output-hk/lace/pull/323/commits/e44861f59376f8e929ad0930d26e291838fdc38f)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->