### PR TITLE
test(extension): e2e - LW-7734 add tests for nft folder thumbnails co…

### DIFF
--- a/packages/core/src/ui/components/Nft/NftFolderItem.tsx
+++ b/packages/core/src/ui/components/Nft/NftFolderItem.tsx
@@ -45,7 +45,7 @@ export const NftFolderItem = ({ name, onClick, nfts, contextMenuItems }: NftFold
       placement="top"
       title={`+${restOfNfts}`}
     >
-      <span>+{restOfNfts}</span>
+      <span data-testid="rest-of-nfts">+{restOfNfts}</span>
     </Tooltip>
   );
 

--- a/packages/e2e-tests/src/assert/nftAssert.ts
+++ b/packages/e2e-tests/src/assert/nftAssert.ts
@@ -165,10 +165,13 @@ class NftAssert {
     const folderContainer = await NftsPage.getFolder(folderName);
 
     if (numberOfNFTsInFolder > 4) {
-      const numberOfDisplayedRemainingNFTs = Number(((await folderContainer.$('span').getText()) as string).slice(1));
+      const numberOfDisplayedRemainingNFTs = Number(
+        ((await folderContainer.$(NftsPage.REST_OF_NFTS).getText()) as string).slice(1)
+      );
+
       await expect(numberOfDisplayedRemainingNFTs).to.equal(expectedRemainingNumberOfNFTs);
     } else {
-      await folderContainer.$('span').waitForDisplayed({ reverse: true });
+      await folderContainer.$(NftsPage.REST_OF_NFTS).waitForDisplayed({ reverse: true });
     }
   }
 }

--- a/packages/e2e-tests/src/assert/nftAssert.ts
+++ b/packages/e2e-tests/src/assert/nftAssert.ts
@@ -7,6 +7,7 @@ import { expect, use } from 'chai';
 import { browser } from '@wdio/globals';
 import { TokenSelectionPage } from '../elements/newTransaction/tokenSelectionPage';
 import chaiSorted from 'chai-sorted';
+import testContext from '../utils/testContext';
 
 use(chaiSorted);
 
@@ -134,6 +135,41 @@ class NftAssert {
   async assertSeeFoldersInAlphabeticalOrder() {
     const folderNames = await NftsPage.folderContainers.map((folder) => folder.getText());
     await expect(folderNames).to.be.ascending;
+  }
+
+  async assertNumberOfExpectedThumbnails(folderName: string, numberOfExpectedThumbnails: number) {
+    const numberOfNFTsInFolder = testContext.load('numberOfNftsInFolder') as number;
+    const folderContainer = await NftsPage.getFolder(folderName);
+    const totalDisplayedThumbnails = await folderContainer.$$(NftsPage.NFT_ITEM_IMG_CONTAINER).length;
+
+    switch (true) {
+      case numberOfNFTsInFolder < 4:
+      case numberOfNFTsInFolder > 0:
+        await expect(totalDisplayedThumbnails).to.equal(numberOfExpectedThumbnails);
+        break;
+      case numberOfNFTsInFolder >= 4:
+        await expect(totalDisplayedThumbnails).to.equal(3);
+        break;
+      case numberOfNFTsInFolder === 0:
+        await expect(totalDisplayedThumbnails).to.equal(0);
+        break;
+      default:
+        throw new Error(
+          `Displayed thumbnails: ${totalDisplayedThumbnails} does not match expected thumbnails: ${numberOfExpectedThumbnails}`
+        );
+    }
+  }
+
+  async assertRemainingNumberOfNFTs(expectedRemainingNumberOfNFTs: number, folderName: string) {
+    const numberOfNFTsInFolder = testContext.load('numberOfNftsInFolder') as number;
+    const folderContainer = await NftsPage.getFolder(folderName);
+
+    if (numberOfNFTsInFolder > 4) {
+      const numberOfDisplayedRemainingNFTs = Number(((await folderContainer.$('span').getText()) as string).slice(1));
+      await expect(numberOfDisplayedRemainingNFTs).to.equal(expectedRemainingNumberOfNFTs);
+    } else {
+      await folderContainer.$('span').waitForDisplayed({ reverse: true });
+    }
   }
 }
 

--- a/packages/e2e-tests/src/elements/NFTs/nftsPage.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftsPage.ts
@@ -9,6 +9,7 @@ class NftsPage {
   public NFT_IMAGE = '[data-testid="nft-image"]';
   public NFT_NAME = '[data-testid="nft-item-name"]';
   protected FOLDER_CONTAINER = '[data-testid="folder-item"]';
+  public NFT_ITEM_IMG_CONTAINER = '[data-testid="nft-item-img-container"]';
 
   get title() {
     return SectionTitle.sectionTitle;

--- a/packages/e2e-tests/src/elements/NFTs/nftsPage.ts
+++ b/packages/e2e-tests/src/elements/NFTs/nftsPage.ts
@@ -10,6 +10,7 @@ class NftsPage {
   public NFT_NAME = '[data-testid="nft-item-name"]';
   protected FOLDER_CONTAINER = '[data-testid="folder-item"]';
   public NFT_ITEM_IMG_CONTAINER = '[data-testid="nft-item-img-container"]';
+  public REST_OF_NFTS = '[data-testid="rest-of-nfts"]';
 
   get title() {
     return SectionTitle.sectionTitle;

--- a/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
@@ -390,17 +390,16 @@ Feature: NFT - Folders - Extended view
     And I create folder with name: "Sample NFT folder1" that contains <number_of_nfts_in_folder> NFTs
     When I left click on the NFT folder with name "Sample NFT folder1"
     When I <action> 1 NFT to or from the folder
-    Then I see a toast with text: "<toast_message>"
     And I dismiss the drawer on extended page
     Then Folder "Sample NFT folder1" displays <number_of_nft_thumbnails> NFT thumbnails
     And There is a NFTs counter showing <number_of_remaining_nfts> of remaining NFTs in folder "Sample NFT folder1"
     Examples:
-      | number_of_nfts_in_folder | action | toast_message        | number_of_nft_thumbnails | number_of_remaining_nfts |
-      | 1                        | add    | NFTs added to folder | 2                        | 0                        |
-      | 3                        | add    | NFTs added to folder | 4                        | 0                        |
-      | 4                        | add    | NFTs added to folder | 3                        | 2                        |
-      | 6                        | add    | NFTs added to folder | 3                        | 4                        |
-      | 1                        | remove | NFT removed          | 0                        | 0                        |
-      | 4                        | remove | NFT removed          | 3                        | 0                        |
-      | 5                        | remove | NFT removed          | 4                        | 0                        |
-      | 6                        | remove | NFT removed          | 3                        | 2                        |
+      | number_of_nfts_in_folder | action |  number_of_nft_thumbnails | number_of_remaining_nfts |
+      | 1                        | add    |  2                        | 0                        |
+      | 3                        | add    |  4                        | 0                        |
+      | 4                        | add    |  3                        | 2                        |
+      | 6                        | add    |  3                        | 4                        |
+      | 1                        | remove |  0                        | 0                        |
+      | 4                        | remove |  3                        | 0                        |
+      | 5                        | remove |  4                        | 0                        |
+      | 6                        | remove |  3                        | 2                        |

--- a/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
@@ -390,7 +390,7 @@ Feature: NFT - Folders - Extended view
     And I create folder with name: "Sample NFT folder1" that contains <number_of_nfts_in_folder> NFTs
     When I left click on the NFT folder with name "Sample NFT folder1"
     When I <action> 1 NFT to or from the folder
-    And I dismiss the drawer on extended page
+    Then I close the drawer by clicking close button
     Then Folder "Sample NFT folder1" displays <number_of_nft_thumbnails> NFT thumbnails
     And There is a NFTs counter showing <number_of_remaining_nfts> of remaining NFTs in folder "Sample NFT folder1"
     Examples:

--- a/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersExtended.feature
@@ -367,3 +367,40 @@ Feature: NFT - Folders - Extended view
     And I enter a folder name "Sample NFT folder3" into "Folder name" input
     Then I do not see "Given name already exists" error on "Name your folder" page
     And "Confirm" button is enabled on "Rename your folder" drawer
+
+  @LW-7177
+  Scenario Outline: Extended-view - NFT Folders - Folder thumbnail when there are <number_of_nfts_in_folder> in it
+    Given I navigate to NFTs extended page
+    When I create folder with name: "Sample NFT folder1" that contains <number_of_nfts_in_folder> NFTs
+    Then Folder "Sample NFT folder1" displays <number_of_nft_thumbnails> NFT thumbnails
+    And There is a NFTs counter showing <number_of_remaining_nfts> of remaining NFTs in folder "Sample NFT folder1"
+
+    Examples:
+      | number_of_nfts_in_folder | number_of_nft_thumbnails | number_of_remaining_nfts |
+      | 1                        | 1                        | 0                        |
+      | 2                        | 2                        | 0                        |
+      | 3                        | 3                        | 0                        |
+      | 4                        | 4                        | 0                        |
+      | 5                        | 3                        | 2                        |
+      | 9                        | 3                        | 6                        |
+
+  @LW-7178
+  Scenario Outline: Extended-view - NFT Folders - Folder thumbnail & counter updated when <action> NFT to <number_of_nfts_in_folder> NFTs
+    Given I navigate to NFTs extended page
+    And I create folder with name: "Sample NFT folder1" that contains <number_of_nfts_in_folder> NFTs
+    When I left click on the NFT folder with name "Sample NFT folder1"
+    When I <action> 1 NFT to or from the folder
+    Then I see a toast with text: "<toast_message>"
+    And I dismiss the drawer on extended page
+    Then Folder "Sample NFT folder1" displays <number_of_nft_thumbnails> NFT thumbnails
+    And There is a NFTs counter showing <number_of_remaining_nfts> of remaining NFTs in folder "Sample NFT folder1"
+    Examples:
+      | number_of_nfts_in_folder | action | toast_message        | number_of_nft_thumbnails | number_of_remaining_nfts |
+      | 1                        | add    | NFTs added to folder | 2                        | 0                        |
+      | 3                        | add    | NFTs added to folder | 4                        | 0                        |
+      | 4                        | add    | NFTs added to folder | 3                        | 2                        |
+      | 6                        | add    | NFTs added to folder | 3                        | 4                        |
+      | 1                        | remove | NFT removed          | 0                        | 0                        |
+      | 4                        | remove | NFT removed          | 3                        | 0                        |
+      | 5                        | remove | NFT removed          | 4                        | 0                        |
+      | 6                        | remove | NFT removed          | 3                        | 2                        |

--- a/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
@@ -348,3 +348,40 @@ Feature: NFT - Folders - Popup view
     And I enter a folder name "Sample NFT folder3" into "Folder name" input
     Then I do not see "Given name already exists" error on "Name your folder" page
     And "Confirm" button is enabled on "Rename your folder" drawer
+
+  @LW-7179
+  Scenario Outline: Popup-view - NFT Folders - Folder thumbnail when there are <number_of_nfts_in_folder> in it
+    Given I navigate to NFTs popup page
+    When I create folder with name: "Sample NFT folder1" that contains <number_of_nfts_in_folder> NFTs
+    Then Folder "Sample NFT folder1" displays <number_of_nft_thumbnails> NFT thumbnails
+    And There is a NFTs counter showing <number_of_remaining_nfts> of remaining NFTs in folder "Sample NFT folder1"
+
+    Examples:
+      | number_of_nfts_in_folder | number_of_nft_thumbnails | number_of_remaining_nfts |
+      | 1                        | 1                        | 0                        |
+      | 2                        | 2                        | 0                        |
+      | 3                        | 3                        | 0                        |
+      | 4                        | 4                        | 0                        |
+      | 5                        | 3                        | 2                        |
+      | 9                        | 3                        | 6                        |
+
+  @LW-7180
+  Scenario Outline: Popup-view - NFT Folders - Folder thumbnail & counter updated when <action> NFT to <number_of_nfts_in_folder> NFTs
+    Given I navigate to NFTs popup page
+    And I create folder with name: "Sample NFT folder1" that contains <number_of_nfts_in_folder> NFTs
+    When I left click on the NFT folder with name "Sample NFT folder1"
+    When I <action> 1 NFT to or from the folder
+    Then I see a toast with text: "<toast_message>"
+    And I dismiss the drawer on popup page
+    Then Folder "Sample NFT folder1" displays <number_of_nft_thumbnails> NFT thumbnails
+    And There is a NFTs counter showing <number_of_remaining_nfts> of remaining NFTs in folder "Sample NFT folder1"
+    Examples:
+      | number_of_nfts_in_folder | action | toast_message        | number_of_nft_thumbnails | number_of_remaining_nfts |
+      | 1                        | add    | NFTs added to folder | 2                        | 0                        |
+      | 3                        | add    | NFTs added to folder | 4                        | 0                        |
+      | 4                        | add    | NFTs added to folder | 3                        | 2                        |
+      | 6                        | add    | NFTs added to folder | 3                        | 4                        |
+      | 1                        | remove | NFT removed          | 0                        | 0                        |
+      | 4                        | remove | NFT removed          | 3                        | 0                        |
+      | 5                        | remove | NFT removed          | 4                        | 0                        |
+      | 6                        | remove | NFT removed          | 3                        | 2                        |

--- a/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
@@ -371,17 +371,16 @@ Feature: NFT - Folders - Popup view
     And I create folder with name: "Sample NFT folder1" that contains <number_of_nfts_in_folder> NFTs
     When I left click on the NFT folder with name "Sample NFT folder1"
     When I <action> 1 NFT to or from the folder
-    Then I see a toast with text: "<toast_message>"
     And I dismiss the drawer on popup page
     Then Folder "Sample NFT folder1" displays <number_of_nft_thumbnails> NFT thumbnails
     And There is a NFTs counter showing <number_of_remaining_nfts> of remaining NFTs in folder "Sample NFT folder1"
     Examples:
-      | number_of_nfts_in_folder | action | toast_message        | number_of_nft_thumbnails | number_of_remaining_nfts |
-      | 1                        | add    | NFTs added to folder | 2                        | 0                        |
-      | 3                        | add    | NFTs added to folder | 4                        | 0                        |
-      | 4                        | add    | NFTs added to folder | 3                        | 2                        |
-      | 6                        | add    | NFTs added to folder | 3                        | 4                        |
-      | 1                        | remove | NFT removed          | 0                        | 0                        |
-      | 4                        | remove | NFT removed          | 3                        | 0                        |
-      | 5                        | remove | NFT removed          | 4                        | 0                        |
-      | 6                        | remove | NFT removed          | 3                        | 2                        |
+      | number_of_nfts_in_folder | action |  number_of_nft_thumbnails | number_of_remaining_nfts |
+      | 1                        | add    |  2                        | 0                        |
+      | 3                        | add    |  4                        | 0                        |
+      | 4                        | add    |  3                        | 2                        |
+      | 6                        | add    |  3                        | 4                        |
+      | 1                        | remove |  0                        | 0                        |
+      | 4                        | remove |  3                        | 0                        |
+      | 5                        | remove |  4                        | 0                        |
+      | 6                        | remove |  3                        | 2                        |

--- a/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
+++ b/packages/e2e-tests/src/features/NFTsFoldersPopup.feature
@@ -371,7 +371,7 @@ Feature: NFT - Folders - Popup view
     And I create folder with name: "Sample NFT folder1" that contains <number_of_nfts_in_folder> NFTs
     When I left click on the NFT folder with name "Sample NFT folder1"
     When I <action> 1 NFT to or from the folder
-    And I dismiss the drawer on popup page
+    And I close the drawer by clicking back button
     Then Folder "Sample NFT folder1" displays <number_of_nft_thumbnails> NFT thumbnails
     And There is a NFTs counter showing <number_of_remaining_nfts> of remaining NFTs in folder "Sample NFT folder1"
     Examples:

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -249,16 +249,21 @@ Then(
   }
 );
 
-Then(/^I see a toast with text: "NFTs added to folder"$/, async () => {
-  await ToastMessageAssert.assertSeeToastMessage(await t('browserView.nfts.folderDrawer.toast.update'), true);
+Then(/^I see a toast with text: "(NFTs added to folder|NFT removed)"$/, async (toastMessage: string) => {
+  switch (toastMessage) {
+    case 'NFTs added to folder':
+      await ToastMessageAssert.assertSeeToastMessage(await t('browserView.nfts.folderDrawer.toast.update'), true);
+      break;
+    case 'NFT removed':
+      await ToastMessageAssert.assertSeeToastMessage(await t('browserView.nfts.folderDrawer.toast.delete'), true);
+      break;
+    default:
+      throw new Error(`Unsupported toast message: ${toastMessage}`);
+  }
 });
 
 Then(/^I dismiss the drawer on ([^"]*) page$/, async (mode: 'extended' | 'popup') => {
   mode === 'popup' ? await NftsFolderPage.clickHeaderBackButton() : await NftsFolderPage.clickHeaderCloseButton();
-});
-
-Then(/^I see a toast with text: "NFT removed"$/, async () => {
-  await ToastMessageAssert.assertSeeToastMessage(await t('browserView.nfts.folderDrawer.toast.delete'), true);
 });
 
 Then(/^I select (\d+) NFTs$/, async (numberOfNFTs: number) => {

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -19,6 +19,7 @@ import DeleteFolderModal from '../elements/NFTs/DeleteFolderModal';
 import NftsFolderPage from '../elements/NFTs/nftsFolderPage';
 import NftAssert from '../assert/nftAssert';
 import testContext from '../utils/testContext';
+import MenuHeader from '../elements/menuHeader';
 
 Given(/^all NFT folders are removed$/, async () => {
   await IndexedDB.clearNFTFolders();
@@ -403,7 +404,7 @@ When(
     await NftSelectNftsPage.selectNFTs(numberOfNftsInFolder);
     await NftSelectNftsPage.nextButton.waitForClickable();
     await NftSelectNftsPage.nextButton.click();
-    await NftsPage.createFolderButton.waitForClickable();
+    await MenuHeader.menuButton.waitForClickable();
     await nftCreateFolderAssert.assertSeeFolderOnNftsList(folderName, true);
     testContext.save('numberOfNftsInFolder', numberOfNftsInFolder);
   }

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -258,10 +258,6 @@ Then(/^I see a toast with text: "NFT removed"$/, async () => {
   await ToastMessageAssert.assertSeeToastMessage(await t('browserView.nfts.folderDrawer.toast.delete'), true);
 });
 
-Then(/^I dismiss the drawer on ([^"]*) page$/, async (mode: 'extended' | 'popup') => {
-  mode === 'popup' ? await NftsFolderPage.clickHeaderBackButton() : await NftsFolderPage.clickHeaderCloseButton();
-});
-
 Then(/^I select (\d+) NFTs$/, async (numberOfNFTs: number) => {
   await NftSelectNftsPage.selectNFTs(numberOfNFTs);
 });
@@ -418,7 +414,6 @@ When(
     switch (action) {
       case 'add':
         testContext.saveWithOverride('numberOfNftsInFolder', numberOfNftsInFolder + numberOfNftsWanted);
-        await NftFolderAssert.assertSeeAddNftButton();
         await NftsFolderPage.addNftButton.waitForClickable();
         await NftsFolderPage.addNftButton.click();
         await NftSelectNftsPage.selectNFTs(numberOfNftsWanted);

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -426,8 +426,11 @@ When(
         break;
       case 'remove':
         testContext.saveWithOverride('numberOfNftsInFolder', numberOfNftsInFolder - numberOfNftsWanted);
-        await NftSelectNftsPage.nfts[0].click({ button: 'right' });
-        await NftFolderContextMenu.clickRemoveNFTOption();
+        for (let i = 0; i < numberOfNftsWanted; i++) {
+          await NftSelectNftsPage.nfts[0].waitForClickable();
+          await NftSelectNftsPage.nfts[0].click({ button: 'right' });
+          await NftFolderContextMenu.clickRemoveNFTOption();
+        }
         break;
       default:
         throw new Error(`Unsupported action: ${action}`);

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -250,17 +250,12 @@ Then(
   }
 );
 
-Then(/^I see a toast with text: "(NFTs added to folder|NFT removed)"$/, async (toastMessage: string) => {
-  switch (toastMessage) {
-    case 'NFTs added to folder':
-      await ToastMessageAssert.assertSeeToastMessage(await t('browserView.nfts.folderDrawer.toast.update'), true);
-      break;
-    case 'NFT removed':
-      await ToastMessageAssert.assertSeeToastMessage(await t('browserView.nfts.folderDrawer.toast.delete'), true);
-      break;
-    default:
-      throw new Error(`Unsupported toast message: ${toastMessage}`);
-  }
+Then(/^I see a toast with text: "NFTs added to folder"$/, async () => {
+  await ToastMessageAssert.assertSeeToastMessage(await t('browserView.nfts.folderDrawer.toast.update'), true);
+});
+
+Then(/^I see a toast with text: "NFT removed"$/, async () => {
+  await ToastMessageAssert.assertSeeToastMessage(await t('browserView.nfts.folderDrawer.toast.delete'), true);
 });
 
 Then(/^I dismiss the drawer on ([^"]*) page$/, async (mode: 'extended' | 'popup') => {


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1335/5763297126/index.html) for [027d53ba](https://github.com/input-output-hk/lace/pull/353/commits/027d53bab9b713df724c040056be332abb02478e)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 36     | 0      | 0       | 0     | 36    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->