### PR TITLE
fix: adds correct number fo characters before ellipsis on names

### DIFF
--- a/packages/core/src/ui/components/DestinationAddressInput/DestinationAddressInput.tsx
+++ b/packages/core/src/ui/components/DestinationAddressInput/DestinationAddressInput.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-magic-numbers */
 import React, { useState, useEffect, useMemo } from 'react';
 import classnames from 'classnames';
 import { AutoCompleteProps, Button } from 'antd';
@@ -10,6 +9,11 @@ import { ReactComponent as AvailableAddress } from '../../assets/icons/close-ico
 import styles from './DestinationAddressInput.module.scss';
 import { TranslationsFor } from '@ui/utils/types';
 import { CheckCircleOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
+
+const charBeforeNameEllipsis = 9;
+
+const charBeforeAddressEllipsis = 10;
+const charAfterAddressEllipsis = 6;
 
 enum HandleVerificationState {
   VALID = 'valid',
@@ -40,9 +44,9 @@ export type DestinationAddressInputProps = Omit<AutoCompleteProps, 'value'> & {
 
 export const getInputLabel = (name: string, address: string): React.ReactElement => (
   <div data-testid="search-result-row" className={styles.addressOption}>
-    <span data-testid="search-result-name">{addEllipsis(name, 4, 2)}</span>
+    <span data-testid="search-result-name">{addEllipsis(name, charBeforeNameEllipsis, 0)}</span>
     <span data-testid="search-result-address">
-      <p className={styles.option}>{addEllipsis(address, 10, 6)}</p>
+      <p className={styles.option}>{addEllipsis(address, charBeforeAddressEllipsis, charAfterAddressEllipsis)}</p>
     </span>
   </div>
 );

--- a/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.tsx
+++ b/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import cn from 'classnames';
 import { Cardano } from '@cardano-sdk/core';
 import { Typography, Tooltip } from 'antd';
-import { Ellipsis } from '@lace/common';
+import { Ellipsis, addEllipsis } from '@lace/common';
 import { ReactComponent as MissingIcon } from '../../assets/icons/missing.component.svg';
 import styles from './WalletAddressItem.module.scss';
 import { useTranslate } from '@src/ui/hooks';
@@ -27,16 +27,17 @@ export type WalletAddressItemProps = {
   isAddressWarningVisible?: boolean;
 };
 
-const defaultBeforeEllipsis = 8;
-const defaultAfterEllipsis = 3;
+const charBeforeEllipsisAddress = 8;
+const charAfterEllipsisAddress = 3;
+
+const charBeforeEllipsisName = 12;
+const charAfterEllipsisName = 0;
 
 export const WalletAddressItem = ({
   id,
   name,
   address,
   onClick,
-  beforeEllipsis = defaultBeforeEllipsis,
-  afterEllipsis = defaultAfterEllipsis,
   className,
   isSmall = false,
   shouldUseEllipsisBeforeAndAfter,
@@ -60,7 +61,7 @@ export const WalletAddressItem = ({
           </div>
           <div data-testid="address-list-item-name" className={cn(styles.listItemName, { [styles.small]: isSmall })}>
             <Text className={styles.textField} ellipsis={{ tooltip: name }}>
-              {name}
+              {addEllipsis(name, charBeforeEllipsisName, charAfterEllipsisName)}
             </Text>
           </div>
         </div>
@@ -79,8 +80,8 @@ export const WalletAddressItem = ({
           withTooltip={false}
           {...(isSmall || shouldUseEllipsisBeforeAndAfter
             ? {
-                beforeEllipsis,
-                afterEllipsis
+                charBeforeEllipsisAddress,
+                charAfterEllipsisAddress
               }
             : { ellipsisInTheMiddle: true })}
         />

--- a/packages/core/src/ui/components/WalletAddresses/__tests__/WalletAddressList.test.tsx
+++ b/packages/core/src/ui/components/WalletAddresses/__tests__/WalletAddressList.test.tsx
@@ -24,11 +24,11 @@ describe('Testing WalletAddressList component', () => {
     scrollableTargetId: addressListContainerTestId,
     translations: {
       name: 'Name',
-      address: 'Address'
+      address: 'addr_tes...67p'
     }
   };
   test('should render a list of 10 complete addresses', async () => {
-    const { findByTestId, findAllByText } = render(
+    const { findByTestId } = render(
       <div
         data-testid={addressListContainerTestId}
         id={addressListContainerTestId}
@@ -39,7 +39,8 @@ describe('Testing WalletAddressList component', () => {
     );
     const list = await findByTestId(addressListTestId);
     const items = await within(list).findAllByTestId('address-list-item');
-    const addresses = await findAllByText('addr_tes...67p');
+    const addresses = await within(list).findAllByTestId('address-list-item-address');
+
     expect(items).toHaveLength(10);
     expect(addresses).toHaveLength(10);
   });


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7773
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Ellipsis the name of the contact after 12 chars. and at the end. 

## Testing
Go to the address book, add contacts with less than, equal and longer than 12 char. and make sure that only those with 12 or more char have an ellipsis at the end. 

## Screenshots

<img width="886" alt="Screenshot 2023-08-03 at 13 10 31" src="https://github.com/input-output-hk/lace/assets/4052063/d277ef02-d233-49d5-9d6e-fa557403164c">
<img width="743" alt="Screenshot 2023-08-03 at 13 10 16" src="https://github.com/input-output-hk/lace/assets/4052063/a07389ce-84cd-42d4-8f98-43631cc8eef5">




<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1280/5740818217/index.html) for [b8b093ee](https://github.com/input-output-hk/lace/pull/346/commits/b8b093eefcf347aa42801b4a2ddf0e70b062f724)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->