### PR TITLE
test(extension): disable posthog automation tc

### DIFF
--- a/packages/e2e-tests/src/features/analytics/AnalyticsSendExtended.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsSendExtended.feature
@@ -1,6 +1,6 @@
-@SendSimpleTransaction-Extended-E2E  @Testnet
+@SendSimpleTransaction-Extended-E2E  @Testnet @Pending
 Feature: Analytics - Posthog - Sending - Extended View
-  
+
   @LW-7821
   Scenario: Extended-view - Send Analytics - Success Screen - Close drawer - X button
     Given I set up request interception for posthog analytics request(s)

--- a/packages/e2e-tests/src/features/analytics/AnalyticsSendPopup.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsSendPopup.feature
@@ -1,4 +1,4 @@
-@SendSimpleTransaction-Popup-E2E @Testnet
+@SendSimpleTransaction-Popup-E2E @Testnet @Pending
 Feature: Analytics - Posthog - Sending - Popup View
 
   Background:


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1400/5808593099/index.html) for [37156b18](https://github.com/input-output-hk/lace/pull/377/commits/37156b18630ce51c6af8177d88503f87dfa09eb5)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 2      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->