### PR TITLE
fix(extension): add missing staking events in popup view

### DIFF
--- a/apps/browser-extension-wallet/src/features/delegation/components/DelegationContainer.tsx
+++ b/apps/browser-extension-wallet/src/features/delegation/components/DelegationContainer.tsx
@@ -20,7 +20,8 @@ import { useTranslation } from 'react-i18next';
 import {
   MatomoEventActions,
   MatomoEventCategories,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { useAnalyticsContext } from '@providers';
 import { useObservable } from '@lace/common';
@@ -122,6 +123,7 @@ export const DelegationContainer = (): React.ReactElement => {
       action: MatomoEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.Staking.VIEW_STAKEPOOL_INFO_POPUP
     });
+    analytics.sendEventToPostHog(PostHogAction.StakingStakePoolClick);
   };
 
   return (


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-7867](https://input-output.atlassian.net/browse/LW-7867)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR adds missing event for staking section in popup view

- staking | staking | stake pool | click


[LW-7867]: https://input-output.atlassian.net/browse/LW-7867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1402/5808712777/index.html) for [b40ee921](https://github.com/input-output-hk/lace/pull/378/commits/b40ee92131127c0c247656e4b45551987a3462f9)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 1      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->