### PR TITLE
[LW-7775] lace-blockchain-services: link to Mithril Explorer

### DIFF
--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/setup_systray.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/setup_systray.go
@@ -152,8 +152,21 @@ func setupTrayUI(
 	mMithrilStatusDledSize.Disable()
 	mMithrilStatusTotalSize := mMithrilStatus.AddSubMenuItem("", "")
 	mMithrilStatusTotalSize.Disable()
+
+	mMithrilExplorer := mMithrilStatus.AddSubMenuItem("Mithril Explorer", "")
+	mithrilExplorerUrl := ""
+	go func() {
+		for range mMithrilExplorer.ClickedCh {
+			if mithrilExplorerUrl != "" {
+				openWithDefaultApp(mithrilExplorerUrl)
+			}
+		}
+	}()
+
 	go func(){
 		for upd := range chMithrilStatus {
+			mithrilExplorerUrl = upd.Url
+
 			if upd.Status == "off" {
 				mainthread.Schedule(mMithrilStatus.Hide)
 			} else {


### PR DESCRIPTION
# Checklist

- [ ] JIRA - https://input-output.atlassian.net/browse/LW-7775
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

It adds an item in the Mithril status submenu to open the explorer

### To-dos

* [ ] IMO, right now it’s wrong, because we cannot link to a particular snapshot. There’s only a single page in the Mithril Explorer, listing all snapshots, see e.g. https://mithril.network/explorer?aggregator=https%3A%2F%2Faggregator.release-preprod.api.mithril.network%2Faggregator

### Dependencies

* [x] ~Requires #307 to be merged first~

## Testing

Click the new item – is the Mithril Explorer opened?

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1305/5751604364/index.html) for [df47ddd5](https://github.com/input-output-hk/lace/pull/351/commits/df47ddd5a5fe2ae63904fd737b16025abff5cc92)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 1      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->