### PR TITLE
ci(all): enable npm audit

### DIFF
--- a/.github/scripts/audit.sh
+++ b/.github/scripts/audit.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yarn audit --groups dependencies --level high; [[ $? -ge 8 ]] && exit 1 || exit 0;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         run: ./decrypt_secret.sh
         env:
           WALLET_1_PASSWORD: ${{ secrets.WALLET_PASSWORD_TESTNET }}
+      - name: Audit packages
+        run: ./.github/scripts/audit.sh
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7835

---

## Proposed solution

Enable npm audit step in CI.

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1353/5784667660/index.html) for [ebcd9a0f](https://github.com/input-output-hk/lace/pull/367/commits/ebcd9a0f8b440692edbaf30ca5aa9a775a0db8cf)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 1      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->