### PR TITLE
[LW-7784] fixes the reload of the input form after adding a handle to address

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AddressForm.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AddressForm.tsx
@@ -61,8 +61,8 @@ export const AddressForm = withAddressBookContext(({ isPopupView }: AddressFormP
         });
   };
 
-  const onConfirmClick = (address: AddressBookSchema) => {
-    onAddressSave(address);
+  const onConfirmClick = async (address: AddressBookSchema) => {
+    await onAddressSave(address);
   };
 
   const onCancelClick = () => {


### PR DESCRIPTION

# Checklist

- [x] JIRA - LW-7784
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution
The bug was that we weren't awaiting to send the user back until the resolution of the save address in the db. 

## Testing
Save a handle and make sure that on returning to the original screen, we are showing the name of the saved handle. 




<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1395/5807925218/index.html) for [d0a3c50e](https://github.com/input-output-hk/lace/pull/376/commits/d0a3c50ec23c43037c15a352bf198de1f1f3686d)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 2      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->