### PR TITLE
test(extension): e2e - add tests for DApp connector

### DIFF
--- a/packages/e2e-tests/src/features/DAppConnector.feature
+++ b/packages/e2e-tests/src/features/DAppConnector.feature
@@ -137,3 +137,36 @@ Feature: DAppConnector - Common
     And I open test DApp
     When I click "Send ADA" "Run" button in test DApp
     Then I see DApp connector "Confirm transaction" page in dark mode
+
+  @LW-4071
+  Scenario: DApp remains authorised after choosing "Always" and removing & restoring a wallet
+    Given I open and authorize test DApp with "Always" setting
+    And I switch to window with Lace
+    And I close all remaining tabs except current one
+    And I remove wallet
+    And I restore a wallet
+    And Wallet is synced
+    And I switch network to: "Preprod" in extended mode
+    And Wallet is synced
+    And I open settings from header menu
+    When I click on "Authorized DApps" setting
+    Then I see test DApp on the Authorized DApps list
+    When I open test DApp
+    Then I don't see DApp window
+    And I de-authorize all DApps in extended mode
+
+  @LW-4070
+  Scenario: Authorize Dapp with 'Only once' and leaving/closing DApp
+    Given I open and authorize test DApp with "Only once" setting
+    And I switch to window with DApp
+    And I close all remaining tabs except current one
+    When I open test DApp
+    Then I don't see DApp window
+    And I navigate to home page on extended view
+    And I close all remaining tabs except current one
+    When I open test DApp
+    Then I see DApp authorization window
+    And I switch to window with Lace
+    And I close all remaining tabs except current one
+    When I open test DApp
+    Then I see DApp authorization window

--- a/packages/e2e-tests/src/pageobject/onboardingPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/onboardingPageObject.ts
@@ -8,6 +8,13 @@ import { Logger } from '../support/logger';
 import { browser } from '@wdio/globals';
 import AnalyticsPage from '../elements/onboarding/analyticsPage';
 import { clearInputFieldValue } from '../utils/inputFieldUtils';
+import Modal from '../elements/modal';
+import OnboardingDataCollectionPageAssert from '../assert/onboarding/onboardingDataCollectionPageAssert';
+import OnboardingWalletNamePageAssert from '../assert/onboarding/onboardingWalletNamePageAssert';
+import CommonOnboardingElements from '../elements/onboarding/commonOnboardingElements';
+import { getTestWallet, TestWalletName } from '../support/walletConfiguration';
+import OnboardingAllDonePage from '../elements/onboarding/allDonePage';
+const validPassword = 'N_8J@bne87A';
 
 class OnboardingPageObject {
   async openLegalPage() {
@@ -29,7 +36,6 @@ class OnboardingPageObject {
   }
 
   async goToMnemonicWriteDownPage(length?: '12' | '15' | '24') {
-    const validPassword = 'N_8J@bne87A';
     await this.openNameYourWalletPage();
     await this.fillWalletNameInput('ValidWalletName');
     await OnboardingWalletNamePage.nextButton.click();
@@ -204,6 +210,27 @@ class OnboardingPageObject {
       case '24':
         await RecoveryPhraseLengthPage.radioButton24wordsButton.click();
     }
+  }
+  async restoreWallet() {
+    const commonOnboardingElements = new CommonOnboardingElements();
+
+    await OnboardingMainPage.restoreWalletButton.click();
+    await Modal.confirmButton.waitForClickable();
+    await Modal.confirmButton.click();
+    await this.openAndAcceptTermsOfUsePage();
+    await OnboardingDataCollectionPageAssert.assertSeeDataCollectionPage();
+    await AnalyticsPage.nextButton.click();
+    await OnboardingWalletNamePageAssert.assertSeeWalletNamePage();
+    await this.fillWalletNameInput('ValidName');
+    await commonOnboardingElements.nextButton.click();
+    await this.fillPasswordPage(validPassword, validPassword);
+    await commonOnboardingElements.nextButton.click();
+    await commonOnboardingElements.nextButton.click();
+    await this.openMnemonicVerificationLastPage(getTestWallet(TestWalletName.TestAutomationWallet).mnemonic ?? []);
+    await commonOnboardingElements.nextButton.click();
+    await OnboardingAllDonePage.nextButton.click();
+    await Modal.cancelButton.waitForClickable();
+    await Modal.cancelButton.click();
   }
 }
 

--- a/packages/e2e-tests/src/steps/commonSteps.ts
+++ b/packages/e2e-tests/src/steps/commonSteps.ts
@@ -29,6 +29,7 @@ import { browser } from '@wdio/globals';
 import faqPageAssert from '../assert/faqPageAssert';
 import { visit } from '../utils/pageUtils';
 import CommonDrawerElements from '../elements/CommonDrawerElements';
+import DAppConnectorPageObject from '../pageobject/dAppConnectorPageObject';
 
 Given(/^Lace is ready for test$/, async () => {
   await tokensPageObject.waitUntilCardanoTokenLoaded();
@@ -205,8 +206,8 @@ Then(/^I close all remaining tabs except current one$/, async () => {
   await closeAllTabsExceptActiveOne();
 });
 
-Then(/^I switch to window with Lace$/, async () => {
-  await switchToWindowWithLace();
+Then(/^I switch to window with (Lace|DApp)$/, async (window: 'Lace' | 'DApp') => {
+  await (window === 'Lace' ? switchToWindowWithLace() : DAppConnectorPageObject.switchToTestDAppWindow());
 });
 
 When(/^I resize the window to a width of: ([^"]*) and a height of: ([^"]*)$/, async (width: number, height: number) => {

--- a/packages/e2e-tests/src/steps/onboardingSteps.ts
+++ b/packages/e2e-tests/src/steps/onboardingSteps.ts
@@ -556,3 +556,7 @@ When(/^I click "Help and support" button during wallet setup$/, async () => {
 When(/^I click "here." link on "Keeping your wallet secure" page$/, async () => {
   await OnboardingMnemonicInfoPage.hereLink.click();
 });
+
+Given(/^I restore a wallet$/, async () => {
+  await OnboardingPageObject.restoreWallet();
+});


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1267/5736418793/index.html) for [3c5292e5](https://github.com/input-output-hk/lace/pull/342/commits/3c5292e5354c3eec1c98f696574fc863ee056738)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->