### PR TITLE
test(extension): e2e - bump yarn timeout for installing dependencies …

### DIFF
--- a/.github/workflows/e2e-tests-win.yml
+++ b/.github/workflows/e2e-tests-win.yml
@@ -98,7 +98,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         working-directory: ./packages/e2e-tests
-        run: yarn install --check-cache --frozen-lockfile --non-interactive --loglevel=error --ignore-scripts
+        run: yarn config set network-timeout 300000 && yarn install --check-cache --frozen-lockfile --non-interactive --loglevel=error --ignore-scripts
       - name: Start Chrome driver
         run: |
           if [ ${BROWSER} == "chrome" ]; then


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1333/5762879358/index.html) for [bd319de8](https://github.com/input-output-hk/lace/pull/360/commits/bd319de8308ddc066084882fc41240226649871b)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 1      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->