### PR TITLE
test(extension): block tests because of a bug

### DIFF
--- a/packages/e2e-tests/src/features/SendTransactionSimpleExtended.feature
+++ b/packages/e2e-tests/src/features/SendTransactionSimpleExtended.feature
@@ -68,7 +68,8 @@ Feature: LW-484: Send & Receive - Extended Browser View (Simple Tx)
     And I open address book from header menu
     Then I see address row with name "WalletName" and address "Shelley" on the list in extended mode
 
-  @LW-2362 @Testnet
+  @LW-2362 @Testnet @Pending
+    # bug LW-7773
   Scenario: Extended-view - Existing address can be selected from the address book and used for transaction
     And I have 3 addresses in my address book in extended mode
     And I navigate to Tokens extended page
@@ -79,7 +80,8 @@ Feature: LW-484: Send & Receive - Extended Browser View (Simple Tx)
     When I enter a value of: 1 to the "tADA" asset in bundle 1
     Then "Review transaction" button is enabled on "Send" page
 
-  @LW-2362 @Mainnet
+  @LW-2362 @Mainnet @Pending
+    # bug LW-7773
   Scenario: Extended-view - Existing address can be selected from the address book and used for transaction
     And I have 3 addresses in my address book in extended mode
     And I navigate to Tokens extended page
@@ -90,7 +92,8 @@ Feature: LW-484: Send & Receive - Extended Browser View (Simple Tx)
     When I enter a value of: 1 to the "ADA" asset in bundle 1
     Then "Review transaction" button is enabled on "Send" page
 
-  @LW-2742 @Testnet @Mainnet
+  @LW-2742 @Testnet @Mainnet @Pending
+    # bug LW-7773
   Scenario: Extended-view - Send flow - Search contact
     Given I have several contacts whose start with the same characters
     And I navigate to Tokens extended page
@@ -98,7 +101,8 @@ Feature: LW-484: Send & Receive - Extended Browser View (Simple Tx)
     When I enter the first characters of the contacts
     Then a dropdown showing the first 5 matches is displayed
 
-  @LW-2743 @Testnet @Mainnet
+  @LW-2743 @Testnet @Mainnet @Pending
+    # bug LW-7773
   Scenario: Extended-view - Send flow - Select contact from dropdown
     Given I have several contacts whose start with the same characters
     And I navigate to Tokens extended page
@@ -107,7 +111,8 @@ Feature: LW-484: Send & Receive - Extended Browser View (Simple Tx)
     And click on one of the contacts on the dropdown
     Then the selected contact is added in the bundle recipient's address
 
-  @LW-2363 @Testnet
+  @LW-2363 @Testnet @Pending
+    # bug LW-7773
   Scenario: Extended-view - Existing address can be selected from the address book and then removed
     And I have 3 addresses in my address book in extended mode
     And I navigate to Tokens extended page
@@ -120,7 +125,8 @@ Feature: LW-484: Send & Receive - Extended Browser View (Simple Tx)
     When I enter a value of: 1 to the "tADA" asset in bundle 1
     Then "Review transaction" button is disabled on "Send" page
 
-  @LW-2363 @Mainnet
+  @LW-2363 @Mainnet @Pending
+    # bug LW-7773
   Scenario: Extended-view - Existing address can be selected from the address book and then removed
     When I have 3 addresses in my address book in extended mode
     And I navigate to Tokens extended page

--- a/packages/e2e-tests/src/features/SendTransactionSimplePopup.feature
+++ b/packages/e2e-tests/src/features/SendTransactionSimplePopup.feature
@@ -63,14 +63,16 @@ Feature: LW-484: Send & Receive - Popup View (Simple Tx)
     And I open address book from header menu
     Then I see address row with name "WalletName" and address "Shelley" on the list in popup mode
 
-  @LW-2740 @Testnet @Mainnet
+  @LW-2740 @Testnet @Mainnet @Pending
+    # bug LW-7773
   Scenario: Popup-view - Send flow - Search contact
     Given I have several contacts whose start with the same characters
     When I click "Send" button on Tokens page in popup mode
     And I enter the first characters of the contacts
     Then a dropdown showing the first 3 matches is displayed
 
-  @LW-2741 @Testnet @Mainnet
+  @LW-2741 @Testnet @Mainnet @Pending
+    # bug LW-7773
   Scenario: Popup-view - Send flow - Select contact from dropdown
     Given I have several contacts whose start with the same characters
     When I click "Send" button on Tokens page in popup mode
@@ -78,7 +80,8 @@ Feature: LW-484: Send & Receive - Popup View (Simple Tx)
     And click on one of the contacts on the dropdown
     Then the selected contact is added in the bundle recipient's address
 
-  @LW-2396 @Testnet
+  @LW-2396 @Testnet @Pending
+    # bug LW-7773
   Scenario: Popup-view - Existing address can be selected from the address book and used for transaction
     And I have 3 addresses in my address book in popup mode
     And I navigate to Tokens popup page
@@ -89,7 +92,8 @@ Feature: LW-484: Send & Receive - Popup View (Simple Tx)
     When I enter a value of: 1 to the "tADA" asset in bundle 1
     Then "Review transaction" button is enabled on "Send" page
 
-  @LW-2396 @Mainnet
+  @LW-2396 @Mainnet @Pending
+    # bug LW-7773
   Scenario: Popup-view - Existing address can be selected from the address book and used for transaction
     And I have 3 addresses in my address book in popup mode
     And I navigate to Tokens popup page
@@ -100,7 +104,8 @@ Feature: LW-484: Send & Receive - Popup View (Simple Tx)
     When I enter a value of: 1 to the "ADA" asset in bundle 1
     Then "Review transaction" button is enabled on "Send" page
 
-  @LW-2397 @Testnet
+  @LW-2397 @Testnet @Pending
+    # bug LW-7773
   Scenario: Popup-view - Existing address can be selected from the address book and then removed
     And I have 3 addresses in my address book in popup mode
     And I navigate to Tokens popup page
@@ -113,7 +118,8 @@ Feature: LW-484: Send & Receive - Popup View (Simple Tx)
     When I enter a value of: 1 to the "tADA" asset in bundle 1
     Then "Review transaction" button is disabled on "Send" page
 
-  @LW-2397 @Mainnet
+  @LW-2397 @Mainnet @Pending
+    # bug LW-7773
   Scenario: Popup-view - Existing address can be selected from the address book and then removed
     And I have 3 addresses in my address book in popup mode
     And I navigate to Tokens popup page


### PR DESCRIPTION
# Checklist

- [ ] JIRA https://input-output.atlassian.net/browse/LW-7773
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Block failing address book tests because of a bug


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1272/5738125770/index.html) for [1c7920de](https://github.com/input-output-hk/lace/pull/344/commits/1c7920de91186a2107da019945a73c75149e8081)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->