### PR TITLE
feat(extension): add analytics actions for nft section

### DIFF
--- a/apps/browser-extension-wallet/src/components/MainMenu/MainFooter.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/MainFooter.tsx
@@ -23,7 +23,8 @@ import { useAnalyticsContext } from '@providers';
 import {
   MatomoEventActions,
   MatomoEventCategories,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 
 const includesCoin = /coin/i;
@@ -51,12 +52,16 @@ export const MainFooter = (): React.ReactElement => {
     currentHoveredItem === MenuItemList.TRANSACTIONS ? TransactionsIconHover : TransactionsIconDefault;
   const StakingIcon = currentHoveredItem === MenuItemList.STAKING ? StakingIconHover : StakingIconDefault;
 
-  const sendAnalytics = (category: MatomoEventCategories, name: string) => {
+  const sendAnalytics = (category: MatomoEventCategories, name: string, postHogAction?: PostHogAction) => {
     analytics.sendEventToMatomo({
       category,
       action: MatomoEventActions.CLICK_EVENT,
       name
     });
+
+    if (postHogAction) {
+      analytics.sendEventToPostHog(postHogAction);
+    }
   };
 
   const handleNavigation = (path: string) => {
@@ -65,13 +70,21 @@ export const MainFooter = (): React.ReactElement => {
         sendAnalytics(MatomoEventCategories.VIEW_TOKENS, AnalyticsEventNames.ViewTokens.VIEW_TOKEN_LIST_POPUP);
         break;
       case walletRoutePaths.earn:
-        sendAnalytics(MatomoEventCategories.STAKING, AnalyticsEventNames.Staking.VIEW_STAKING_POPUP);
+        sendAnalytics(
+          MatomoEventCategories.STAKING,
+          AnalyticsEventNames.Staking.VIEW_STAKING_POPUP,
+          PostHogAction.StakingClick
+        );
         break;
       case walletRoutePaths.activity:
         sendAnalytics(MatomoEventCategories.VIEW_TRANSACTIONS, AnalyticsEventNames.ViewTransactions.VIEW_TX_LIST_POPUP);
         break;
       case walletRoutePaths.nfts:
-        sendAnalytics(MatomoEventCategories.VIEW_NFT, AnalyticsEventNames.ViewNFTs.VIEW_NFT_LIST_POPUP);
+        sendAnalytics(
+          MatomoEventCategories.VIEW_NFT,
+          AnalyticsEventNames.ViewNFTs.VIEW_NFT_LIST_POPUP,
+          PostHogAction.NFTsClick
+        );
     }
     history.push(path);
   };

--- a/apps/browser-extension-wallet/src/features/nfts/components/Nfts.tsx
+++ b/apps/browser-extension-wallet/src/features/nfts/components/Nfts.tsx
@@ -16,7 +16,8 @@ import { getTokenList } from '@src/utils/get-token-list';
 import {
   MatomoEventActions,
   MatomoEventCategories,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import FolderIcon from '@assets/icons/new-folder-icon.component.svg';
 import { SectionTitle } from '@components/Layout/SectionTitle';
@@ -55,6 +56,7 @@ export const Nfts = withNftsFoldersContext((): React.ReactElement => {
         action: MatomoEventActions.CLICK_EVENT,
         name: AnalyticsEventNames.ViewNFTs.VIEW_NFT_DETAILS_POPUP
       });
+      analytics.sendEventToPostHog(PostHogAction.NFTsImageClick);
       redirectToNftDetail({ params: { id: nft.assetId.toString() } });
     },
     [analytics, redirectToNftDetail]

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -93,7 +93,10 @@ export enum PostHogAction {
   SendSomethingWentWrongView = 'send | something went wrong | view',
   SendSomethingWentWrongBackClick = 'send | something went wrong | back | click',
   SendSomethingWentWrongCancelClick = 'send | something went wrong | cancel | click',
-  SendSomethingWentWrongXClick = 'send | something went wrong | x | click'
+  SendSomethingWentWrongXClick = 'send | something went wrong | x | click',
+  // NFTs Flow
+  NFTsClick = 'nft | nfts | click',
+  NFTsImageClick = 'nft | nfts | nft image | click'
 }
 
 export enum EnhancedAnalyticsOptInStatus {

--- a/apps/browser-extension-wallet/src/views/browser-view/components/SideMenu/SideMenu.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/SideMenu/SideMenu.tsx
@@ -35,14 +35,16 @@ export const SideMenu = (): React.ReactElement => {
     return () => unregisterListener();
   }, [listen]);
 
-  const sendAnalytics = (category: MatomoEventCategories, name: string) => {
+  const sendAnalytics = (category: MatomoEventCategories, name: string, postHogAction?: PostHogAction) => {
     analytics.sendEventToMatomo({
       category,
       action: MatomoEventActions.CLICK_EVENT,
       name
     });
 
-    analytics.sendEventToPostHog(PostHogAction.StakingClick);
+    if (postHogAction) {
+      analytics.sendEventToPostHog(postHogAction);
+    }
   };
 
   const handleRedirection: MenuProps['onClick'] = (field) => {
@@ -51,7 +53,11 @@ export const SideMenu = (): React.ReactElement => {
         sendAnalytics(MatomoEventCategories.VIEW_TOKENS, AnalyticsEventNames.ViewTokens.VIEW_TOKEN_LIST_BROWSER);
         break;
       case routes.staking:
-        sendAnalytics(MatomoEventCategories.STAKING, AnalyticsEventNames.Staking.VIEW_STAKING_BROWSER);
+        sendAnalytics(
+          MatomoEventCategories.STAKING,
+          AnalyticsEventNames.Staking.VIEW_STAKING_BROWSER,
+          PostHogAction.StakingClick
+        );
         break;
       case routes.activity:
         sendAnalytics(
@@ -60,7 +66,11 @@ export const SideMenu = (): React.ReactElement => {
         );
         break;
       case routes.nfts:
-        sendAnalytics(MatomoEventCategories.VIEW_NFT, AnalyticsEventNames.ViewNFTs.VIEW_NFT_LIST_BROWSER);
+        sendAnalytics(
+          MatomoEventCategories.VIEW_NFT,
+          AnalyticsEventNames.ViewNFTs.VIEW_NFT_LIST_BROWSER,
+          PostHogAction.NFTsClick
+        );
     }
     push(field.key);
   };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftsLayout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftsLayout.tsx
@@ -98,6 +98,7 @@ export const NftsLayout = withNftsFoldersContext((): React.ReactElement => {
         action: MatomoEventActions.CLICK_EVENT,
         name: AnalyticsEventNames.ViewNFTs.VIEW_NFT_DETAILS_BROWSER
       });
+      analytics.sendEventToPostHog(PostHogAction.NFTsImageClick);
     },
     [analytics]
   );


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-7369](https://input-output.atlassian.net/browse/LW-7369)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR implements the following Post Hog events for NFT section: 

- nft | nfts | click
- nft | nfts | nft image | click




[LW-7369]: https://input-output.atlassian.net/browse/LW-7369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1364/5787871507/index.html) for [bd1ca548](https://github.com/input-output-hk/lace/pull/369/commits/bd1ca548538fb75033b1d0ef9e74cb4d900ca306)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 4      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->