### PR TITLE
fix: error thrown by undefined handles array

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/AddressInput.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/AddressInput.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable complexity */
+/* eslint-disable complexity, sonarjs/cognitive-complexity */
 /* eslint-disable unicorn/no-useless-undefined */
 import { Typography } from 'antd';
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
@@ -50,7 +50,6 @@ export enum HandleVerificationState {
 }
 const isHandleAddressBookEnabled = process.env.USE_HANDLE_SEND_UPDATE === 'true';
 
-// eslint-disable-next-line sonarjs/cognitive-complexity
 export const AddressInput = ({ row, currentNetwork, isPopupView }: AddressInputProps): React.ReactElement => {
   const { t } = useTranslation();
   const handleResolver = useHandleResolver();
@@ -102,7 +101,8 @@ export const AddressInput = ({ row, currentNetwork, isPopupView }: AddressInputP
           } else {
             setHandleVerificationState(HandleVerificationState.INVALID);
           }
-          setAddressValue(row, handles[0].cardanoAddress, addressInputValue.address, { isVerified: true });
+          const cardanoAddress = handles?.length > 0 ? handles[0].cardanoAddress : '';
+          setAddressValue(row, cardanoAddress, addressInputValue.address, { isVerified: true });
           return;
         }
 


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7783
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Fixed error thrown by finding a cardano address in an undefined handles array by replacing the address with an empty string



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1292/5749821165/index.html) for [a5f35b0e](https://github.com/input-output-hk/lace/pull/352/commits/a5f35b0ee0394fec3d6b762ed9fa0d006640acd9)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->