### PR TITLE
test(extension): e2e - re-enable DApp e2e (smoke) after bugfix

### DIFF
--- a/.github/workflows/e2e-tests-win.yml
+++ b/.github/workflows/e2e-tests-win.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           storageType: s3
           resultsGlob: './packages/e2e-tests/reports/allure/results/*'
-          bucket: lightwallet
+          bucket: lace-e2e-test-results
           prefix: 'windows/${BROWSER}/${RUN}'
           copyLatest: true
           ignoreMissingResults: true

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           storageType: s3
           resultsGlob: './packages/e2e-tests/reports/allure/results'
-          bucket: lightwallet
+          bucket: lace-e2e-test-results
           prefix: 'linux/${BROWSER}/${RUN}'
           copyLatest: true
           ignoreMissingResults: true

--- a/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
+++ b/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
@@ -39,7 +39,11 @@ class DAppConnectorAssert {
     await expect(await commonDappPageElements.betaPill.getText()).to.equal(await t('core.dapp.beta'));
   }
 
-  async assertSeeTitleAndDappDetails(expectedTitleKey: string, expectedDappDetails: ExpectedDAppDetails) {
+  async assertSeeTitleAndDappDetails(
+    expectedTitleKey: string,
+    expectedDappDetails: ExpectedDAppDetails,
+    shouldIncludeFullDAppUrl: boolean
+  ) {
     const currentDAppUrl = new URL(expectedDappDetails.url);
     const commonDappPageElements = new CommonDappPageElements();
     await commonDappPageElements.pageTitle.waitForDisplayed();
@@ -48,14 +52,15 @@ class DAppConnectorAssert {
     await commonDappPageElements.dAppName.waitForDisplayed();
     await expect(await commonDappPageElements.dAppName.getText()).to.equal(expectedDappDetails.name);
     await commonDappPageElements.dAppUrl.waitForDisplayed();
-    await expect(await commonDappPageElements.dAppUrl.getText()).to.equal(
-      `${currentDAppUrl.protocol}//${currentDAppUrl.host}`
-    );
+    const expectedUrl = shouldIncludeFullDAppUrl
+      ? currentDAppUrl.href
+      : `${currentDAppUrl.protocol}//${currentDAppUrl.host}`;
+    await expect(await commonDappPageElements.dAppUrl.getText()).to.equal(expectedUrl);
   }
 
   async assertSeeAuthorizeDAppPage(expectedDappDetails: ExpectedDAppDetails) {
     await this.assertSeeHeader();
-    await this.assertSeeTitleAndDappDetails('dapp.connect.header', expectedDappDetails);
+    await this.assertSeeTitleAndDappDetails('dapp.connect.header', expectedDappDetails, false);
 
     await AuthorizeDAppPage.banner.container.waitForDisplayed();
     await AuthorizeDAppPage.banner.icon.waitForDisplayed();
@@ -225,7 +230,7 @@ class DAppConnectorAssert {
     expectedTransactionData: ExpectedTransactionData
   ) {
     await this.assertSeeHeader();
-    await this.assertSeeTitleAndDappDetails('dapp.confirm.header', expectedDApp);
+    await this.assertSeeTitleAndDappDetails('dapp.confirm.header', expectedDApp, true);
     await ConfirmTransactionPage.transactionTypeTitle.waitForDisplayed();
     await expect(await ConfirmTransactionPage.transactionTypeTitle.getText()).to.equal(
       await t('dapp.confirm.details.header')

--- a/packages/e2e-tests/src/assert/transactionDetailsAssert.ts
+++ b/packages/e2e-tests/src/assert/transactionDetailsAssert.ts
@@ -30,9 +30,9 @@ class TransactionsDetailsAssert {
 
   async assertSeeTransactionDetails(expectedTransactionDetails: ExpectedTransactionDetails) {
     const transactionsDetails = new TransactionDetailsPage();
-    await $(transactionsDetails.transactionDetailsDescription().toJSLocator()).waitForClickable({ timeout: 15_000 });
+    await transactionsDetails.transactionDetailsDescription.waitForClickable({ timeout: 15_000 });
 
-    await expect(await webTester.getTextValueFromElement(transactionsDetails.transactionDetailsDescription())).contains(
+    await expect(await transactionsDetails.transactionDetailsDescription.getText()).contains(
       `${expectedTransactionDetails.transactionDescription}`
     );
     if (expectedTransactionDetails.hash) {
@@ -90,7 +90,7 @@ class TransactionsDetailsAssert {
 
     for (let i = 0; i <= rowsNumber && i < 10; i++) {
       await TransactionsPage.clickOnTransactionRow(i);
-      await webTester.waitUntilSeeElement(transactionsDetails.transactionDetailsDescription(), 15_000);
+      await transactionsDetails.transactionDetailsDescription.waitForClickable({ timeout: 15_000 });
       await transactionsDetails.transactionDetailsHash.waitForDisplayed();
       await webTester.seeWebElement(transactionsDetails.transactionDetailsStatus());
       await webTester.seeWebElement(transactionsDetails.transactionDetailsTimestamp());
@@ -98,7 +98,7 @@ class TransactionsDetailsAssert {
       await webTester.seeWebElement(transactionsDetails.transactionDetailsOutputsSection());
       await webTester.seeWebElement(transactionsDetails.transactionDetailsFeeADA());
       await webTester.seeWebElement(transactionsDetails.transactionDetailsFeeFiat());
-      const txType = (await transactionsDetails.getTransactionDetailDescription()) as string;
+      const txType = await transactionsDetails.transactionDetailsDescription.getText();
       if (txType.includes('Delegation')) {
         await webTester.seeWebElement(transactionsDetails.transactionDetailsStakepoolName());
         await webTester.seeWebElement(transactionsDetails.transactionDetailsStakepoolTicker());
@@ -181,7 +181,7 @@ class TransactionsDetailsAssert {
     for (let i = 0; i <= rowsNumber && i < 10; i++) {
       const transactionType = await TransactionsPage.transactionsTableItemType(i).getText();
       await TransactionsPage.clickOnTransactionRow(i);
-      await webTester.waitUntilSeeElement(transactionsDetails.transactionDetailsDescription(), 15_000);
+      await transactionsDetails.transactionDetailsDescription.waitForClickable({ timeout: 15_000 });
       if (!(transactionType.includes('Delegation') || transactionType.includes('Self'))) {
         await webTester.seeWebElement(transactionsDetails.transactionDetailsSent());
         await webTester.seeWebElement(transactionsDetails.transactionDetailsToAddress());
@@ -200,8 +200,8 @@ class TransactionsDetailsAssert {
       // TODO Cover self transaction details with automation
       if ((await TransactionsPage.transactionsTableItemType(i).getText()) !== 'Self Transaction') {
         await TransactionsPage.clickOnTransactionRow(i);
-        await webTester.waitUntilSeeElement(transactionsDetails.transactionDetailsDescription(), 15_000);
-        const txType = (await transactionsDetails.getTransactionDetailDescription()) as string;
+        await transactionsDetails.transactionDetailsDescription.waitForClickable({ timeout: 15_000 });
+        const txType = await transactionsDetails.transactionDetailsDescription.getText();
         if (!txType.includes('Delegation')) {
           const tokensAmountSummary =
             (await transactionsDetails.getTransactionSentTokensWithoutDuplicates()).length + 1;

--- a/packages/e2e-tests/src/assert/transactionDetailsAssert.ts
+++ b/packages/e2e-tests/src/assert/transactionDetailsAssert.ts
@@ -30,7 +30,7 @@ class TransactionsDetailsAssert {
 
   async assertSeeTransactionDetails(expectedTransactionDetails: ExpectedTransactionDetails) {
     const transactionsDetails = new TransactionDetailsPage();
-    await webTester.waitUntilSeeElement(transactionsDetails.transactionDetailsDescription(), 15_000);
+    await $(transactionsDetails.transactionDetailsDescription().toJSLocator()).waitForClickable({ timeout: 15_000 });
 
     await expect(await webTester.getTextValueFromElement(transactionsDetails.transactionDetailsDescription())).contains(
       `${expectedTransactionDetails.transactionDescription}`

--- a/packages/e2e-tests/src/elements/transactionDetails.ts
+++ b/packages/e2e-tests/src/elements/transactionDetails.ts
@@ -47,8 +47,9 @@ export class TransactionDetailsPage extends CommonDrawerElements {
   get transactionDetailsHash(): ChainablePromiseElement<WebdriverIO.Element> {
     return $(`${this.CONTAINER}${this.TRANSACTION_DETAILS_HASH}`);
   }
-  transactionDetailsDescription(): WebElement {
-    return Factory.fromSelector(`${this.CONTAINER}${this.TRANSACTION_DETAILS_DESCRIPTION}`, 'xpath');
+
+  get transactionDetailsDescription(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(`${this.CONTAINER}${this.TRANSACTION_DETAILS_DESCRIPTION}`);
   }
 
   transactionDetailsAmountOfTokens(): WebElement {
@@ -237,10 +238,6 @@ export class TransactionDetailsPage extends CommonDrawerElements {
 
   async getTransactionSentTokensWithoutDuplicates(): Promise<unknown[]> {
     return await webTester.getTextValuesFromArrayElementWithoutDuplicates(await this.transactionSentTokens());
-  }
-
-  async getTransactionDetailDescription(): Promise<string | number> {
-    return await webTester.getTextValueFromElement(this.transactionDetailsDescription());
   }
 
   async getTransactionDetailDescriptionAmountOfAssets(): Promise<string | number> {

--- a/packages/e2e-tests/src/features/e2e/SendTransactionDappE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/SendTransactionDappE2E.feature
@@ -4,8 +4,7 @@ Feature: Send Transactions from Dapp - E2E
   Background:
     Given Wallet is synced
 
-  @Pending @LW-3761 @Testnet @Smoke
-    # Bug LW-7482
+  @LW-3761 @Testnet @Smoke
   Scenario: Send ADA from DApp E2E
     And I save token: "Cardano" balance
     And I open and authorize test DApp with "Only once" setting
@@ -32,8 +31,7 @@ Feature: Send Transactions from Dapp - E2E
     And I click on a transaction: 1
     Then The Tx details are displayed as "package.core.transactionDetailBrowser.received" for ADA with value: 3.00 and wallet: "WalletSendSimpleTransactionE2E" address
 
-  @Pending @LW-6797 @Testnet
-    # Bug LW-7482
+  @LW-6797 @Testnet
   Scenario: Send Token from DApp E2E
     And I save token: "LaceCoin2" balance
     And I open and authorize test DApp with "Only once" setting


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1264/5736074860/index.html) for [d064e6d1](https://github.com/input-output-hk/lace/pull/343/commits/d064e6d13edf9bcc4deac111229b02a0df629c5b)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 1      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->