### PR TITLE
Implements Post Hog events for send flow

### DIFF
--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -66,7 +66,20 @@ export enum PostHogAction {
   OnboardingCreateWritePassphrase17NextClick = 'onboarding | new wallet | write passphrase #17 | next | click',
   OnboardingCreateEnterPassphrase01NextClick = 'onboarding | new wallet | enter passphrase #01 | next | click',
   OnboardingCreateEnterPassphrase09NextClick = 'onboarding | new wallet | enter passphrase #09 | next | click',
-  OnboardingCreateEnterPassphrase17NextClick = 'onboarding | new wallet | enter passphrase #17 | next | click'
+  OnboardingCreateEnterPassphrase17NextClick = 'onboarding | new wallet | enter passphrase #17 | next | click',
+  // Send Flow
+  SendClick = 'send | send | click',
+  SendTransactionDataReviewTransactionClick = 'send | transaction data | review transaction | click',
+  SendTransactionSummaryConfirmClick = 'send | transaction summary | confirm | click',
+  SendTransactionConfirmationConfirmClick = 'send | transaction confirmation | confirm | click',
+  SendAllDoneView = 'send | all done | view',
+  SendAllDoneViewTransactionClick = 'send | all done | view transaction | click',
+  SendAllDoneCloseClick = 'send | all done | close | click',
+  SendAllDoneXClick = 'send | all done | x | click',
+  SendSomethingWentWrongView = 'send | something went wrong | view',
+  SendSomethingWentWrongBackClick = 'send | something went wrong | back | click',
+  SendSomethingWentWrongCancelClick = 'send | something went wrong | cancel | click',
+  SendSomethingWentWrongXClick = 'send | something went wrong | x | click'
 }
 
 export enum EnhancedAnalyticsOptInStatus {

--- a/apps/browser-extension-wallet/src/views/browser-view/components/SendReceiveBox/SendReceiveBox.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/SendReceiveBox/SendReceiveBox.tsx
@@ -10,7 +10,8 @@ import styles from './SendReceiveBox.module.scss';
 import {
   MatomoEventActions,
   MatomoEventCategories,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 
 export const SendReceiveBox = (): React.ReactElement => {
@@ -35,6 +36,7 @@ export const SendReceiveBox = (): React.ReactElement => {
       action: MatomoEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.SendTransaction.SEND_TX_BUTTON_BROWSER
     });
+    analytics.sendEventToPostHog(PostHogAction.SendClick);
     setDrawerConfig({ content: DrawerContent.SEND_TRANSACTION });
   };
 

--- a/apps/browser-extension-wallet/src/views/browser-view/components/SendReceiveBox/SendReceiveBox.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/SendReceiveBox/SendReceiveBox.tsx
@@ -13,12 +13,12 @@ import {
   AnalyticsEventNames,
   PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
-import { SendFlowAnalyticsProperties, useTriggerPoint } from '../../features/send-transaction';
+import { SendFlowTriggerPoints, useAnalyticsSendFlowTriggerPoint } from '../../features/send-transaction';
 
 export const SendReceiveBox = (): React.ReactElement => {
   const analytics = useAnalytics();
   const [config, setDrawerConfig] = useDrawer();
-  const { setTriggerPoint } = useTriggerPoint();
+  const { setTriggerPoint } = useAnalyticsSendFlowTriggerPoint();
   const { t } = useTranslation();
 
   const openReceive = () =>
@@ -33,16 +33,15 @@ export const SendReceiveBox = (): React.ReactElement => {
       )
     });
   const openSend = () => {
-    // eslint-disable-next-line camelcase
-    const postHogProperties: SendFlowAnalyticsProperties = { trigger_point: 'send button' };
     analytics.sendEventToMatomo({
       category: MatomoEventCategories.SEND_TRANSACTION,
       action: MatomoEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.SendTransaction.SEND_TX_BUTTON_BROWSER
     });
-    analytics.sendEventToPostHog(PostHogAction.SendClick, postHogProperties);
+    // eslint-disable-next-line camelcase
+    analytics.sendEventToPostHog(PostHogAction.SendClick, { trigger_point: SendFlowTriggerPoints.SEND_BUTTON });
     setDrawerConfig({ content: DrawerContent.SEND_TRANSACTION });
-    setTriggerPoint('send button');
+    setTriggerPoint(SendFlowTriggerPoints.SEND_BUTTON);
   };
 
   const sendReceiveTranslation = {

--- a/apps/browser-extension-wallet/src/views/browser-view/components/SendReceiveBox/SendReceiveBox.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/SendReceiveBox/SendReceiveBox.tsx
@@ -13,10 +13,12 @@ import {
   AnalyticsEventNames,
   PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
+import { SendFlowAnalyticsProperties, useTriggerPoint } from '../../features/send-transaction';
 
 export const SendReceiveBox = (): React.ReactElement => {
   const analytics = useAnalytics();
   const [config, setDrawerConfig] = useDrawer();
+  const { setTriggerPoint } = useTriggerPoint();
   const { t } = useTranslation();
 
   const openReceive = () =>
@@ -31,13 +33,16 @@ export const SendReceiveBox = (): React.ReactElement => {
       )
     });
   const openSend = () => {
+    // eslint-disable-next-line camelcase
+    const postHogProperties: SendFlowAnalyticsProperties = { trigger_point: 'send button' };
     analytics.sendEventToMatomo({
       category: MatomoEventCategories.SEND_TRANSACTION,
       action: MatomoEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.SendTransaction.SEND_TX_BUTTON_BROWSER
     });
-    analytics.sendEventToPostHog(PostHogAction.SendClick);
+    analytics.sendEventToPostHog(PostHogAction.SendClick, postHogProperties);
     setDrawerConfig({ content: DrawerContent.SEND_TRANSACTION });
+    setTriggerPoint('send button');
   };
 
   const sendReceiveTranslation = {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/Assets.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/Assets.tsx
@@ -17,10 +17,11 @@ import { useAnalyticsContext } from '@providers';
 import {
   MatomoEventCategories,
   MatomoEventActions,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { isNFT } from '@src/utils/is-nft';
-import { useCoinStateSelector } from '../../send-transaction';
+import { SendFlowAnalyticsProperties, useCoinStateSelector, useTriggerPoint } from '../../send-transaction';
 import { getTotalWalletBalance, sortAssets } from '../utils';
 import { AssetsPortfolio } from './AssetsPortfolio/AssetsPortfolio';
 import { AssetDetailsDrawer } from './AssetDetailsDrawer/AssetDetailsDrawer';
@@ -55,6 +56,7 @@ export const Assets = ({ topSection }: AssetsProps): React.ReactElement => {
   const popupView = appMode === APP_MODE_POPUP;
   const hiddenBalancePlaceholder = getHiddenBalancePlaceholder();
   const { setPickedCoin } = useCoinStateSelector(SEND_COIN_OUTPUT_ID);
+  const { setTriggerPoint } = useTriggerPoint();
 
   const [isTransactionDetailsOpen, setIsTransactionDetailsOpen] = useState(false);
   const [fullAssetList, setFullAssetList] = useState<AssetTableProps['rows']>();
@@ -212,7 +214,10 @@ export const Assets = ({ topSection }: AssetsProps): React.ReactElement => {
   );
 
   const onSendAssetClick = (id: string) => {
+    // eslint-disable-next-line camelcase
+    const postHogProperties: SendFlowAnalyticsProperties = { trigger_point: 'tokens page' };
     setPickedCoin(SEND_COIN_OUTPUT_ID, { prev: cardanoCoin.id, next: id });
+    setTriggerPoint('tokens page');
     analytics.sendEventToMatomo({
       category: MatomoEventCategories.VIEW_TOKENS,
       action: MatomoEventActions.CLICK_EVENT,
@@ -221,6 +226,7 @@ export const Assets = ({ topSection }: AssetsProps): React.ReactElement => {
         : AnalyticsEventNames.ViewTokens.SEND_TOKEN_BROWSER
     });
 
+    analytics.sendEventToPostHog(PostHogAction.SendClick, postHogProperties);
     if (popupView) {
       redirectToSend({ params: { id } });
     } else {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/Assets.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/Assets.tsx
@@ -21,7 +21,12 @@ import {
   PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { isNFT } from '@src/utils/is-nft';
-import { SendFlowAnalyticsProperties, useCoinStateSelector, useTriggerPoint } from '../../send-transaction';
+import {
+  SendFlowAnalyticsProperties,
+  useCoinStateSelector,
+  useAnalyticsSendFlowTriggerPoint,
+  SendFlowTriggerPoints
+} from '../../send-transaction';
 import { getTotalWalletBalance, sortAssets } from '../utils';
 import { AssetsPortfolio } from './AssetsPortfolio/AssetsPortfolio';
 import { AssetDetailsDrawer } from './AssetDetailsDrawer/AssetDetailsDrawer';
@@ -56,7 +61,7 @@ export const Assets = ({ topSection }: AssetsProps): React.ReactElement => {
   const popupView = appMode === APP_MODE_POPUP;
   const hiddenBalancePlaceholder = getHiddenBalancePlaceholder();
   const { setPickedCoin } = useCoinStateSelector(SEND_COIN_OUTPUT_ID);
-  const { setTriggerPoint } = useTriggerPoint();
+  const { setTriggerPoint } = useAnalyticsSendFlowTriggerPoint();
 
   const [isTransactionDetailsOpen, setIsTransactionDetailsOpen] = useState(false);
   const [fullAssetList, setFullAssetList] = useState<AssetTableProps['rows']>();
@@ -215,9 +220,9 @@ export const Assets = ({ topSection }: AssetsProps): React.ReactElement => {
 
   const onSendAssetClick = (id: string) => {
     // eslint-disable-next-line camelcase
-    const postHogProperties: SendFlowAnalyticsProperties = { trigger_point: 'tokens page' };
+    const postHogProperties: SendFlowAnalyticsProperties = { trigger_point: SendFlowTriggerPoints.TOKENS };
     setPickedCoin(SEND_COIN_OUTPUT_ID, { prev: cardanoCoin.id, next: id });
-    setTriggerPoint('tokens page');
+    setTriggerPoint(SendFlowTriggerPoints.TOKENS);
     analytics.sendEventToMatomo({
       category: MatomoEventCategories.VIEW_TOKENS,
       action: MatomoEventActions.CLICK_EVENT,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetsPortfolio/AssetsPortfolio.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetsPortfolio/AssetsPortfolio.tsx
@@ -17,7 +17,8 @@ import { useAnalyticsContext } from '@providers/AnalyticsProvider';
 import {
   MatomoEventCategories,
   MatomoEventActions,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import styles from './AssetsPortfolio.module.scss';
 import BigNumber from 'bignumber.js';
@@ -73,6 +74,7 @@ export const AssetsPortfolio = ({
       action: MatomoEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.SendTransaction.SEND_TX_BUTTON_POPUP
     });
+    analytics.sendEventToPostHog(PostHogAction.SendClick);
     redirectToSend({ params: { id: '1' } });
   };
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftsLayout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftsLayout.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { NftItemProps, NftList, NftListProps, NftFolderItemProps, NftsItemsTypes } from '@lace/core';
 import flatten from 'lodash/flatten';
 import isNil from 'lodash/isNil';
-import { SendFlowAnalyticsProperties, useOutputInitialState, useTriggerPoint } from '../../send-transaction';
+import { useOutputInitialState, useAnalyticsSendFlowTriggerPoint, SendFlowTriggerPoints } from '../../send-transaction';
 import { Button, useObservable } from '@lace/common';
 import { DEFAULT_WALLET_BALANCE } from '@src/utils/constants';
 import { Skeleton } from 'antd';
@@ -52,7 +52,7 @@ export const NftsLayout = withNftsFoldersContext((): React.ReactElement => {
     utils: { deleteRecord }
   } = useNftsFoldersContext();
   const { fiatCurrency } = useCurrencyStore();
-  const { setTriggerPoint } = useTriggerPoint();
+  const { setTriggerPoint } = useAnalyticsSendFlowTriggerPoint();
   const [, setDrawerConfig] = useDrawer();
   const setSendInitialState = useOutputInitialState();
 
@@ -180,18 +180,17 @@ export const NftsLayout = withNftsFoldersContext((): React.ReactElement => {
   }, [blockchainProvider]);
 
   const onSendAsset = useCallback(() => {
-    // eslint-disable-next-line camelcase
-    const postHogProperties: SendFlowAnalyticsProperties = { trigger_point: 'nft page' };
     analytics.sendEventToMatomo({
       category: MatomoEventCategories.VIEW_NFT,
       action: MatomoEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.ViewNFTs.SEND_NFT_BROWSER
     });
-    analytics.sendEventToPostHog(PostHogAction.SendClick, postHogProperties);
+    // eslint-disable-next-line camelcase
+    analytics.sendEventToPostHog(PostHogAction.SendClick, { trigger_point: SendFlowTriggerPoints.NFTS });
     closeNftDetails();
     setSendInitialState(selectedNft?.assetId.toString());
     setDrawerConfig({ content: DrawerContent.SEND_TRANSACTION });
-    setTriggerPoint('tokens page');
+    setTriggerPoint(SendFlowTriggerPoints.NFTS);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setDrawerConfig, analytics, selectedNft?.assetId, setSendInitialState]);
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftsLayout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftsLayout.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { NftItemProps, NftList, NftListProps, NftFolderItemProps, NftsItemsTypes } from '@lace/core';
 import flatten from 'lodash/flatten';
 import isNil from 'lodash/isNil';
-import { useOutputInitialState } from '../../send-transaction';
+import { SendFlowAnalyticsProperties, useOutputInitialState, useTriggerPoint } from '../../send-transaction';
 import { Button, useObservable } from '@lace/common';
 import { DEFAULT_WALLET_BALANCE } from '@src/utils/constants';
 import { Skeleton } from 'antd';
@@ -25,7 +25,8 @@ import { useAnalyticsContext, useCurrencyStore } from '@providers';
 import {
   MatomoEventActions,
   MatomoEventCategories,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { DetailsDrawer } from './DetailsDrawer';
 import { NFTFolderDrawer } from './CreateFolder/CreateFolderDrawer';
@@ -51,7 +52,7 @@ export const NftsLayout = withNftsFoldersContext((): React.ReactElement => {
     utils: { deleteRecord }
   } = useNftsFoldersContext();
   const { fiatCurrency } = useCurrencyStore();
-
+  const { setTriggerPoint } = useTriggerPoint();
   const [, setDrawerConfig] = useDrawer();
   const setSendInitialState = useOutputInitialState();
 
@@ -179,14 +180,19 @@ export const NftsLayout = withNftsFoldersContext((): React.ReactElement => {
   }, [blockchainProvider]);
 
   const onSendAsset = useCallback(() => {
+    // eslint-disable-next-line camelcase
+    const postHogProperties: SendFlowAnalyticsProperties = { trigger_point: 'nft page' };
     analytics.sendEventToMatomo({
       category: MatomoEventCategories.VIEW_NFT,
       action: MatomoEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.ViewNFTs.SEND_NFT_BROWSER
     });
+    analytics.sendEventToPostHog(PostHogAction.SendClick, postHogProperties);
     closeNftDetails();
     setSendInitialState(selectedNft?.assetId.toString());
     setDrawerConfig({ content: DrawerContent.SEND_TRANSACTION });
+    setTriggerPoint('tokens page');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setDrawerConfig, analytics, selectedNft?.assetId, setSendInitialState]);
 
   const onCloseFolderDrawer = useCallback(() => {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -15,7 +15,7 @@ import {
   useTransactionProps,
   usePassword,
   useMetadata,
-  useTriggerPoint
+  useAnalyticsSendFlowTriggerPoint
 } from '../../store';
 import { useHandleClose } from './Header';
 import { useWalletStore } from '@src/stores';
@@ -58,7 +58,7 @@ export const Footer = ({ isPopupView, openContinueDialog }: FooterProps): React.
   const confirmRef = useRef<HTMLButtonElement>();
   const triggerSubmit = () => confirmRef.current?.click();
   const { t } = useTranslation();
-  const { triggerPoint } = useTriggerPoint();
+  const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
   const { hasInvalidOutputs, outputMap } = useTransactionProps();
   const { builtTxData } = useBuiltTxState();
   const { setSection, currentSection } = useSections();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -24,7 +24,8 @@ import { useAnalyticsContext } from '@providers/AnalyticsProvider/context';
 import {
   MatomoEventActions,
   MatomoEventCategories,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { buttonIds } from '@hooks/useEnterKeyPress';
 import { AssetPickerFooter } from './AssetPickerFooter';
@@ -82,21 +83,32 @@ export const Footer = ({ isPopupView, openContinueDialog }: FooterProps): React.
 
   const sendAnalytics = useCallback(() => {
     switch (currentSection.currentSection) {
-      case Sections.FORM:
+      case Sections.FORM: {
         sendEventToMatomo(isPopupView ? Events.REVIEW_TX_DETAILS_POPUP : Events.REVIEW_TX_DETAILS_BROWSER);
+        analytics.sendEventToPostHog(PostHogAction.SendTransactionDataReviewTransactionClick);
         break;
-      case Sections.SUMMARY:
+      }
+      case Sections.SUMMARY: {
         sendEventToMatomo(isPopupView ? Events.CONFIRM_TX_DETAILS_POPUP : Events.CONFIRM_TX_DETAILS_BROWSER);
+        analytics.sendEventToPostHog(PostHogAction.SendTransactionSummaryConfirmClick);
         break;
-      case Sections.CONFIRMATION:
+      }
+      case Sections.CONFIRMATION: {
         sendEventToMatomo(isPopupView ? Events.INPUT_TX_PASSWORD_POPUP : Events.INPUT_TX_PASSWORD_BROWSER);
+        analytics.sendEventToPostHog(PostHogAction.SendTransactionConfirmationConfirmClick);
         break;
-      case Sections.SUCCESS_TX:
+      }
+      case Sections.SUCCESS_TX: {
         sendEventToMatomo(isPopupView ? Events.SUCCESS_VIEW_TX_POPUP : Events.SUCCESS_VIEW_TX_BROWSER);
+        analytics.sendEventToPostHog(PostHogAction.SendAllDoneViewTransactionClick);
         break;
-      case Sections.FAIL_TX:
+      }
+      case Sections.FAIL_TX: {
         sendEventToMatomo(isPopupView ? Events.FAIL_BACK_POPUP : Events.FAIL_BACK_BROWSER);
+        analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongBackClick);
+      }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentSection.currentSection, isPopupView, sendEventToMatomo]);
 
   const keyAgentType = getKeyAgentType();
@@ -183,6 +195,16 @@ export const Footer = ({ isPopupView, openContinueDialog }: FooterProps): React.
     sendAnalytics
   ]);
 
+  const handleClose = () => {
+    if (currentSection.currentSection === Sections.SUCCESS_TX) {
+      analytics.sendEventToPostHog(PostHogAction.SendAllDoneCloseClick);
+    } else if (currentSection.currentSection === Sections.FAIL_TX) {
+      analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongCancelClick);
+    }
+
+    onClose();
+  };
+
   const confirmDisable = useMemo(
     () => !builtTxData.tx || hasInvalidOutputs || metadata?.length > METADATA_MAX_LENGTH,
     [builtTxData.tx, hasInvalidOutputs, metadata]
@@ -248,7 +270,7 @@ export const Footer = ({ isPopupView, openContinueDialog }: FooterProps): React.
       >
         {confirmButtonLabel}
       </Button>
-      <Button color="secondary" size="large" block onClick={onClose} data-testid="send-cancel-btn">
+      <Button color="secondary" size="large" block onClick={handleClose} data-testid="send-cancel-btn">
         {currentSection.currentSection === Sections.SUCCESS_TX
           ? t('browserView.transaction.send.footer.close')
           : t('browserView.transaction.send.footer.cancel')}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /* eslint-disable max-statements */
 /* eslint-disable unicorn/no-null */
 import React, { useCallback, useMemo, useEffect, useRef } from 'react';
@@ -13,7 +14,8 @@ import {
   useSubmitingState,
   useTransactionProps,
   usePassword,
-  useMetadata
+  useMetadata,
+  useTriggerPoint
 } from '../../store';
 import { useHandleClose } from './Header';
 import { useWalletStore } from '@src/stores';
@@ -56,6 +58,7 @@ export const Footer = ({ isPopupView, openContinueDialog }: FooterProps): React.
   const confirmRef = useRef<HTMLButtonElement>();
   const triggerSubmit = () => confirmRef.current?.click();
   const { t } = useTranslation();
+  const { triggerPoint } = useTriggerPoint();
   const { hasInvalidOutputs, outputMap } = useTransactionProps();
   const { builtTxData } = useBuiltTxState();
   const { setSection, currentSection } = useSections();
@@ -81,31 +84,34 @@ export const Footer = ({ isPopupView, openContinueDialog }: FooterProps): React.
 
   const isSummaryStep = currentSection.currentSection === Sections.SUMMARY;
 
+  const sendEventToPostHog = (action: PostHogAction) =>
+    analytics.sendEventToPostHog(action, { trigger_point: triggerPoint });
+
   const sendAnalytics = useCallback(() => {
     switch (currentSection.currentSection) {
       case Sections.FORM: {
         sendEventToMatomo(isPopupView ? Events.REVIEW_TX_DETAILS_POPUP : Events.REVIEW_TX_DETAILS_BROWSER);
-        analytics.sendEventToPostHog(PostHogAction.SendTransactionDataReviewTransactionClick);
+        sendEventToPostHog(PostHogAction.SendTransactionDataReviewTransactionClick);
         break;
       }
       case Sections.SUMMARY: {
         sendEventToMatomo(isPopupView ? Events.CONFIRM_TX_DETAILS_POPUP : Events.CONFIRM_TX_DETAILS_BROWSER);
-        analytics.sendEventToPostHog(PostHogAction.SendTransactionSummaryConfirmClick);
+        sendEventToPostHog(PostHogAction.SendTransactionSummaryConfirmClick);
         break;
       }
       case Sections.CONFIRMATION: {
         sendEventToMatomo(isPopupView ? Events.INPUT_TX_PASSWORD_POPUP : Events.INPUT_TX_PASSWORD_BROWSER);
-        analytics.sendEventToPostHog(PostHogAction.SendTransactionConfirmationConfirmClick);
+        sendEventToPostHog(PostHogAction.SendTransactionConfirmationConfirmClick);
         break;
       }
       case Sections.SUCCESS_TX: {
         sendEventToMatomo(isPopupView ? Events.SUCCESS_VIEW_TX_POPUP : Events.SUCCESS_VIEW_TX_BROWSER);
-        analytics.sendEventToPostHog(PostHogAction.SendAllDoneViewTransactionClick);
+        sendEventToPostHog(PostHogAction.SendAllDoneViewTransactionClick);
         break;
       }
       case Sections.FAIL_TX: {
         sendEventToMatomo(isPopupView ? Events.FAIL_BACK_POPUP : Events.FAIL_BACK_BROWSER);
-        analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongBackClick);
+        sendEventToPostHog(PostHogAction.SendSomethingWentWrongBackClick);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -197,9 +203,9 @@ export const Footer = ({ isPopupView, openContinueDialog }: FooterProps): React.
 
   const handleClose = () => {
     if (currentSection.currentSection === Sections.SUCCESS_TX) {
-      analytics.sendEventToPostHog(PostHogAction.SendAllDoneCloseClick);
+      sendEventToPostHog(PostHogAction.SendAllDoneCloseClick);
     } else if (currentSection.currentSection === Sections.FAIL_TX) {
-      analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongCancelClick);
+      sendEventToPostHog(PostHogAction.SendSomethingWentWrongCancelClick);
     }
 
     onClose();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /* eslint-disable complexity */
 /* eslint-disable unicorn/no-null */
 /* eslint-disable sonarjs/cognitive-complexity */
@@ -18,7 +19,8 @@ import {
   usePassword,
   useSubmitingState,
   useMultipleSelection,
-  useSelectedTokenList
+  useSelectedTokenList,
+  useTriggerPoint
 } from '../../store';
 import { useCoinStateSelector, useAddressState } from '@src/views/browser-view/features/send-transaction';
 import { useDrawer } from '@src/views/browser-view/stores';
@@ -135,6 +137,7 @@ export const HeaderNavigation = ({ isPopupView }: HeaderNavigationProps): React.
   const analytics = useAnalyticsContext();
   const [isMultipleSelectionAvailable, setMultipleSelection] = useMultipleSelection();
   const { selectedTokenList, resetTokenList } = useSelectedTokenList();
+  const { triggerPoint } = useTriggerPoint();
 
   const sendAnalytics = useCallback(() => {
     if (section.currentSection === Sections.SUMMARY) {
@@ -178,9 +181,9 @@ export const HeaderNavigation = ({ isPopupView }: HeaderNavigationProps): React.
 
   const onCrossIconClick = () => {
     if (section.currentSection === Sections.SUCCESS_TX) {
-      analytics.sendEventToPostHog(PostHogAction.SendAllDoneXClick);
+      analytics.sendEventToPostHog(PostHogAction.SendAllDoneXClick, { trigger_point: triggerPoint });
     } else if (section.currentSection === Sections.FAIL_TX) {
-      analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongXClick);
+      analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongXClick, { trigger_point: triggerPoint });
     }
     onClose();
   };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
@@ -30,7 +30,8 @@ import { useAnalyticsContext } from '@providers';
 import {
   MatomoEventActions,
   MatomoEventCategories,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 
 import { useWalletStore } from '@src/stores';
@@ -175,6 +176,15 @@ export const HeaderNavigation = ({ isPopupView }: HeaderNavigationProps): React.
     }
   };
 
+  const onCrossIconClick = () => {
+    if (section.currentSection === Sections.SUCCESS_TX) {
+      analytics.sendEventToPostHog(PostHogAction.SendAllDoneXClick);
+    } else if (section.currentSection === Sections.FAIL_TX) {
+      analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongXClick);
+    }
+    onClose();
+  };
+
   const { uiOutputs } = useCoinStateSelector(FIRST_ROW);
   const { address } = useAddressState(FIRST_ROW);
 
@@ -222,7 +232,7 @@ export const HeaderNavigation = ({ isPopupView }: HeaderNavigationProps): React.
             }
           />
         ) : shouldRenderCross ? (
-          <NavigationButton icon="cross" onClick={onClose} />
+          <NavigationButton icon="cross" onClick={onCrossIconClick} />
         ) : undefined
       }
     />

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
@@ -20,7 +20,7 @@ import {
   useSubmitingState,
   useMultipleSelection,
   useSelectedTokenList,
-  useTriggerPoint
+  useAnalyticsSendFlowTriggerPoint
 } from '../../store';
 import { useCoinStateSelector, useAddressState } from '@src/views/browser-view/features/send-transaction';
 import { useDrawer } from '@src/views/browser-view/stores';
@@ -137,7 +137,7 @@ export const HeaderNavigation = ({ isPopupView }: HeaderNavigationProps): React.
   const analytics = useAnalyticsContext();
   const [isMultipleSelectionAvailable, setMultipleSelection] = useMultipleSelection();
   const { selectedTokenList, resetTokenList } = useSelectedTokenList();
-  const { triggerPoint } = useTriggerPoint();
+  const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
 
   const sendAnalytics = useCallback(() => {
     if (section.currentSection === Sections.SUMMARY) {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
@@ -4,13 +4,16 @@ import { ResultMessage } from '@components/ResultMessage';
 import { useAnalyticsContext } from '@providers';
 import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 import styles from './TransactionSuccessView.module.scss';
+import { useTriggerPoint } from '../store';
 
 export const TransactionFail = (): React.ReactElement => {
   const { t } = useTranslation();
   const analytics = useAnalyticsContext();
+  const { triggerPoint } = useTriggerPoint();
 
   useEffect(() => {
-    analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongView);
+    // eslint-disable-next-line camelcase
+    analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongView, { trigger_point: triggerPoint });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
@@ -4,12 +4,12 @@ import { ResultMessage } from '@components/ResultMessage';
 import { useAnalyticsContext } from '@providers';
 import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 import styles from './TransactionSuccessView.module.scss';
-import { useTriggerPoint } from '../store';
+import { useAnalyticsSendFlowTriggerPoint } from '../store';
 
 export const TransactionFail = (): React.ReactElement => {
   const { t } = useTranslation();
   const analytics = useAnalyticsContext();
-  const { triggerPoint } = useTriggerPoint();
+  const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
 
   useEffect(() => {
     // eslint-disable-next-line camelcase

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ResultMessage } from '@components/ResultMessage';
+import { useAnalyticsContext } from '@providers';
+import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 import styles from './TransactionSuccessView.module.scss';
 
 export const TransactionFail = (): React.ReactElement => {
   const { t } = useTranslation();
+  const analytics = useAnalyticsContext();
+
+  useEffect(() => {
+    analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongView);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div data-testid="tx-fail-container" className={styles.successTxContainer}>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
@@ -2,7 +2,7 @@ import { ResultMessage } from '@components/ResultMessage';
 import { TransactionHashBox } from '@components/TransactionHashBox';
 import { useAnalyticsContext } from '@providers';
 import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
-import { useBuiltTxState } from '@views/browser/features/send-transaction';
+import { useBuiltTxState, useTriggerPoint } from '@views/browser/features/send-transaction';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './TransactionSuccessView.module.scss';
@@ -10,10 +10,12 @@ import styles from './TransactionSuccessView.module.scss';
 export const TransactionSuccessView = ({ footerSlot }: { footerSlot?: React.ReactElement }): React.ReactElement => {
   const { t } = useTranslation();
   const { builtTxData: { uiTx: { hash } = {} } = {} } = useBuiltTxState();
+  const { triggerPoint } = useTriggerPoint();
   const analytics = useAnalyticsContext();
 
   useEffect(() => {
-    analytics.sendEventToPostHog(PostHogAction.SendAllDoneView);
+    // eslint-disable-next-line camelcase
+    analytics.sendEventToPostHog(PostHogAction.SendAllDoneView, { trigger_point: triggerPoint });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
@@ -1,13 +1,22 @@
 import { ResultMessage } from '@components/ResultMessage';
 import { TransactionHashBox } from '@components/TransactionHashBox';
+import { useAnalyticsContext } from '@providers';
+import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 import { useBuiltTxState } from '@views/browser/features/send-transaction';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './TransactionSuccessView.module.scss';
 
 export const TransactionSuccessView = ({ footerSlot }: { footerSlot?: React.ReactElement }): React.ReactElement => {
   const { t } = useTranslation();
   const { builtTxData: { uiTx: { hash } = {} } = {} } = useBuiltTxState();
+  const analytics = useAnalyticsContext();
+
+  useEffect(() => {
+    analytics.sendEventToPostHog(PostHogAction.SendAllDoneView);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <>
       <div className={styles.successTxContainer} data-testid="transaction-success-container">

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
@@ -2,7 +2,7 @@ import { ResultMessage } from '@components/ResultMessage';
 import { TransactionHashBox } from '@components/TransactionHashBox';
 import { useAnalyticsContext } from '@providers';
 import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
-import { useBuiltTxState, useTriggerPoint } from '@views/browser/features/send-transaction';
+import { useBuiltTxState, useAnalyticsSendFlowTriggerPoint } from '@views/browser/features/send-transaction';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './TransactionSuccessView.module.scss';
@@ -10,7 +10,7 @@ import styles from './TransactionSuccessView.module.scss';
 export const TransactionSuccessView = ({ footerSlot }: { footerSlot?: React.ReactElement }): React.ReactElement => {
   const { t } = useTranslation();
   const { builtTxData: { uiTx: { hash } = {} } = {} } = useBuiltTxState();
-  const { triggerPoint } = useTriggerPoint();
+  const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
   const analytics = useAnalyticsContext();
 
   useEffect(() => {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/store/store.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/store/store.ts
@@ -1,7 +1,15 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { cardanoCoin } from '@src/utils/constants';
 import create, { SetState, GetState } from 'zustand';
-import { OutputsMap, BuiltTxData, SpentBalances, OutputList, AssetInfo, FormOptions } from '../types';
+import {
+  OutputsMap,
+  BuiltTxData,
+  SpentBalances,
+  OutputList,
+  AssetInfo,
+  FormOptions,
+  SendFlowTriggerPoint
+} from '../types';
 import { Wallet } from '@lace/cardano';
 import { calculateSpentBalance, getOutputValues } from '../helpers';
 import { useCallback, useMemo } from 'react';
@@ -88,6 +96,9 @@ export interface Store {
   setIsRestaking: (param: boolean) => void;
   lastFocusedInput?: string;
   setLastFocusedInput: (param?: string) => void;
+  // Analytics specific properties
+  triggerPoint?: SendFlowTriggerPoint;
+  setTriggerPoint: (param: SendFlowTriggerPoint) => void;
 }
 
 // ====== state setters ======
@@ -290,7 +301,14 @@ const useStore = create<Store>((set, get) => ({
       }
     }),
   resetStates: () =>
-    set((state) => ({ ...state, ...initialState, currentRow: undefined, metadata: undefined, password: undefined })),
+    set((state) => ({
+      ...state,
+      ...initialState,
+      currentRow: undefined,
+      metadata: undefined,
+      password: undefined,
+      triggerPoint: undefined
+    })),
   setMetadataMsg: (msg) => set({ metadata: msg }),
   setSubmitingTxState: (params) =>
     set({
@@ -307,7 +325,8 @@ const useStore = create<Store>((set, get) => ({
     ),
   resetTokenList: () => set({ selectedTokenList: [], selectedNFTs: [] }),
   setIsRestaking: (isRestaking) => set({ isRestaking }),
-  setLastFocusedInput: (lastFocusedInput) => set({ lastFocusedInput }) // keep track of the last focused input element, this way we know where to display the error
+  setLastFocusedInput: (lastFocusedInput) => set({ lastFocusedInput }), // keep track of the last focused input element, this way we know where to display the error
+  setTriggerPoint: (triggerPoint) => set({ triggerPoint })
 }));
 
 // ====== selectors ======
@@ -502,5 +521,10 @@ export const useLastFocusedInput = (): {
     lastFocusedInput,
     setLastFocusedInput
   }));
+
+export const useTriggerPoint = (): {
+  triggerPoint: Store['triggerPoint'];
+  setTriggerPoint: Store['setTriggerPoint'];
+} => useStore(({ triggerPoint, setTriggerPoint }) => ({ triggerPoint, setTriggerPoint }));
 
 export { useStore as sendTransactionStore };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/store/store.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/store/store.ts
@@ -8,7 +8,7 @@ import {
   OutputList,
   AssetInfo,
   FormOptions,
-  SendFlowTriggerPoint
+  SendFlowTriggerPoints
 } from '../types';
 import { Wallet } from '@lace/cardano';
 import { calculateSpentBalance, getOutputValues } from '../helpers';
@@ -97,8 +97,8 @@ export interface Store {
   lastFocusedInput?: string;
   setLastFocusedInput: (param?: string) => void;
   // Analytics specific properties
-  triggerPoint?: SendFlowTriggerPoint;
-  setTriggerPoint: (param: SendFlowTriggerPoint) => void;
+  triggerPoint?: SendFlowTriggerPoints;
+  setTriggerPoint: (param: SendFlowTriggerPoints) => void;
 }
 
 // ====== state setters ======
@@ -522,7 +522,7 @@ export const useLastFocusedInput = (): {
     setLastFocusedInput
   }));
 
-export const useTriggerPoint = (): {
+export const useAnalyticsSendFlowTriggerPoint = (): {
   triggerPoint: Store['triggerPoint'];
   setTriggerPoint: Store['setTriggerPoint'];
 } => useStore(({ triggerPoint, setTriggerPoint }) => ({ triggerPoint, setTriggerPoint }));

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
@@ -68,9 +68,13 @@ export interface TemporaryTransactionData {
   [TemporaryTransactionDataKeys.TEMP_SOURCE]: 'popup' | 'hardware-wallet';
 }
 
-export type SendFlowTriggerPoint = 'nft page' | 'send button' | 'tokens page';
+export enum SendFlowTriggerPoints {
+  NFTS = 'nfts page',
+  SEND_BUTTON = 'send button',
+  TOKENS = 'tokens page'
+}
 
 export type SendFlowAnalyticsProperties = {
-  trigger_point: SendFlowTriggerPoint;
+  trigger_point: SendFlowTriggerPoints;
   // TODO: add rest of the porpeties (LW-7711)
 };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { CardanoTxOut, TxMinimumCoinQuantity } from '../../../../types';
 import { Wallet } from '@lace/cardano';
 import { Handle } from '@cardano-sdk/core';
@@ -66,3 +67,10 @@ export interface TemporaryTransactionData {
   [TemporaryTransactionDataKeys.TEMP_OUTPUTS]: AssetInfo[];
   [TemporaryTransactionDataKeys.TEMP_SOURCE]: 'popup' | 'hardware-wallet';
 }
+
+export type SendFlowTriggerPoint = 'nft page' | 'send button' | 'tokens page';
+
+export type SendFlowAnalyticsProperties = {
+  trigger_point: SendFlowTriggerPoint;
+  // TODO: add rest of the porpeties (LW-7711)
+};

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/__tests__/CollateralDrawer.test.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/__tests__/CollateralDrawer.test.tsx
@@ -16,6 +16,7 @@ const mockUseSyncingTheFirstTime = jest.fn();
 const setSection = jest.fn();
 const mockUseRedirection = jest.fn();
 const mockNotify = jest.fn();
+const mockUseAnalyticsSendFlowTriggerPoint = jest.fn();
 import * as React from 'react';
 import { screen, cleanup, fireEvent, render, within, waitFor } from '@testing-library/react';
 import { CollateralDrawer } from '../CollateralDrawer';
@@ -74,7 +75,8 @@ jest.mock('@src/views/browser-view/features/send-transaction', () => {
   return {
     __esModule: true,
     ...original,
-    useBuiltTxState: mockUseBuitTxState
+    useBuiltTxState: mockUseBuitTxState,
+    useAnalyticsSendFlowTriggerPoint: mockUseAnalyticsSendFlowTriggerPoint
   };
 });
 
@@ -156,6 +158,7 @@ describe('Testing CollateralDrawer component', () => {
       setBuiltTxData,
       builtTxData: {} as unknown as sendTx.BuiltTxData
     });
+    mockUseAnalyticsSendFlowTriggerPoint.mockReturnValue({ triggerPoint: '', setTriggerPoint: jest.fn() });
     mockUseCollateral.mockReturnValue(useCollateral);
     mockGetKeyAgentType.mockReturnValue(Wallet.KeyManagement.KeyAgentType.InMemory);
     mockUseWalletStore.mockImplementation(() => ({


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-7368](https://input-output.atlassian.net/browse/LW-7368)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR implements the Post Hog events for the send flow and adds the trigger point property on each event

List of events:
- send | send | click
- send | transaction data | review transaction | click
- send | transaction summary | confirm | click
- send | transaction confirmation | confirm | click
- send | all done | view
- send | all done | view transaction | click
- send | all done | close | click
- send | all done | x | click
- send | something went wrong | view
- send | something went wrong | back | click
- send | something went wrong | cancel | click
- send | something went wrong | x | click	

## Testing

Go to post hog event explorer section, all send events should have a `trigger_point` property in the property tab,
depending from where the send drawer was opened, the `trigger_point` property can have one of the following values:

- nfts page
- send button
- tokens page

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-7368]: https://input-output.atlassian.net/browse/LW-7368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ