### PR TITLE
test(extension): e2e - add tests for editing ada handle in address book

### DIFF
--- a/packages/e2e-tests/src/assert/addressBook/AddressDetailsAssert.ts
+++ b/packages/e2e-tests/src/assert/addressBook/AddressDetailsAssert.ts
@@ -1,9 +1,10 @@
 import AddressDetails from '../../elements/addressbook/AddressDetails';
 import { t } from '../../utils/translationService';
 import { expect } from 'chai';
+import { Address } from '../../data/Address';
 
 class AddressDetailsAssert {
-  assertSeeAddressDetailsPage = async (shouldSee: boolean, mode: 'extended' | 'popup') => {
+  assertSeeAddressDetailsPage = async (shouldSee: boolean, mode: 'extended' | 'popup', expectedAddress: Address) => {
     if (shouldSee) {
       await AddressDetails.drawerNavigationTitle.waitForDisplayed({ reverse: mode === 'popup' });
       await AddressDetails.drawerHeaderCloseButton.waitForDisplayed({ reverse: mode === 'popup' });
@@ -18,7 +19,9 @@ class AddressDetailsAssert {
         await t('browserView.addressBook.addressDetail.title')
       );
       await AddressDetails.name.waitForDisplayed();
+      await expect(await AddressDetails.name.getText()).to.equal(expectedAddress.getName());
       await AddressDetails.address.waitForDisplayed();
+      await expect(await AddressDetails.address.getText()).to.equal(expectedAddress.getAddress());
       await AddressDetails.copyButton.waitForDisplayed();
       await expect(await AddressDetails.copyButton.getText()).to.equal(await t('addressBook.addressDetail.btn.copy'));
       await AddressDetails.editButton.waitForDisplayed();

--- a/packages/e2e-tests/src/assert/addressBook/AddressFormAssert.ts
+++ b/packages/e2e-tests/src/assert/addressBook/AddressFormAssert.ts
@@ -1,5 +1,6 @@
 import AddressForm from '../../elements/addressbook/AddressForm';
 import { expect } from 'chai';
+import { Address } from '../../data/Address';
 
 class AddressFormAssert {
   assertSeeAddressFormInputs = async () => {
@@ -7,11 +8,11 @@ class AddressFormAssert {
     await AddressForm.addressInput.waitForDisplayed();
   };
 
-  assertSeeAddressFormInputsPopulated = async () => {
+  assertSeeAddressFormInputsPopulated = async (expectedAddress: Address) => {
     await AddressForm.nameInput.waitForDisplayed();
-    expect(await AddressForm.nameInput.getValue()).to.match(/^(?!\\s*$).+/);
+    expect(await AddressForm.nameInput.getValue()).to.equal(expectedAddress.getName());
     await AddressForm.addressInput.waitForDisplayed();
-    expect(await AddressForm.addressInput.getValue()).to.match(/^(?!\s*$).+/);
+    expect(await AddressForm.addressInput.getValue()).to.equal(expectedAddress.getAddress());
   };
 
   assertSeeNameError = async (shouldBeDisplayed: boolean, expectedNameError?: string) => {

--- a/packages/e2e-tests/src/assert/addressBook/EditAddressDrawerAssert.ts
+++ b/packages/e2e-tests/src/assert/addressBook/EditAddressDrawerAssert.ts
@@ -2,9 +2,10 @@ import EditAddressDrawer from '../../elements/addressbook/EditAddressDrawer';
 import { expect } from 'chai';
 import { t } from '../../utils/translationService';
 import AddressFormAssert from './AddressFormAssert';
+import { Address } from '../../data/Address';
 
 class EditAddressDrawerAssert {
-  async assertSeeEditAddressDrawer(mode: 'extended' | 'popup') {
+  async assertSeeEditAddressDrawer(mode: 'extended' | 'popup', expectedAddress: Address) {
     await EditAddressDrawer.drawerHeaderBackButton.waitForClickable();
     await EditAddressDrawer.drawerHeaderCloseButton.waitForClickable({ reverse: mode === 'popup' });
     await EditAddressDrawer.drawerNavigationTitle.waitForDisplayed({ reverse: mode === 'popup' });
@@ -18,7 +19,7 @@ class EditAddressDrawerAssert {
       await t('browserView.addressBook.editAddress.title')
     );
 
-    await AddressFormAssert.assertSeeAddressFormInputsPopulated();
+    await AddressFormAssert.assertSeeAddressFormInputsPopulated(expectedAddress);
 
     await EditAddressDrawer.doneButton.waitForDisplayed();
     expect(await EditAddressDrawer.doneButton.getText()).to.equal(await t('core.editAddressForm.doneButton'));

--- a/packages/e2e-tests/src/data/AddressData.ts
+++ b/packages/e2e-tests/src/data/AddressData.ts
@@ -67,6 +67,9 @@ export const validAddress6 = new Address(
   'addr1q9qxfqcjz3uq4mevu7rnf5zefvk9gz8fnt7e2saq44qhcytj9hwek0yzxwfa3446amdf3f8sn070pp53p52pczfc0r4syd9k07'
 );
 
+export const adaHandle1 = new Address('Ada Handle 1', '$test_handle_1', '$test_handle_1');
+export const adaHandle2 = new Address('Ada Handle 2', '$test_handle_2', '$test_handle_2');
+
 export const testAddresses = new Map<string, Address>([
   ['Shelley', shelley],
   ['Byron', byron],
@@ -78,7 +81,9 @@ export const testAddresses = new Map<string, Address>([
   ['Valid address3', validAddress3],
   ['Valid address4', validAddress4],
   ['Valid address5', validAddress5],
-  ['Valid address6', validAddress6]
+  ['Valid address6', validAddress6],
+  ['Ada Handle 1', adaHandle1],
+  ['Ada Handle 2', adaHandle2]
 ]);
 
 export const getAddressByName = (addressName: string): string | undefined =>

--- a/packages/e2e-tests/src/elements/transactionsPage.ts
+++ b/packages/e2e-tests/src/elements/transactionsPage.ts
@@ -81,7 +81,7 @@ class TransactionsPage {
     let rowIndex = 0;
     while (rowIndex < tokensCounterValue && (await this.rows).length < tokensCounterValue) {
       await this.scrollToTheRow(rowIndex);
-      rowIndex += 10;
+      rowIndex += 8;
       await browser.pause(1000);
     }
   }

--- a/packages/e2e-tests/src/features/AdaHandleExtended.feature
+++ b/packages/e2e-tests/src/features/AdaHandleExtended.feature
@@ -22,3 +22,36 @@ Feature: ADA handle - extended view
     Then Red "X" icon is displayed next to ADA handle
     And "Handle not found" error is displayed
     And "Save address" button is disabled on "Add new address" drawer
+
+  @LW-7335
+  Scenario: Extended view - Edit an ADA handle from the address book
+    Given I have 2 addresses with ADA handle in my address book in extended mode
+    And I click address on the list with name "Ada Handle 1"
+    And I see address detail page in extended mode with details of "Ada Handle 1" address
+    And I click "Edit" button on address details page
+    And I see "Edit address" drawer in extended mode with details of "Ada Handle 1" address
+    When I fill address form with "AH 1 edited" name and "$test_handle_3" address
+    Then Green tick icon is displayed next to ADA handle
+    And I click "Done" button on "Edit address" drawer
+    And I see a toast with message: "browserView.addressBook.toast.editAddress"
+    And I see address row with name "AH 1 edited" and address "$test_handle_3" on the list in extended mode
+
+  @LW-7337
+  Scenario: Extended view - Edit an ADA handle from the address book with an invalid handle
+    Given I have 2 addresses with ADA handle in my address book in extended mode
+    And I click address on the list with name "Ada Handle 1"
+    And I click "Edit" button on address details page
+    When I fill address form with "AH 1 edited" name and "$a3asd35" address
+    Then Red "X" icon is displayed next to ADA handle
+    And Contact "empty" name error and "Handle not found" address error are displayed
+    And "Done" button is disabled on "Edit address" drawer
+
+  @LW-7339
+  Scenario: Extended view - Edit an ADA handle from the address book with a duplicated handle
+    Given I have 2 addresses with ADA handle in my address book in extended mode
+    And I click address on the list with name "Ada Handle 1"
+    And I click "Edit" button on address details page
+    When I fill address form with "AH 1 edited" name and "$test_handle_2" address
+    Then Green tick icon is displayed next to ADA handle
+    And I click "Done" button on "Edit address" drawer
+    And I see a toast with message: "addressBook.errors.givenAddressAlreadyExist"

--- a/packages/e2e-tests/src/features/AdaHandlePopup.feature
+++ b/packages/e2e-tests/src/features/AdaHandlePopup.feature
@@ -22,3 +22,36 @@ Feature: ADA handle - popup view
     Then Red "X" icon is displayed next to ADA handle
     And "Handle not found" error is displayed
     And "Save address" button is disabled on "Add new address" drawer
+
+  @LW-7336
+  Scenario: Popup view - Edit an ADA handle from the address book
+    Given I have 2 addresses with ADA handle in my address book in popup mode
+    And I click address on the list with name "Ada Handle 1"
+    And I see address detail page in popup mode with details of "Ada Handle 1" address
+    And I click "Edit" button on address details page
+    And I see "Edit address" drawer in popup mode with details of "Ada Handle 1" address
+    When I fill address form with "AH 1 edited" name and "$test_handle_3" address
+    Then Green tick icon is displayed next to ADA handle
+    And I click "Done" button on "Edit address" drawer
+    And I see a toast with message: "browserView.addressBook.toast.editAddress"
+    And I see address row with name "AH 1 edited" and address "$test_handle_3" on the list in popup mode
+
+  @LW-7338
+  Scenario: Popup view - Edit an ADA handle from the address book with an invalid handle
+    Given I have 2 addresses with ADA handle in my address book in popup mode
+    And I click address on the list with name "Ada Handle 1"
+    And I click "Edit" button on address details page
+    When I fill address form with "AH 1 edited" name and "$a3asd35" address
+    Then Red "X" icon is displayed next to ADA handle
+    And Contact "empty" name error and "Handle not found" address error are displayed
+    And "Done" button is disabled on "Edit address" drawer
+
+  @LW-7340
+  Scenario: Popup view - Edit an ADA handle from the address book with a duplicated handle
+    Given I have 2 addresses with ADA handle in my address book in popup mode
+    And I click address on the list with name "Ada Handle 1"
+    And I click "Edit" button on address details page
+    When I fill address form with "AH 1 edited" name and "$test_handle_2" address
+    Then Green tick icon is displayed next to ADA handle
+    And I click "Done" button on "Edit address" drawer
+    And I see a toast with message: "addressBook.errors.givenAddressAlreadyExist"

--- a/packages/e2e-tests/src/features/AddressBookExtended.feature
+++ b/packages/e2e-tests/src/features/AddressBookExtended.feature
@@ -81,7 +81,7 @@ Feature: Address book - extended view
   Scenario: Extended-view - Address Book - Remove address
     Given I have 3 addresses in my address book in extended mode
     When I click address on the list with name "Byron"
-    And I see address detail page in extended mode
+    And I see address detail page in extended mode with details of "Byron" address
     And I click "Delete" button on address details page
     Then I see delete address modal
     When I click "Delete address" button on delete address modal
@@ -91,10 +91,10 @@ Feature: Address book - extended view
   Scenario: Extended-view - Address Book - Remove address and cancel
     Given I have 3 addresses in my address book in extended mode
     When I click address on the list with name "Byron"
-    And I see address detail page in extended mode
+    And I see address detail page in extended mode with details of "Byron" address
     And I click "Delete" button on address details page
     And I click "Cancel" button on delete address modal
-    Then I see address detail page in extended mode
+    Then I see address detail page in extended mode with details of "Byron" address
 
   @LW-4468 @Smoke
   Scenario Outline: Extended-view - Address Book - Uniqueness validation and toast display with text <toast_message>
@@ -137,7 +137,7 @@ Feature: Address book - extended view
     And I click address on the list with name "Shelley"
     And I click "Edit" button on address details page
     When I click "Cancel" button on "Edit address" drawer
-    Then I see address detail page in extended mode
+    Then I see address detail page in extended mode with details of "Shelley" address
 
   @LW-4565
   Scenario Outline: Extended-view - Address Book - Edit wallet name/address and display error message - name error: <name_error>, address error: <address_error>
@@ -186,7 +186,7 @@ Feature: Address book - extended view
     And I click address on the list with name "Shelley"
     And I click "Edit" button on address details page
     When I close the drawer by clicking back button
-    Then I see address detail page in extended mode
+    Then I see address detail page in extended mode with details of "Shelley" address
 
   @LW-4484
   Scenario: Extended-view - Address Book - "About your wallet" widget
@@ -208,11 +208,11 @@ Feature: Address book - extended view
   Scenario: Extended-view - Address Book - Enter and Escape buttons support when editing address
     Given I have 3 addresses in my address book in extended mode
     When I click address on the list with name "Byron"
-    Then I see address detail page in extended mode
+    Then I see address detail page in extended mode with details of "Byron" address
     When I press keyboard Enter button
-    Then I see "Edit address" drawer in extended mode
+    Then I see "Edit address" drawer in extended mode with details of "Byron" address
     When I press keyboard Escape button
-    And I see address detail page in extended mode
+    And I see address detail page in extended mode with details of "Byron" address
     When I press keyboard Enter button
     And I fill address form with "Byron_edited" name and "37btjrVyb4KC6N6XtRHwEuLPQW2aa9JA89gbnm67PArSi8E7vGeqgA6W1pFBphc1hhrk1WKGPZpUbnvYRimVLRVnUH6M6d3dsVdxYoAC4m7oNj7Dzp" address
     When I press keyboard Enter button
@@ -222,9 +222,9 @@ Feature: Address book - extended view
   Scenario: Extended-view - Address Book - Escape button support when closing drawer
     Given I have 3 addresses in my address book in extended mode
     When I click address on the list with name "Byron"
-    Then I see address detail page in extended mode
+    Then I see address detail page in extended mode with details of "Byron" address
     When I press keyboard Escape button
-    Then I do not see address detail page in extended mode
+    Then I do not see address detail page in extended mode with details of "Byron" address
 
   @LW-4779 @Pending
   # Bug LW-7419

--- a/packages/e2e-tests/src/features/AddressBookPopup.feature
+++ b/packages/e2e-tests/src/features/AddressBookPopup.feature
@@ -38,7 +38,7 @@ Feature: Address book - popup view
     And I click address on the list with name "Shelley"
     And I click "Edit" button on address details page
     When I click "Cancel" button on "Edit address" drawer
-    Then I see address detail page in popup mode
+    Then I see address detail page in popup mode with details of "Shelley" address
 
   @LW-4566
   Scenario Outline: Popup-view - Address Book - Edit wallet name/address and display error message - name error: <name_error>, address error: <address_error>
@@ -80,13 +80,13 @@ Feature: Address book - popup view
     And I click address on the list with name "Shelley"
     And I click "Edit" button on address details page
     When I close the drawer by clicking back button
-    Then I see address detail page in popup mode
+    Then I see address detail page in popup mode with details of "Shelley" address
 
   @LW-4477
   Scenario: Popup-view - Address Book - Remove address
     Given I have 3 addresses in my address book in popup mode
     When I click address on the list with name "Byron"
-    And I see address detail page in popup mode
+    And I see address detail page in popup mode with details of "Byron" address
     And I click "Delete" button on address details page
     Then I see delete address modal
     When I click "Delete address" button on delete address modal
@@ -96,10 +96,10 @@ Feature: Address book - popup view
   Scenario: Popup-view - Address Book - Remove address and cancel
     Given I have 3 addresses in my address book in popup mode
     When I click address on the list with name "Byron"
-    And I see address detail page in popup mode
+    And I see address detail page in popup mode with details of "Byron" address
     And I click "Delete" button on address details page
     And I click "Cancel" button on delete address modal
-    Then I see address detail page in popup mode
+    Then I see address detail page in popup mode with details of "Byron" address
 
   @LW-4479 @Pending
   # BUG LW-7925

--- a/packages/e2e-tests/src/steps/AddressBookSteps.ts
+++ b/packages/e2e-tests/src/steps/AddressBookSteps.ts
@@ -11,11 +11,20 @@ import EditAddressDrawer from '../elements/addressbook/EditAddressDrawer';
 import EditAddressDrawerAssert from '../assert/addressBook/EditAddressDrawerAssert';
 import testContext from '../utils/testContext';
 import commonAssert from '../assert/commonAssert';
-import { byron, getAddressByName, icarus, shelley } from '../data/AddressData';
+import {
+  adaHandle1,
+  adaHandle2,
+  byron,
+  getAddressByName,
+  getAddressDetailsByName,
+  icarus,
+  shelley
+} from '../data/AddressData';
 import indexedDB from '../fixture/indexedDB';
 import popupView from '../page/popupView';
 import extendedView from '../page/extendedView';
 import { browser } from '@wdio/globals';
+import { Address } from '../data/Address';
 
 Given(
   /^I don't have any addresses added to my address book in (popup|extended) mode$/,
@@ -40,6 +49,22 @@ Given(/^I have 3 addresses in my address book in (popup|extended) mode$/, async 
     await extendedView.visitAddressBook();
   }
 });
+
+Given(
+  /^I have 2 addresses with ADA handle in my address book in (popup|extended) mode$/,
+  async (mode: 'popup' | 'extended') => {
+    await indexedDB.clearAddressBook();
+    await indexedDB.insertAddress(adaHandle1);
+    await indexedDB.insertAddress(adaHandle2);
+    await browser.pause(500);
+    if (mode === 'popup') {
+      await popupView.visitAddressBook();
+      await AddressBookPageAssert.assertSeeAddressBookTitle();
+    } else {
+      await extendedView.visitAddressBook();
+    }
+  }
+);
 
 Given(/^I open address book in (popup|extended) mode$/, async (mode: 'popup' | 'extended') => {
   if (mode === 'popup') {
@@ -92,9 +117,10 @@ Then(/^I see empty address book$/, async () => {
 });
 
 Then(
-  /^I (see|do not see) address detail page in (extended|popup) mode$/,
-  async (shouldSee: 'see' | 'do not see', mode: 'extended' | 'popup') => {
-    await AddressDetailsAssert.assertSeeAddressDetailsPage(shouldSee === 'see', mode);
+  /^I (see|do not see) address detail page in (extended|popup) mode with details of "([^"]*)" address$/,
+  async (shouldSee: 'see' | 'do not see', mode: 'extended' | 'popup', addressName: string) => {
+    const addressDetails = getAddressDetailsByName(addressName) as Address;
+    await AddressDetailsAssert.assertSeeAddressDetailsPage(shouldSee === 'see', mode, addressDetails);
   }
 );
 
@@ -171,9 +197,13 @@ When(
   }
 );
 
-Then(/^I see "Edit address" drawer in (extended|popup) mode$/, async (mode: 'extended' | 'popup') => {
-  await EditAddressDrawerAssert.assertSeeEditAddressDrawer(mode);
-});
+Then(
+  /^I see "Edit address" drawer in (extended|popup) mode with details of "([^"]*)" address$/,
+  async (mode: 'extended' | 'popup', addressName: string) => {
+    const addressDetails = getAddressDetailsByName(addressName) as Address;
+    await EditAddressDrawerAssert.assertSeeEditAddressDrawer(mode, addressDetails);
+  }
+);
 
 When(/^I click "(Cancel|Done)" button on "Edit address" drawer$/, async (button: 'Cancel' | 'Done') => {
   switch (button) {


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1512/5888089553/index.html) for [2a16acf5](https://github.com/input-output-hk/lace/pull/393/commits/2a16acf58ec50f277635a25df9cd4f84f5d8ffb2)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 4      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->