### PR TITLE
[LW-7842] lace-blockchain-services: Mithril: small tweaks

### DIFF
--- a/nix/lace-blockchain-services/internal/any-darwin.nix
+++ b/nix/lace-blockchain-services/internal/any-darwin.nix
@@ -112,6 +112,12 @@ in rec {
       cp ${common.openApiJson} openapi.json
       go-bindata -pkg assets -o assets/assets.go tray-icon openapi.json
       mkdir -p constants && cp ${common.constants} constants/constants.go
+
+      chmod -R +w vendor
+      (
+        cd vendor/github.com/getlantern/systray
+        patch -p1 -i ${./getlantern-systray--darwin-handle-reopen.patch}
+      )
     '';
   };
 

--- a/nix/lace-blockchain-services/internal/getlantern-systray--darwin-handle-reopen.patch
+++ b/nix/lace-blockchain-services/internal/getlantern-systray--darwin-handle-reopen.patch
@@ -1,0 +1,17 @@
+diff --git a/systray_darwin.m b/systray_darwin.m
+index 884fa43..7dd9500 100644
+--- a/systray_darwin.m
++++ b/systray_darwin.m
+@@ -74,6 +74,12 @@ withParentMenuId: (int)theParentMenuId
+   systray_ready();
+ }
+ 
++extern signed char lbs__ui__handle_app_reopen(signed char flag);
++
++- (BOOL)applicationShouldHandleReopen:(NSApplication *)sender hasVisibleWindows:(BOOL)flag {
++  return lbs__ui__handle_app_reopen(flag);
++}
++
+ - (void)applicationWillTerminate:(NSNotification *)aNotification
+ {
+   systray_on_exit();

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
@@ -21,6 +21,7 @@ import (
 	"lace.io/lace-blockchain-services/constants"
 	"lace.io/lace-blockchain-services/ourpaths"
 	"lace.io/lace-blockchain-services/mainthread"
+	"lace.io/lace-blockchain-services/ui"
 )
 
 func childMithril(shared SharedState, statusCh chan<- StatusAndUrl) ManagedChild {
@@ -121,6 +122,7 @@ func childMithril(shared SharedState, statusCh chan<- StatusAndUrl) ManagedChild
 				fmt.Printf("%s[%d]: fetching snapshots failed: %v (stderr: %v) (stdout: %v)\n",
 					serviceName, pid, err, string(stdout), string(stderr))
 				mainthread.Schedule(func() {
+					ui.BringAppToForeground()
 					dialog.Message("Fetching Mithril snapshots failed: %v." +
 						"\n\nMore details in the log file.", err).
 						Title("Mithril error").Error()

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
@@ -262,6 +262,9 @@ func childMithril(shared SharedState, statusCh chan<- StatusAndUrl) ManagedChild
 		ForceKillAfter: 5 * time.Second,
 		AfterExit: func() error {
 			if currentStatus != SGoodSignature {
+				// Since Mithril cannot resume interrupted downloads, let’s clear them on failures:
+				os.RemoveAll(downloadDir)
+
 				return fmt.Errorf("cannot move DB as snapshot download was not successful")
 			}
 			currentStatus = SMovingDB

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child-mithril.go
@@ -77,7 +77,7 @@ func childMithril(shared SharedState, statusCh chan<- StatusAndUrl) ManagedChild
 
 	// A mini-monster, we’ll be able to get rid of it once Mithril provides more machine-readable output:
 	reProgress := regexp.MustCompile(
-		`^.\s\[[0-9:]+\]\s+\[[#>-]+\]\s+([0-9]*\.[0-9]+)\s+([A-Za-z]*B)/([0-9]*\.[0-9]+)\s+([A-Za-z]*B)\s+\(([0-9]*\.[0-9]+)([A-Za-z]+)\)$`)
+		`^\[[0-9:]+\]\s+\[[#>-]+\]\s+([0-9]*\.[0-9]+)\s+([A-Za-z]*B)/([0-9]*\.[0-9]+)\s+([A-Za-z]*B)\s+\(([0-9]*\.[0-9]+)([A-Za-z]+)\)$`)
 
 	unitToBytes := func(unit string) int64 {
 		switch unit {
@@ -255,6 +255,16 @@ func childMithril(shared SharedState, statusCh chan<- StatusAndUrl) ManagedChild
 			}
 		},
 		LogModifier: func(line string) string {
+			// Remove the wigglers (⠙, ⠒, etc.):
+			brailleDotsLow := rune(0x2800)
+			brailleDotsHi := rune(0x28ff)
+			var result strings.Builder
+			for _, char := range line {
+				if char < brailleDotsLow || char > brailleDotsHi {
+					result.WriteRune(char)
+				}
+			}
+			line = result.String()
 			line = strings.TrimSpace(line)
 			return line
 		},

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child.go
@@ -419,7 +419,10 @@ func childProcess(
 		defer wgOuts.Done()
 		scanner := bufio.NewScanner(stdout)
 		for scanner.Scan() {
-			outputLines <- logModifier(scanner.Text())
+			line := logModifier(scanner.Text())
+			if len(line) > 0 {
+				outputLines <- line
+			}
 		}
 	}()
 
@@ -432,7 +435,10 @@ func childProcess(
 		defer wgOuts.Done()
 		scanner := bufio.NewScanner(stderr)
 		for scanner.Scan() {
-			outputLines <- "[stderr] " + logModifier(scanner.Text())
+			line := logModifier(scanner.Text())
+			if len(line) > 0 {
+				outputLines <- "[stderr] " + line
+			}
 		}
 	}()
 
@@ -575,7 +581,10 @@ func childProcessPTY(
 				return (c == '\n' || c == '\r' || c == rune(0x08))  // 0x08 for Windows
 			}) {
 				if len(line) > 0 {
-					outputLines <- logModifier(line)
+					line = logModifier(line)
+					if len(line) > 0 {
+						outputLines <- line
+					}
 				}
 			}
 		}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child_windows.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child_windows.go
@@ -178,7 +178,7 @@ func childProcessPTYWindows(
 				if len(line) > 0 {
 					line = logModifier(line)
 					if len(line) > 0 {
-						outputLines <- logModifier(line)
+						outputLines <- line
 					}
 				}
 			}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/child_windows.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/child_windows.go
@@ -176,7 +176,10 @@ func childProcessPTYWindows(
 				return (c == '\n' || c == '\r' || c == rune(0x08))  // 0x08 for Windows
 			}) {
 				if len(line) > 0 {
-					outputLines <- logModifier(line)
+					line = logModifier(line)
+					if len(line) > 0 {
+						outputLines <- logModifier(line)
+					}
 				}
 			}
 		}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
@@ -138,7 +138,7 @@ func main() {
 			Revision: constants.LaceBlockchainServicesRevision,
 		}
 
-		initiateShutdownCh := make(chan struct{}, 1)
+		initiateShutdownCh := make(chan struct{}, 16)
 
 		return CommChannels_UI {
 			ServiceUpdate: serviceUpdateToUI,
@@ -196,6 +196,10 @@ func main() {
 	}()
 
 	systray.Run(setupTrayUI(commUI, logFile, networks, appConfig), func(){
+		// It’s possible that this callback is called from macOS “Quit” even from the Dock area
+		// (we’re briefly shown there while dialogs are displayed) – let’s (re)initiate a clean shutdown:
+		commUI.InitiateShutdownCh <- struct{}{}
+
 		wgManager.Wait()
 		fmt.Printf("%s[%d]: all good, exiting\n", OurLogPrefix, os.Getpid())
 	})

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/gopsutil/v3/load"
-	"github.com/sqweek/dialog"
 	"github.com/getlantern/systray"
 	"github.com/allan-simon/go-singleinstance"
 )
@@ -52,9 +51,7 @@ func main() {
 	lockFile := ourpaths.WorkDir + sep + "instance.lock"
 	lockFileFile, err := singleinstance.CreateLockFile(lockFile)
 	if err != nil {
-		ui.BringAppToForeground()
-		dialog.Message("Another instance of ‘%s’ is already running.\n\nCheck in the system tray area.",
-			OurLogPrefix).Title("Already running!").Error()
+		ui.HandleAppReopened()
 		os.Exit(1)
 	}
 	defer lockFileFile.Close() // or else, it will be GC’d (and unlocked!)

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/foreground_darwin.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/foreground_darwin.go
@@ -1,0 +1,15 @@
+package ui
+
+/*
+#cgo darwin CFLAGS: -DDARWIN -x objective-c -fobjc-arc
+#cgo darwin LDFLAGS: -framework Cocoa -framework Webkit
+
+void lbs__ui__bring_app_to_foreground();
+*/
+import "C"
+
+// On Darwin, we have to activate our app (bring it to foreground),
+// so that our dialog boxes are shown on top.
+func BringAppToForeground() {
+	C.lbs__ui__bring_app_to_foreground()
+}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/foreground_darwin.m
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/foreground_darwin.m
@@ -1,0 +1,6 @@
+#import <Cocoa/Cocoa.h>
+
+void lbs__ui__bring_app_to_foreground() {
+  [[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyAccessory];
+  [NSApp activateIgnoringOtherApps:YES];
+}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/foreground_nondarwin.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/foreground_nondarwin.go
@@ -1,0 +1,7 @@
+// +build !darwin
+
+package ui
+
+func BringAppToForeground() {
+	// no-op
+}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/handle_reopen.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/handle_reopen.go
@@ -1,0 +1,11 @@
+package ui
+
+import (
+	"github.com/sqweek/dialog"
+)
+
+func HandleAppReopened() {
+	BringAppToForeground()
+	dialog.Message("Another instance of ‘%s’ is already running.\n\nCheck in the system tray area.",
+		OurLogPrefix).Title("Already running!").Error()
+}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/handle_reopen_darwin.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/handle_reopen_darwin.go
@@ -1,0 +1,9 @@
+package ui
+
+import "C"
+
+//export lbs__ui__handle_app_reopen
+func lbs__ui__handle_app_reopen(flag int8) int8 {
+	HandleAppReopened()
+	return 0  // i.e. Objective-C ‘NO’ (false) – prevent default processing of this event
+}

--- a/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/ui.go
+++ b/nix/lace-blockchain-services/internal/lace-blockchain-services/ui/ui.go
@@ -1,4 +1,4 @@
-package main
+package ui
 
 import (
 	"fmt"
@@ -12,7 +12,7 @@ import (
 	"strconv"
 
 	t "lace.io/lace-blockchain-services/types"
-	_ "lace.io/lace-blockchain-services/ourpaths" // has to be imported before clipboard.init()
+	"lace.io/lace-blockchain-services/ourpaths" // has to be imported before clipboard.init()
 	"lace.io/lace-blockchain-services/assets"
 	"lace.io/lace-blockchain-services/appconfig"
 	"lace.io/lace-blockchain-services/mainthread"
@@ -22,8 +22,22 @@ import (
 	"github.com/sqweek/dialog"
 )
 
-func setupTrayUI(
-	comm CommChannels_UI,
+const (
+	OurLogPrefix = ourpaths.OurLogPrefix
+)
+
+type CommChannels struct {
+	ServiceUpdate        <-chan t.ServiceStatus
+	BlockRestartUI       <-chan bool
+	HttpSwitchesNetwork  <-chan t.NetworkMagic
+
+	NetworkSwitch        chan<- string
+	InitiateShutdownCh   chan<- struct{}
+	TriggerMithril       chan<- struct{}
+}
+
+func SetupTray(
+	comm CommChannels,
 	logFile string,
 	networks map[t.NetworkMagic]string,
 	appConfig appconfig.AppConfig,
@@ -264,6 +278,7 @@ func setupTrayUI(
 			mainthread.Schedule(func() {
 				fmt.Printf("%s[%d]: info: Mithril from goroutine %v\n",
 					OurLogPrefix, os.Getpid(), goid())
+				BringAppToForeground()
 				ans := dialog.Message(
 					"Resync the entire blockchain from scratch with Mithril?\n\n" +
 					"This will delete your current cardano-node DB.\n\n" +


### PR DESCRIPTION
# Checklist

- [ ] JIRA - https://input-output.atlassian.net/browse/LW-7842
- [ ] Proper tests implemented
- [ ] Screenshots added.

Also solves https://input-output.atlassian.net/browse/LW-7468

---

## Proposed solution

n/a

## Testing

1. Check that interrupted Mithril downloads are deleted from the state directory (you can interrupt by "Quit" or "Force Restart", or by changing networks etc.)

2. Check there are less logs (debounced – at most 3 per second) when downloading Mithril snapshots

3. Console.app on macOS is not jumping between beginning and end of log during Mithril resync – select "Open Current Log" on macOS and trigger Mithril resync and observe Console.app

4. On macOS, have another app in foreground (Finder, Chrome, Terminal, whatever you wish), and trigger Mithril resync – did the question dialog window get shown on top of your active app?

5. On macOS, we show an alert message when the app was started twice – try to start it twice and observe the warning (first reported in [LW-7468](https://input-output.atlassian.net/browse/LW-7468))

## Screenshots

n/a


[LW-7468]: https://input-output.atlassian.net/browse/LW-7468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1427/5821255175/index.html) for [274d316b](https://github.com/input-output-hk/lace/pull/373/commits/274d316b263781c6afe612c8b983389a0daa7679)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 2      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->