### PR TITLE
chore(extension): bump to 1.4.0

### DIFF
--- a/apps/browser-extension-wallet/manifest.json
+++ b/apps/browser-extension-wallet/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Lace",
   "description": "One fast, accessible, and secure platform for digital assets, DApps, NFTs, and DeFi.",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "manifest_version": 3,
   "key": "$LACE_EXTENSION_KEY",
   "icons": {

--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lace/browser-extension-wallet",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A fully capable wallet packaged as browser extensions for Chrome, Firefox, and Edge",
   "homepage": "https://github.com/input-output-hk/lace/blob/master/apps/browser-extension-wallet/README.md",
   "bugs": {

--- a/apps/browser-extension-wallet/src/release-notes/1_4_0.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_4_0.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+import React from 'react';
+
+const ReleaseNote_1_4_0 = (): React.ReactElement => (
+  <>
+    <p>Introducing Lace 1.4.0 This version supports the following features:</p>
+    <ul style={{ listStyleType: 'disc', margin: 0 }}>
+      <li />
+    </ul>
+    <p>
+      Check out the details in the{' '}
+      <a href="https://www.lace.io/blog/lace-1-4-release" target="_blank">
+        blog
+      </a>
+    </p>
+  </>
+);
+
+export default ReleaseNote_1_4_0;


### PR DESCRIPTION
This pull request includes the commit made on the release branch to update the version to 1.4.0

- [ ] JIRA - [LW-7769](https://input-output.atlassian.net/browse/LW-7769)

[LW-7769]: https://input-output.atlassian.net/browse/LW-7769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1382/5798212343/index.html) for [fe421db7](https://github.com/input-output-hk/lace/pull/371/commits/fe421db7b91d2e6ad3e6f836d2cf8faf2bd3aaad)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 1      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->