### PR TITLE
test(extension): remove invalid matomo tc

### DIFF
--- a/packages/e2e-tests/src/features/SettingsPageExtended.feature
+++ b/packages/e2e-tests/src/features/SettingsPageExtended.feature
@@ -241,22 +241,11 @@ Feature: General Settings - Extended Browser View
     And Analytics toggle is enabled: true
     Then clicking on "<element>" in extended mode, existence of matomo event with payload containing: "<action_name>" should be: true
     Examples:
-      | element      | action_name                            |
-      | Tokens       | view-tokens,click-event,cookie=1       |
-      | NFTs         | view-nft,click-event,cookie=1          |
-      | Transactions | view-transactions,click-event,cookie=1 |
-      | Staking      | staking,click-event,cookie=1           |
-
-  @LW-3059 @Mainnet @Testnet
-  Scenario Outline: Extended view - Settings - Analytics option enabled: <is_enabled> and events sent: <is_enabled>
-    When I open settings from header menu
-    And Analytics toggle is enabled: <toggle_enabled>
-    Then clicking on "Tokens" in extended mode, existence of matomo event with payload containing: "<action_name>" should be: <request_present>
-    Examples:
-      | toggle_enabled | request_present | action_name          |
-      | true           | true            | view-tokens,cookie=1 |
-      | false          | true            | view-tokens          |
-      | false          | false           | cookie=1             |
+      | element      | action_name                   |
+      | Tokens       | view-tokens,click-event       |
+      | NFTs         | view-nft,click-event          |
+      | Transactions | view-transactions,click-event |
+      | Staking      | staking,click-event           |
 
   @LW-3869 @Mainnet @Testnet
   Scenario: Extended view - Settings - Show passphrase displayed above Analytics under the Security section in the Settings page


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1301/5750990522/index.html) for [9e66e243](https://github.com/input-output-hk/lace/pull/354/commits/9e66e243acae312b80fbf6ff2e8747360daf5547)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 33     | 3      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->