### PR TITLE
test(extension): e2e - add test for dark/light theme support while onboarding

### DIFF
--- a/packages/e2e-tests/src/assert/commonAssert.ts
+++ b/packages/e2e-tests/src/assert/commonAssert.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import { getNumberOfOpenedTabs, switchToLastWindow } from '../utils/window';
 import testContext from '../utils/testContext';
 import { browser } from '@wdio/globals';
+import TopNavigationAssert from './topNavigationAssert';
 
 class CommonAssert {
   async assertClipboardContains(text: string) {
@@ -60,6 +61,11 @@ class CommonAssert {
     const hasHorizontalScroll = pageWidth >= viewportWidth;
     await expect(hasHorizontalScroll).to.equal(shouldBeVisible);
   };
+
+  async assertSeeThemeMode(mode: 'dark' | 'light') {
+    await expect(await $('html').getAttribute('data-theme')).to.equal(mode);
+    await TopNavigationAssert.assertBackgroundColor(mode);
+  }
 }
 
 export default new CommonAssert();

--- a/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
+++ b/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
@@ -16,7 +16,6 @@ import extensionUtils from '../utils/utils';
 import TokensPageObject from '../pageobject/tokensPageObject';
 import { getTestWallet, TestWalletName } from '../support/walletConfiguration';
 import { browser } from '@wdio/globals';
-import TopNavigationAssert from './topNavigationAssert';
 
 export type ExpectedDAppDetails = {
   hasLogo: boolean;
@@ -72,11 +71,6 @@ class DAppConnectorAssert {
     await expect(await AuthorizeDAppPage.authorizeButton.getText()).to.equal(await t('dapp.connect.btn.accept'));
     await AuthorizeDAppPage.cancelButton.waitForDisplayed();
     await expect(await AuthorizeDAppPage.cancelButton.getText()).to.equal(await t('dapp.connect.btn.cancel'));
-  }
-
-  async assertSeeDAppThemeMode(mode: 'dark' | 'light') {
-    await expect(await $('html').getAttribute('data-theme')).to.equal(mode);
-    await TopNavigationAssert.assertBackgroundColor(mode);
   }
 
   async assertSeeAuthorizePagePermissions() {

--- a/packages/e2e-tests/src/features/OnboardingCreateWallet.feature
+++ b/packages/e2e-tests/src/features/OnboardingCreateWallet.feature
@@ -156,6 +156,7 @@ Feature: Onboarding - Create wallet
     Then "Mnemonic writedown" page is displayed with words 8 of 24
     And I save the words
     And Words 1 - 8 are the same
+    And I clear saved words
 
   @LW-2438
   Scenario: Create Wallet - Mnemonic writedown - back button to start over and new words
@@ -168,6 +169,7 @@ Feature: Onboarding - Create wallet
     Then "Mnemonic writedown" page is displayed with words 8 of 24
     And I save the words
     And Words 1 - 8 are not the same
+    And I clear saved words
 
   @LW-2439
   Scenario: Create Wallet - Mnemonic verification page displayed
@@ -340,3 +342,59 @@ Feature: Onboarding - Create wallet
       | Cookie policy    |
       | Privacy policy   |
       | Terms of service |
+
+  @LW-4993
+  Scenario Outline: Create Wallet - <mode> theme applied to onboarding pages
+    Given I set <mode> theme mode in Local Storage
+    When "Get started" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I click "Create" button on wallet setup page
+    When "Legal page" is displayed
+    Then I see current onboarding page in <mode> mode
+    And I accept "T&C" checkbox
+    And I click "Next" button during wallet setup
+    When "Help us improve your experience" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I click "Next" button during wallet setup
+    When "Name your wallet" page is displayed
+    Then I see current onboarding page in <mode> mode
+    When I enter wallet name: "someWallet"
+    And I click "Next" button during wallet setup
+    When "Wallet password" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I enter password: "N_8J@bne87A" and password confirmation: "N_8J@bne87A"
+    And I click "Next" button during wallet setup
+    When "Mnemonic info" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I click "Next" button during wallet setup
+    Then "Mnemonic writedown" page is displayed with words 8 of 24
+    Then I see current onboarding page in <mode> mode
+    And I save the words
+    And I click "Next" button during wallet setup
+    Then "Mnemonic writedown" page is displayed with words 16 of 24
+    Then I see current onboarding page in <mode> mode
+    And I save the words
+    And I click "Next" button during wallet setup
+    Then "Mnemonic writedown" page is displayed with words 24 of 24
+    Then I see current onboarding page in <mode> mode
+    And I save the words
+    And I click "Next" button during wallet setup
+    When "Mnemonic verification" page is displayed with words 8 of 24
+    Then I see current onboarding page in <mode> mode
+    And I fill saved words 8 of 24
+    And I click "Next" button during wallet setup
+    When "Mnemonic verification" page is displayed with words 16 of 24
+    Then I see current onboarding page in <mode> mode
+    And I fill saved words 16 of 24
+    And I click "Next" button during wallet setup
+    When "Mnemonic verification" page is displayed with words 24 of 24
+    Then I see current onboarding page in <mode> mode
+    And I fill saved words 24 of 24
+    And I click "Next" button during wallet setup
+    Then "All done" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I clear saved words
+    Examples:
+      | mode  |
+      | dark  |
+      | light |

--- a/packages/e2e-tests/src/features/OnboardingHardwareWallet.feature
+++ b/packages/e2e-tests/src/features/OnboardingHardwareWallet.feature
@@ -75,3 +75,24 @@ Feature: Onboarding - Hardware wallet
     And I am on "Connect Hardware Wallet" page
     When I click "Back" button during wallet setup
     Then "Help us improve your experience" page is displayed
+
+  @LW-4993
+  Scenario Outline: Hardware wallet - <mode> theme applied to onboarding pages
+    Given I set <mode> theme mode in Local Storage
+    When "Get started" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I click "Connect" button on wallet setup page
+    And I click "OK" button on "Limited support for DApp" modal
+    When "Legal page" is displayed
+    Then I see current onboarding page in <mode> mode
+    And I accept "T&C" checkbox
+    And I click "Next" button during wallet setup
+    When "Help us improve your experience" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I click "Next" button during wallet setup
+    When "Connect Hardware Wallet" page is displayed
+    Then I see current onboarding page in <mode> mode
+    Examples:
+      | mode  |
+      | dark  |
+      | light |

--- a/packages/e2e-tests/src/features/OnboardingRestoreWallet.feature
+++ b/packages/e2e-tests/src/features/OnboardingRestoreWallet.feature
@@ -429,3 +429,46 @@ Feature: Onboarding - Restore wallet
       | 12             |
       | 15             |
       | 24             |
+
+  @LW-4993
+  Scenario Outline: Restore Wallet - <mode> theme applied to onboarding pages
+    Given I set <mode> theme mode in Local Storage
+    When "Get started" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I click "Restore" button and confirm
+    When "Legal page" is displayed
+    Then I see current onboarding page in <mode> mode
+    And I accept "T&C" checkbox
+    And I click "Next" button during wallet setup
+    When "Help us improve your experience" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I click "Next" button during wallet setup
+    When "Name your wallet" page is displayed
+    Then I see current onboarding page in <mode> mode
+    When I enter wallet name: "someWallet"
+    And I click "Next" button during wallet setup
+    When "Wallet password" page is displayed
+    Then I see current onboarding page in <mode> mode
+    And I enter password: "N_8J@bne87A" and password confirmation: "N_8J@bne87A"
+    And I click "Next" button during wallet setup
+    When "Recovery phrase length page" is displayed and 24 words checkbox is checked
+    Then I see current onboarding page in <mode> mode
+    And I click "Next" button during wallet setup
+    When "Mnemonic verification" page is displayed with words 8 of 24
+    Then I see current onboarding page in <mode> mode
+    And I fill passphrase fields using 24 words mnemonic on 8/24 page
+    And I click "Next" button during wallet setup
+    When "Mnemonic verification" page is displayed with words 16 of 24
+    Then I see current onboarding page in <mode> mode
+    And I fill passphrase fields using 24 words mnemonic on 16/24 page
+    And I click "Next" button during wallet setup
+    When "Mnemonic verification" page is displayed with words 24 of 24
+    Then I see current onboarding page in <mode> mode
+    And I fill passphrase fields using 24 words mnemonic on 24/24 page
+    And I click "Next" button during wallet setup
+    Then "All done" page is displayed
+    Then I see current onboarding page in <mode> mode
+    Examples:
+      | mode  |
+      | dark  |
+      | light |

--- a/packages/e2e-tests/src/fixture/localStorageInitializer.ts
+++ b/packages/e2e-tests/src/fixture/localStorageInitializer.ts
@@ -16,7 +16,7 @@ class LocalStorageInitializer {
   }
 
   async initializeMode(mode: 'light' | 'dark'): Promise<void> {
-    await localStorageManager.setItem('mode', JSON.stringify(mode));
+    await localStorageManager.setItem('mode', mode);
   }
 
   async initializeAppSettings(): Promise<void> {

--- a/packages/e2e-tests/src/steps/commonSteps.ts
+++ b/packages/e2e-tests/src/steps/commonSteps.ts
@@ -243,3 +243,7 @@ When(/^I reopen the page$/, async () => {
   await closeAllTabsExceptActiveOne();
   await browser.url(currentPageUrl);
 });
+When(/^I set (light|dark) theme mode in Local Storage$/, async (mode: 'light' | 'dark') => {
+  await localStorageInitializer.initializeMode(mode);
+  await browser.refresh();
+});

--- a/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
+++ b/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
@@ -9,6 +9,7 @@ import SignTransactionPage from '../elements/dappConnector/signTransactionPage';
 import AllDonePage from '../elements/dappConnector/dAppTransactionAllDonePage';
 import TestDAppPage from '../elements/dappConnector/testDAppPage';
 import WalletUnlockScreenAssert from '../assert/walletUnlockScreenAssert';
+import CommonAssert from '../assert/commonAssert';
 
 const testDAppDetails: ExpectedDAppDetails = {
   hasLogo: true,
@@ -28,12 +29,12 @@ Then(/^I see DApp authorization window$/, async () => {
 Then(/^I see DApp authorization window in (dark|light) mode$/, async (mode: 'dark' | 'light') => {
   await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow(3);
   await DAppConnectorAssert.assertSeeAuthorizeDAppPage(testDAppDetails);
-  await DAppConnectorAssert.assertSeeDAppThemeMode(mode);
+  await CommonAssert.assertSeeThemeMode(mode);
 });
 
 Then(/^I see DApp connector "Confirm transaction" page in (dark|light) mode$/, async (mode: 'dark' | 'light') => {
   await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow(3);
-  await DAppConnectorAssert.assertSeeDAppThemeMode(mode);
+  await CommonAssert.assertSeeThemeMode(mode);
 });
 
 Then(

--- a/packages/e2e-tests/src/steps/onboardingSteps.ts
+++ b/packages/e2e-tests/src/steps/onboardingSteps.ts
@@ -34,6 +34,7 @@ import TopNavigationAssert from '../assert/topNavigationAssert';
 import testContext from '../utils/testContext';
 import webTester from '../actor/webTester';
 import MainLoader from '../elements/MainLoader';
+import CommonAssert from '../assert/commonAssert';
 
 const mnemonicWords: string[] = getTestWallet(TestWalletName.TestAutomationWallet).mnemonic ?? [];
 const invalidMnemonicWords: string[] = getTestWallet(TestWalletName.InvalidMnemonic).mnemonic ?? [];
@@ -385,8 +386,25 @@ Given(/^I fill passphrase fields using 15 words mnemonic on (8\/15|15\/15) page$
 });
 
 Then(/^I save the words$/, async () => {
-  mnemonicWordsForReference.length = 0;
   mnemonicWordsForReference.push(...(await OnboardingMnemonicPage.getMnemonicWordTexts()));
+});
+
+Then(/^I clear saved words$/, async () => {
+  mnemonicWordsForReference.length = 0;
+});
+
+Then(/^I fill saved words (8|16|24) of 24$/, async (pageNumber: string) => {
+  switch (pageNumber) {
+    case '8':
+      await OnboardingPageObject.fillMnemonicFields(mnemonicWordsForReference, 0);
+      break;
+    case '16':
+      await OnboardingPageObject.fillMnemonicFields(mnemonicWordsForReference, 8);
+      break;
+    case '24':
+      await OnboardingPageObject.fillMnemonicFields(mnemonicWordsForReference, 16);
+      break;
+  }
 });
 
 When(/^I fill mnemonic input with "([^"]*)"$/, async (value: string) => {
@@ -559,4 +577,8 @@ When(/^I click "here." link on "Keeping your wallet secure" page$/, async () => 
 
 Given(/^I restore a wallet$/, async () => {
   await OnboardingPageObject.restoreWallet();
+});
+
+Given(/^I see current onboarding page in (light|dark) mode$/, async (mode: 'light' | 'dark') => {
+  await CommonAssert.assertSeeThemeMode(mode);
 });


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1442/5830287915/index.html) for [838b0977](https://github.com/input-output-hk/lace/pull/384/commits/838b09779d6d545e9ac3c39d164c840950f3bf22)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 33     | 3      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->