### PR TITLE
fix: replace `visible` prop with `open` on modals, tooltips and drawers

### DIFF
--- a/apps/browser-extension-wallet/src/components/Announcement/Announcement.tsx
+++ b/apps/browser-extension-wallet/src/components/Announcement/Announcement.tsx
@@ -42,7 +42,7 @@ export const Announcement = ({ visible, onConfirm, version, reason }: Announceme
       closable={false}
       // eslint-disable-next-line unicorn/no-null
       footer={null}
-      visible={visible && !!releaseNotes}
+      open={visible && !!releaseNotes}
       width="100%"
       className={styles.modal}
     >

--- a/apps/browser-extension-wallet/src/components/ContinueInBrowserDialog/ContinueInBrowserDialog.tsx
+++ b/apps/browser-extension-wallet/src/components/ContinueInBrowserDialog/ContinueInBrowserDialog.tsx
@@ -30,7 +30,7 @@ export const ContinueInBrowserDialog = ({
     closable={false}
     // eslint-disable-next-line unicorn/no-null
     footer={null}
-    visible={visible}
+    open={visible}
     width={HW_POPUPS_WIDTH}
     className={styles.continueInBrowser}
   >

--- a/apps/browser-extension-wallet/src/components/TransitionAcknowledgmentDialog/TransitionAcknowledgmentDialog.tsx
+++ b/apps/browser-extension-wallet/src/components/TransitionAcknowledgmentDialog/TransitionAcknowledgmentDialog.tsx
@@ -39,7 +39,7 @@ export const TransitionAcknowledgmentDialog = ({
       closable={false}
       // eslint-disable-next-line unicorn/no-null
       footer={null}
-      visible={visible}
+      open={visible}
       width={HW_POPUPS_WIDTH}
       className={styles.transitionAcknowledgment}
       zIndex={1001}

--- a/apps/browser-extension-wallet/src/features/activity/components/Activity.tsx
+++ b/apps/browser-extension-wallet/src/features/activity/components/Activity.tsx
@@ -74,7 +74,7 @@ export const Activity = (): React.ReactElement => {
   return (
     <ContentLayout title={layoutTitle} titleSideText={layoutSideText} isLoading={isLoading}>
       <Drawer
-        visible={!!transactionDetail}
+        open={!!transactionDetail}
         onClose={resetTransactionState}
         navigation={
           <DrawerNavigation

--- a/apps/browser-extension-wallet/src/features/address-book/components/AddressActionsModal.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/components/AddressActionsModal.tsx
@@ -23,7 +23,7 @@ export const AddressActionsModal = ({
   action,
   onCancel,
   onConfirm,
-  visible,
+  open,
   isPopup
 }: AddressActionsModalProps): React.ReactElement => {
   const { t: translate } = useTranslation();
@@ -46,7 +46,7 @@ export const AddressActionsModal = ({
       // eslint-disable-next-line unicorn/no-null
       footer={null}
       closable={false}
-      visible={visible}
+      open={open}
       width={isPopup ? 'calc(100% - 50px)' : modalWidth}
       zIndex={1000}
     >

--- a/apps/browser-extension-wallet/src/features/address-book/components/AddressDetailDrawer/AddressChangeDetailDrawer.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/components/AddressDetailDrawer/AddressChangeDetailDrawer.tsx
@@ -277,7 +277,7 @@ export const AddressChangeDetailDrawer = ({
         action={action}
         onCancel={onHandleCancel}
         onConfirm={onHandleConfirm}
-        visible={!!selectedId}
+        open={!!selectedId}
         isPopup={popupView}
       />
     </>

--- a/apps/browser-extension-wallet/src/features/address-book/components/AddressDetailDrawer/AddressDetailDrawer.tsx
+++ b/apps/browser-extension-wallet/src/features/address-book/components/AddressDetailDrawer/AddressDetailDrawer.tsx
@@ -186,7 +186,7 @@ export const AddressDetailDrawer = ({
             )}
           </>
         }
-        visible={visible}
+        open={visible}
         popupView={popupView}
       >
         {visible && (
@@ -267,7 +267,7 @@ export const AddressDetailDrawer = ({
           setSelectedId(null);
           onCancelClick();
         }}
-        visible={!!selectedId}
+        open={!!selectedId}
         isPopup={popupView}
       />
     </>

--- a/apps/browser-extension-wallet/src/features/dapp/components/Connect.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/Connect.tsx
@@ -148,7 +148,7 @@ export const Connect = (): React.ReactElement => {
       <Modal
         centered
         closable={false}
-        visible={isModalVisible}
+        open={isModalVisible}
         width={312}
         className={styles.dappConnection}
         zIndex={1001}

--- a/apps/browser-extension-wallet/src/features/unlock-wallet/components/ForgotPassword.tsx
+++ b/apps/browser-extension-wallet/src/features/unlock-wallet/components/ForgotPassword.tsx
@@ -25,7 +25,7 @@ export const ForgotPassword = ({ onForgotPasswordClick }: UnlockWalletProps): Re
         closable={false}
         // eslint-disable-next-line unicorn/no-null
         footer={null}
-        visible={isModalVisible}
+        open={isModalVisible}
         width={HW_POPUPS_WIDTH}
         className={styles.modal}
       >

--- a/apps/browser-extension-wallet/src/views/browser-view/components/Drawer/DrawerUIContent.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/Drawer/DrawerUIContent.tsx
@@ -43,7 +43,7 @@ export const DrawerUIContainer = ({ defaultContent }: { defaultContent?: DrawerC
   return (
     <Drawer
       className={config?.wrapperClassName}
-      visible={!isUndefined(config) || !isUndefined(defaultContent)}
+      open={!isUndefined(config) || !isUndefined(defaultContent)}
       destroyOnClose
       onClose={() => (config?.onClose ? config?.onClose() : clearContent())}
       footer={footer || undefined}

--- a/apps/browser-extension-wallet/src/views/browser-view/components/WarningModal/WarningModal.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/WarningModal/WarningModal.tsx
@@ -45,7 +45,7 @@ export const WarningModal = ({
       onCancel={onCancel}
       // eslint-disable-next-line unicorn/no-null
       footer={null}
-      visible={visible}
+      open={visible}
       width={isPopupView ? '100%' : modalWidth}
     >
       <div data-testid="delete-address-modal-title" className={styles.header}>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityLayout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityLayout.tsx
@@ -122,7 +122,7 @@ export const ActivityLayout = (): ReactElement => {
           sideText={activitiesCount ? `(${activitiesCount})` : ''}
         />
         <Drawer
-          visible={!!transactionDetail}
+          open={!!transactionDetail}
           onClose={resetTransactionState}
           navigation={
             <DrawerNavigation title={t('transactions.detail.title')} onCloseIconClick={resetTransactionState} />

--- a/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetDetailsDrawer/AssetDetailsDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetDetailsDrawer/AssetDetailsDrawer.tsx
@@ -175,7 +175,7 @@ export const AssetDetailsDrawer = ({
       className={styles.drawer}
       navigation={<DrawerNavigation title={t('browserView.assetDetails.title')} onCloseIconClick={setVisibility} />}
       footer={renderFooter(handleOpenSend, t('browserView.assets.send'), popupView)}
-      visible={isVisible}
+      open={isVisible}
       destroyOnClose
       onClose={setVisibility}
       popupView={popupView}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetTransactionDetails/AssetTransactionDetails.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetTransactionDetails/AssetTransactionDetails.tsx
@@ -25,8 +25,8 @@ export const AssetTransactionDetails = ({
 
   return (
     <Drawer
-      afterVisibleChange={afterVisibleChange}
-      visible={isVisible}
+      afterOpenChange={afterVisibleChange}
+      open={isVisible}
       onClose={onClose}
       navigation={<DrawerNavigation onCloseIconClick={onClose} onArrowIconClick={onBack} />}
       popupView={appMode === APP_MODE_POPUP}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/dapp/components/DappList/DappList.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/dapp/components/DappList/DappList.tsx
@@ -52,7 +52,7 @@ export const DappList = withDappContext(
             onArrowIconClick={popupView ? onCancelClick : undefined}
           />
         }
-        visible={visible}
+        open={visible}
         popupView={popupView}
       >
         <>
@@ -99,7 +99,7 @@ export const DappList = withDappContext(
                         setDappToDelete(undefined);
                       });
                   }}
-                  visible={!!dappToDelete}
+                  open={!!dappToDelete}
                   isPopupView={popupView}
                 />
               </div>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/dapp/components/DappList/DeleteDappModal.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/dapp/components/DappList/DeleteDappModal.tsx
@@ -16,7 +16,7 @@ export type deleteDappModalProps = {
 export const DeleteDappModal = ({
   onCancel,
   onConfirm,
-  visible,
+  open,
   isPopupView
 }: deleteDappModalProps): React.ReactElement => {
   const { t: translate } = useTranslation();
@@ -27,7 +27,7 @@ export const DeleteDappModal = ({
       closable={false}
       // eslint-disable-next-line unicorn/no-null
       footer={null}
-      visible={visible}
+      open={open}
       width={isPopupView ? modalPopupWidth : modalBrowserWidth}
     >
       <div data-testid="delete-dapp-modal-title" className={styles.header}>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/CreateFolderDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/CreateFolder/CreateFolderDrawer.tsx
@@ -245,7 +245,7 @@ export const NFTFolderDrawer = withNftsFoldersContext(
       <>
         <Drawer
           keyboard={false}
-          visible={visible}
+          open={visible}
           onClose={onCloseDrawer}
           title={headerMap[currentSection]}
           navigation={

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/DetailsDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/DetailsDrawer.tsx
@@ -37,7 +37,7 @@ export const DetailsDrawer = ({
 
   return (
     <Drawer
-      visible={!!selectedNft}
+      open={!!selectedNft}
       onClose={onClose}
       title={assetInfo ? <DrawerHeader title={nftNameSelector(assetInfo, environmentName)} /> : undefined}
       navigation={

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftFolderConfirmationModal.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/NftFolderConfirmationModal.tsx
@@ -39,7 +39,7 @@ export const NftFolderConfirmationModal = ({
     onCancel={onCancel}
     // eslint-disable-next-line unicorn/no-null
     footer={null}
-    visible={visible}
+    open={visible}
     width={popupView ? popupModalWidth : extendedModalWidth}
   >
     <div data-testid="create-folder-modal-title" className={styles.header}>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/RenameFolderDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/nfts/components/RenameFolderDrawer.tsx
@@ -78,7 +78,7 @@ export const RenameFolderDrawer = withNftsFoldersContext(
     return (
       <>
         <Drawer
-          visible={visible}
+          open={visible}
           onClose={onCloseDrawer}
           popupView={isPopupView}
           title={<DrawerHeader popupView={isPopupView} title={t('browserView.nfts.renameYourFolder')} />}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/CancelEditAddressModal.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/CancelEditAddressModal.tsx
@@ -30,7 +30,7 @@ export const CancelEditAddressModal = ({
       closable={false}
       // eslint-disable-next-line unicorn/no-null
       footer={null}
-      visible={visible}
+      open={visible}
       width={isPopupView ? modalPopupWidth : modalBrowserWidth}
     >
       <div data-testid="stake-confirmation-modal-title" className={styles.header}>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/AboutDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/AboutDrawer.tsx
@@ -13,7 +13,7 @@ export const AboutDrawer = ({ visible, onClose, popupView }: AboutDrawerProps): 
   const { t } = useTranslation();
   return (
     <Drawer
-      visible={visible}
+      open={visible}
       onClose={onClose}
       title={<DrawerHeader popupView={popupView} />}
       navigation={

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/CollateralDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/CollateralDrawer.tsx
@@ -140,7 +140,7 @@ export const CollateralDrawer = ({
 
   return (
     <Drawer
-      visible={visible}
+      open={visible}
       onClose={handleClose}
       title={<DrawerHeader popupView={popupView} title={t('browserView.settings.wallet.collateral.title')} />}
       navigation={

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/CookiePolicyDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/CookiePolicyDrawer.tsx
@@ -46,7 +46,7 @@ export const CookiePolicyDrawer = ({
 
   return (
     <Drawer
-      visible={visible}
+      open={visible}
       onClose={onClose}
       title={<DrawerHeader popupView={popupView} title={t('browserView.settings.legal.cookiePolicy.title')} />}
       navigation={

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/GeneralSettingsDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/GeneralSettingsDrawer.tsx
@@ -40,7 +40,7 @@ export const GeneralSettingsDrawer = ({
   return (
     <>
       <Drawer
-        visible={visible}
+        open={visible}
         onClose={handleClose}
         title={
           <DrawerHeader

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/NetworkChoiceDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/NetworkChoiceDrawer.tsx
@@ -22,7 +22,7 @@ export const NetworkChoiceDrawer = ({
 
   return (
     <Drawer
-      visible={visible}
+      open={visible}
       onClose={onClose}
       title={<DrawerHeader popupView={popupView} title={t('browserView.settings.wallet.network.title')} />}
       navigation={

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/PassphraseSettingsDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/PassphraseSettingsDrawer.tsx
@@ -49,7 +49,7 @@ export const PassphraseSettingsDrawer = ({
 
   return (
     <Drawer
-      visible={visible}
+      open={visible}
       onClose={onClose}
       title={
         <DrawerHeader popupView={popupView} title={t('browserView.settings.security.periodicVerification.title')} />

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/PrivacyPolicyDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/PrivacyPolicyDrawer.tsx
@@ -24,7 +24,7 @@ export const PrivacyPolicyDrawer = ({
 
   return (
     <Drawer
-      visible={visible}
+      open={visible}
       onClose={onClose}
       title={<DrawerHeader popupView={popupView} title={t('browserView.settings.legal.privacyPolicy.title')} />}
       navigation={

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsPreferences/CurrencyDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsPreferences/CurrencyDrawer.tsx
@@ -41,7 +41,7 @@ export const CurrencyDrawer = ({ visible, onClose, popupView = false }: Currency
 
   return (
     <Drawer
-      visible={visible}
+      open={visible}
       onClose={onClose}
       title={
         <DrawerHeader

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/ShowPassphraseDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/ShowPassphraseDrawer.tsx
@@ -123,7 +123,7 @@ export const ShowPassphraseDrawer = ({
 
   return (
     <Drawer
-      visible={visible}
+      open={visible}
       onClose={handleOnClose}
       title={
         <DrawerHeader popupView={popupView} title={t('browserView.settings.security.showPassphraseDrawer.title')} />

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SupportDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SupportDrawer.tsx
@@ -23,7 +23,7 @@ export const SupportDrawer = ({
 
   return (
     <Drawer
-      visible={visible}
+      open={visible}
       onClose={onClose}
       title={<DrawerHeader popupView={popupView} title={t('browserView.settings.help.support.help')} />}
       navigation={

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolDetails/StakePoolDetailsDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolDetails/StakePoolDetailsDrawer.tsx
@@ -108,7 +108,7 @@ export const StakePoolDetailsDrawer = ({
 
   return (
     <Drawer
-      visible={isDrawerVisible}
+      open={isDrawerVisible}
       destroyOnClose
       onClose={closeDrawer}
       navigation={

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingModals/StakingModal.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingModals/StakingModal.tsx
@@ -47,7 +47,7 @@ export const StakingModal = ({
       onCancel={handleCancelModal}
       // eslint-disable-next-line unicorn/no-null
       footer={null}
-      visible={visible}
+      open={visible}
       width={popupView ? popupModalWidth : extendedModalWidth}
     >
       <div data-testid="stake-modal-title" className={styles.header}>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/voting/components/VotingLayout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/voting/components/VotingLayout.tsx
@@ -198,7 +198,7 @@ export const VotingLayout = (): React.ReactElement => {
         />
         <Drawer
           onClose={handleCloseRegistrationRequest}
-          visible={isRegisteringWallet}
+          open={isRegisteringWallet}
           title={<DrawerHeader title={translate('browserView.voting.catalystRegistrationFlow.title')} />}
           navigation={<DrawerNavigation onCloseIconClick={handleCloseRegistrationRequest} />}
         >

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/ErrorDialog.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/ErrorDialog.tsx
@@ -38,7 +38,7 @@ export const ErrorDialog = ({ visible, onRetry, errorCode = 'common' }: ErrorDia
       closable={false}
       // eslint-disable-next-line unicorn/no-null
       footer={null}
-      visible={visible}
+      open={visible}
       width={420}
       className={styles.errorDialog}
     >

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/StartOverDialog.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/StartOverDialog.tsx
@@ -21,7 +21,7 @@ export const StartOverDialog = ({ visible, onStartOver, onClose }: StartOverDial
       closable={false}
       // eslint-disable-next-line unicorn/no-null
       footer={null}
-      visible={visible}
+      open={visible}
       width={480}
       className={styles.startOverDialog}
     >

--- a/packages/core/src/ui/components/Nft/NftFolderItem.tsx
+++ b/packages/core/src/ui/components/Nft/NftFolderItem.tsx
@@ -41,7 +41,7 @@ export const NftFolderItem = ({ name, onClick, nfts, contextMenuItems }: NftFold
   const restOfNftsContent = (
     <Tooltip
       className={styles.restOfNftsNumber}
-      visible={!shouldShowCompactNumber ? false : undefined}
+      open={!shouldShowCompactNumber ? false : undefined}
       placement="top"
       title={`+${restOfNfts}`}
     >

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupStepLayout.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupStepLayout.tsx
@@ -138,7 +138,7 @@ export const WalletSetupStepLayout = ({
           {onNext && (
             <span ref={nextButtonContainerRef}>
               <Tooltip
-                visible={!isNextEnabled && !!toolTipText}
+                open={!isNextEnabled && !!toolTipText}
                 title={!isNextEnabled && toolTipText}
                 getPopupContainer={() => nextButtonContainerRef.current}
                 autoAdjustOverflow={false}

--- a/packages/staking/src/features/drawer/StakePoolDetailsDrawer.tsx
+++ b/packages/staking/src/features/drawer/StakePoolDetailsDrawer.tsx
@@ -106,7 +106,7 @@ export const StakePoolDetailsDrawer = ({
 
   return (
     <Drawer
-      visible={isDrawerVisible}
+      open={isDrawerVisible}
       destroyOnClose
       onClose={closeDrawer}
       navigation={


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7857
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

`visible` prop is deprecated in favour of `open` on antd Modal, Tooltip and Drawer component. I updated all the components of the app to match this

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1439/5826253054/index.html) for [ae25eb3e](https://github.com/input-output-hk/lace/pull/385/commits/ae25eb3eff4bd1337777fc5ef547cf57a7e7f401)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 33     | 3      | 0       | 0     | 36    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->