### PR TITLE
fix(staking): pool mapping conditions in StakePoolConfirmation and cardano-sdk pkg versions

### DIFF
--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -61,8 +61,8 @@
     "react-i18next": "^12.3.1"
   },
   "devDependencies": {
-    "@cardano-sdk/input-selection": "0.11.2",
-    "@cardano-sdk/tx-construction": "0.9.2",
+    "@cardano-sdk/input-selection": "0.11.4",
+    "@cardano-sdk/tx-construction": "0.9.4",
     "@cardano-sdk/util": "0.13.0",
     "@lace/cardano": "^0.1.0",
     "@lace/common": "^0.1.0",
@@ -97,8 +97,8 @@
     "zustand": "3.5.14"
   },
   "peerDependencies": {
-    "@cardano-sdk/input-selection": "0.11.2",
-    "@cardano-sdk/tx-construction": "0.9.2",
+    "@cardano-sdk/input-selection": "0.11.4",
+    "@cardano-sdk/tx-construction": "0.9.4",
     "@cardano-sdk/util": "0.13.0",
     "@lace/cardano": "^0.1.0",
     "@lace/common": "^0.1.0",

--- a/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.tsx
+++ b/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.tsx
@@ -103,7 +103,8 @@ export const StakePoolItemBrowser = ({
           label={stakePoolStateLabel}
           onClick={(event) => {
             event.stopPropagation();
-            includedInDraft ? removeFromDraft() : addToDraft();
+
+            draftPortfolioExists ? (includedInDraft ? removeFromDraft() : addToDraft()) : onClick(id);
           }}
         />
       </div>

--- a/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.tsx
+++ b/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolItemBrowser/StakePoolItemBrowser.tsx
@@ -103,8 +103,7 @@ export const StakePoolItemBrowser = ({
           label={stakePoolStateLabel}
           onClick={(event) => {
             event.stopPropagation();
-
-            draftPortfolioExists ? (includedInDraft ? removeFromDraft() : addToDraft()) : onClick(id);
+            includedInDraft ? removeFromDraft() : addToDraft();
           }}
         />
       </div>

--- a/packages/staking/src/features/drawer/StakePoolConfirmation.tsx
+++ b/packages/staking/src/features/drawer/StakePoolConfirmation.tsx
@@ -156,15 +156,12 @@ export const StakePoolConfirmation = (): React.ReactElement => {
 
   useEffect(() => {
     (async () => {
-      if (!openPool?.hexId || draftPortfolio.length === 0) return;
+      if (draftPortfolio.length === 0) return;
       // TODO: move below logic to zustand store
       try {
         setIsBuildingTx(true);
         const txBuilder = inMemoryWallet.createTxBuilder();
-        const pools =
-          draftPortfolio.length > 0
-            ? draftPortfolio.map((pool) => ({ id: pool.id, weight: pool.weight }))
-            : [{ id: openPool.hexId, weight: 1 }];
+        const pools = draftPortfolio.map((pool) => ({ id: pool.id, weight: pool.weight }));
         const tx = await txBuilder.delegatePortfolio({ pools }).build().inspect();
         setDelegationTxBuilder(txBuilder);
         setDelegationTxFee(tx.body.fee.toString());
@@ -178,7 +175,15 @@ export const StakePoolConfirmation = (): React.ReactElement => {
         setIsBuildingTx(false);
       }
     })();
-  }, [inMemoryWallet, openPool, setDelegationTxBuilder, setDelegationTxFee, setIsBuildingTx, setStakingError]);
+  }, [
+    draftPortfolio,
+    inMemoryWallet,
+    openPool,
+    setDelegationTxBuilder,
+    setDelegationTxFee,
+    setIsBuildingTx,
+    setStakingError,
+  ]);
 
   const protocolParameters = useObservable(inMemoryWallet?.protocolParameters$);
   const rewardAccounts = useObservable(inMemoryWallet.delegation.rewardAccounts$);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4025,22 +4025,6 @@
     ts-custom-error "^3.2.0"
     ts-log "^2.2.4"
 
-"@cardano-sdk/core@~0.15.3":
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/@cardano-sdk/core/-/core-0.15.3.tgz#a9e3143c2b02f39da387be57498bbf5ef932b393"
-  integrity sha512-OsPMYWZHrrDrDsvR0tmO57yqZVqHUuCTCXiBz7bcDhdDFxVZEJNup5M39HdbgumWRQNkMXyjKgv0AyLjZGp43w==
-  dependencies:
-    "@cardano-ogmios/client" "5.6.0"
-    "@cardano-ogmios/schema" "5.6.0"
-    "@cardano-sdk/crypto" "~0.1.9"
-    "@cardano-sdk/util" "~0.13.0"
-    "@dcspark/cardano-multiplatform-lib-nodejs" "^3.1.1"
-    "@foxglove/crc" "^0.0.3"
-    "@scure/base" "^1.1.1"
-    lodash "^4.17.21"
-    ts-custom-error "^3.2.0"
-    ts-log "^2.2.4"
-
 "@cardano-sdk/crypto@0.1.9", "@cardano-sdk/crypto@~0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@cardano-sdk/crypto/-/crypto-0.1.9.tgz#d8107900f555ff7a4b058fe60dd2fad23faace26"
@@ -4068,17 +4052,6 @@
     ts-log "^2.2.4"
     webextension-polyfill "^0.8.0"
 
-"@cardano-sdk/dapp-connector@~0.9.10":
-  version "0.9.10"
-  resolved "https://registry.yarnpkg.com/@cardano-sdk/dapp-connector/-/dapp-connector-0.9.10.tgz#e24ccedf8543bdb3fb21eff00d8546e5bdd7fa1c"
-  integrity sha512-hjQvPULxukbVFQCU9vfC4p/gJ2owQpG5zXOiaHP2wQN8xSEr29gimBZT4WIW3h2h1ytMnA1NdckOt0+D9d0I8g==
-  dependencies:
-    "@cardano-sdk/core" "~0.15.3"
-    "@cardano-sdk/util" "~0.13.0"
-    ts-custom-error "^3.2.0"
-    ts-log "^2.2.4"
-    webextension-polyfill "^0.8.0"
-
 "@cardano-sdk/hardware-ledger@0.2.17", "@cardano-sdk/hardware-ledger@~0.2.17":
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/@cardano-sdk/hardware-ledger/-/hardware-ledger-0.2.17.tgz#4df15af89e240abc4627f0a015b898aba0943bfe"
@@ -4095,18 +4068,6 @@
     "@ledgerhq/hw-transport-webhid" "^6.27.12"
     ts-custom-error "^3.2.0"
     ts-log "^2.2.4"
-
-"@cardano-sdk/input-selection@0.11.2", "@cardano-sdk/input-selection@~0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@cardano-sdk/input-selection/-/input-selection-0.11.2.tgz#7e6cc9bc31f63c3e3ddb1cabaf7692056d53740c"
-  integrity sha512-ftT/LveMDNoGXm/vNmyLgKEfbLxUVlBxEP+8CQ8n1HFN8SN4B/FZRX3hANJoFuccqr9iiy22vDJNt3CJRNH1Zw==
-  dependencies:
-    "@cardano-sdk/core" "~0.15.3"
-    "@cardano-sdk/key-management" "~0.8.1"
-    "@cardano-sdk/util" "~0.13.0"
-    bignumber.js "^9.1.1"
-    lodash "^4.17.21"
-    ts-custom-error "^3.2.0"
 
 "@cardano-sdk/input-selection@0.11.4", "@cardano-sdk/input-selection@~0.11.4":
   version "0.11.4"
@@ -4138,44 +4099,6 @@
     pbkdf2 "^3.1.2"
     rxjs "^7.4.0"
     trezor-connect "8.2.11-extended"
-    ts-custom-error "^3.2.0"
-    ts-log "^2.2.4"
-
-"@cardano-sdk/key-management@~0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@cardano-sdk/key-management/-/key-management-0.8.1.tgz#a156cb39ae1674a859323cb466e85399ef83b42c"
-  integrity sha512-+1JIoa2xIXVeOghVUO2jJedijQcFCWrPVANGrn8iagZPFNn8A0jOK/1eRvYL14q6oLPPdcU4Pc8LFsVCRIg6Jw==
-  dependencies:
-    "@cardano-foundation/ledgerjs-hw-app-cardano" "^6.0.0"
-    "@cardano-sdk/core" "~0.15.3"
-    "@cardano-sdk/crypto" "~0.1.9"
-    "@cardano-sdk/dapp-connector" "~0.9.10"
-    "@cardano-sdk/util" "~0.13.0"
-    "@emurgo/cardano-message-signing-nodejs" "^1.0.1"
-    bip39 "^3.0.4"
-    chacha "^2.1.0"
-    get-random-values "^2.0.0"
-    lodash "^4.17.21"
-    pbkdf2 "^3.1.2"
-    rxjs "^7.4.0"
-    trezor-connect "8.2.11-extended"
-    ts-custom-error "^3.2.0"
-    ts-log "^2.2.4"
-
-"@cardano-sdk/tx-construction@0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@cardano-sdk/tx-construction/-/tx-construction-0.9.2.tgz#dff7ee39ba6f8c75e1d4a7e18f02971d4268d96b"
-  integrity sha512-5/UkriEJG8voChR1/B5fpP3yqehGJsw/n5JDm2zK1OqVBjWOLAeNVZ7tFxIxOpI/9HVDOZx+EON5VphHAsQ3QA==
-  dependencies:
-    "@cardano-sdk/core" "~0.15.3"
-    "@cardano-sdk/crypto" "~0.1.9"
-    "@cardano-sdk/input-selection" "~0.11.2"
-    "@cardano-sdk/key-management" "~0.8.1"
-    "@cardano-sdk/util" "~0.13.0"
-    "@cardano-sdk/util-rxjs" "~0.5.4"
-    lodash "^4.17.21"
-    npm "^9.3.0"
-    rxjs "^7.4.0"
     ts-custom-error "^3.2.0"
     ts-log "^2.2.4"
 
@@ -4214,15 +4137,6 @@
     lodash "^4.17.21"
     rxjs "^7.4.0"
     ts-log "^2.2.4"
-
-"@cardano-sdk/util-rxjs@~0.5.4":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@cardano-sdk/util-rxjs/-/util-rxjs-0.5.4.tgz#d5e6dca4ba9624ebb684ca6645a0c37d7b269416"
-  integrity sha512-3VNUIHCORCHRJ/2K6QeXz8Onh5pbxe9anAzAjNK8+HZ9GNBKLQU8UiIkmbSIoqRmSjdPWdV+nWAv60Cq7svTHw==
-  dependencies:
-    "@cardano-sdk/util" "~0.13.0"
-    backoff-rxjs "^7.0.0"
-    rxjs "^7.4.0"
 
 "@cardano-sdk/util-rxjs@~0.5.5":
   version "0.5.5"


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7713

---

## Proposed solution

The multi-delegation feature was broken due to a mismatch of SDK packages. Additionally, the StakePoolConfirmation could not create the transaction builder and calculate the fees because of the legacy condition related to single staking (that is now removed).

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1283/5740930842/index.html) for [a91d641e](https://github.com/input-output-hk/lace/pull/347/commits/a91d641e59204f7a0fa98e3a65d504a4e80e9f5e)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->