### PR TITLE
feat(extension): add custom properties for send flow last step

### DIFF
--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.ts
@@ -1,4 +1,10 @@
-import { EnhancedAnalyticsOptInStatus, ExtensionViews, MatomoSendEventProps, PostHogAction } from './types';
+import {
+  EnhancedAnalyticsOptInStatus,
+  ExtensionViews,
+  MatomoSendEventProps,
+  PostHogAction,
+  PostHogProperties
+} from './types';
 import { Wallet } from '@lace/cardano';
 import { MatomoClient } from '../matomo';
 import { POSTHOG_ENABLED, PostHogClient } from '../postHog';
@@ -50,7 +56,7 @@ export class AnalyticsTracker {
     await this.userIdService?.extendLifespan();
   }
 
-  async sendEventToPostHog(action: PostHogAction, properties: Record<string, string | boolean> = {}): Promise<void> {
+  async sendEventToPostHog(action: PostHogAction, properties: PostHogProperties = {}): Promise<void> {
     await this.postHogClient?.sendEvent(action, properties);
     await this.userIdService?.extendLifespan();
   }

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -139,3 +139,7 @@ export type PostHogMetadata = {
   view: ExtensionViews;
   sent_at_local: string;
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PostHogProperty = string | boolean | Record<string, any> | Array<Record<string, any>>;
+export type PostHogProperties = Record<string, PostHogProperty>;

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -2,7 +2,7 @@
 import posthog from 'posthog-js';
 import dayjs from 'dayjs';
 import { Wallet } from '@lace/cardano';
-import { ExtensionViews, PostHogAction, PostHogMetadata } from '../analyticsTracker';
+import { ExtensionViews, PostHogAction, PostHogMetadata, PostHogProperties } from '../analyticsTracker';
 import {
   DEV_NETWORK_ID_TO_POSTHOG_TOKEN_MAP,
   PRODUCTION_NETWORK_ID_TO_POSTHOG_TOKEN_MAP,
@@ -59,7 +59,7 @@ export class PostHogClient {
     posthog.alias(alias, id);
   }
 
-  async sendEvent(action: PostHogAction, properties: Record<string, string | boolean> = {}): Promise<void> {
+  async sendEvent(action: PostHogAction, properties: PostHogProperties = {}): Promise<void> {
     const payload = {
       ...(await this.getEventMetadata()),
       ...properties

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/__tests__/helpers.test.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/__tests__/helpers.test.ts
@@ -2,9 +2,12 @@
 import {
   clearTemporaryTxDataFromStorage,
   getTemporaryTxDataFromStorage,
-  saveTemporaryTxDataInStorage
+  saveTemporaryTxDataInStorage,
+  getTokensProperty
 } from '../helpers';
-import { TemporaryTransactionDataKeys } from '../types';
+import { TemporaryTransactionDataKeys, OutputList } from '../types';
+import { Wallet } from '@lace/cardano';
+import { mockAssetMetadata as mockAssetBasicMetadata } from '@src/utils/mocks/test-helpers';
 
 describe('send-transaction helpers', () => {
   let localStorageSetSpy: jest.SpyInstance;
@@ -96,6 +99,200 @@ describe('send-transaction helpers', () => {
       expect(localStorageRemoveSpy).toHaveBeenCalledWith(TemporaryTransactionDataKeys.TEMP_ADDRESS);
       expect(localStorageRemoveSpy).toHaveBeenCalledWith(TemporaryTransactionDataKeys.TEMP_OUTPUTS);
       expect(localStorageRemoveSpy).not.toHaveBeenCalledWith(TemporaryTransactionDataKeys.TEMP_SOURCE);
+    });
+  });
+
+  describe('getTokensProperty', () => {
+    const cardanoCoinMock = {
+      id: '1',
+      symbol: 'ADA',
+      name: 'Cardano',
+      decimals: 6
+    };
+
+    const nftMetadata: Wallet.Asset.NftMetadata = {
+      name: 'test-nft',
+      version: '1',
+      image: Wallet.Asset.Uri('ipfs://c8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe')
+    };
+    const tokenMetadata: Wallet.Asset.TokenMetadata = {
+      assetId: Wallet.Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'),
+      name: 'Test-token',
+      ticker: 'TTOKEN'
+    };
+    const mockNFTMetadata: Wallet.Asset.AssetInfo = {
+      ...mockAssetBasicMetadata,
+      supply: BigInt('1'),
+      nftMetadata,
+      fingerprint: Wallet.Cardano.AssetFingerprint('asset1cvmyrfrc7lpht2hcjwr9lulzyyjv27uxh3kcz0'),
+      assetId: Wallet.Cardano.AssetId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a76e7574636f696e')
+    };
+    const mockTokenMetadata: Wallet.Asset.AssetInfo = { ...mockAssetBasicMetadata, tokenMetadata };
+
+    const assetsInfo = new Map([
+      [Wallet.Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'), mockTokenMetadata],
+      [
+        Wallet.Cardano.AssetId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a76e7574636f696e'),
+        mockNFTMetadata
+      ]
+    ]);
+
+    test('one output transaction with cardano coin, should return an array of length 1', () => {
+      const outputs: OutputList = {
+        '1': {
+          address: ' addr_test...',
+          assets: [
+            {
+              id: cardanoCoinMock.id,
+              value: '100'
+            }
+          ]
+        }
+      };
+
+      const result = getTokensProperty(outputs, assetsInfo, cardanoCoinMock);
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: cardanoCoinMock.id,
+            name: cardanoCoinMock.name,
+            ticker: cardanoCoinMock.symbol,
+            amount: outputs['1'].assets[0].value
+          })
+        ])
+      );
+    });
+
+    test('one output transaction with cardano coin, NFT and token should return an array of length 3', () => {
+      const outputs: OutputList = {
+        '1': {
+          address: ' addr_test...',
+          assets: [
+            {
+              id: cardanoCoinMock.id,
+              value: '100'
+            },
+            {
+              id: mockTokenMetadata.assetId.toString(),
+              value: '500'
+            },
+            {
+              id: mockNFTMetadata.assetId.toString(),
+              value: '1'
+            }
+          ]
+        }
+      };
+
+      const result = getTokensProperty(outputs, assetsInfo, cardanoCoinMock);
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: cardanoCoinMock.id,
+            name: cardanoCoinMock.name,
+            ticker: cardanoCoinMock.symbol,
+            amount: outputs['1'].assets[0].value
+          }),
+          expect.objectContaining({
+            id: mockTokenMetadata.fingerprint.toString(),
+            name: mockTokenMetadata.tokenMetadata.name,
+            ticker: mockTokenMetadata.tokenMetadata.ticker,
+            amount: outputs['1'].assets[1].value
+          }),
+          expect.objectContaining({
+            id: mockNFTMetadata.fingerprint.toString(),
+            name: mockNFTMetadata.nftMetadata.name,
+            amount: outputs['1'].assets[2].value,
+            ticker: undefined
+          })
+        ])
+      );
+    });
+
+    test('two output transaction with cardano coin and same token in each output should return an array of length 2 that sums the amount of each repeated asset', () => {
+      const outputs: OutputList = {
+        '1': {
+          address: ' addr_test...',
+          assets: [
+            {
+              id: cardanoCoinMock.id,
+              value: '100'
+            },
+            {
+              id: mockTokenMetadata.assetId.toString(),
+              value: '500'
+            }
+          ]
+        },
+        '2': {
+          address: ' addr_test...',
+          assets: [
+            {
+              id: cardanoCoinMock.id,
+              value: '100'
+            },
+            {
+              id: mockTokenMetadata.assetId.toString(),
+              value: '500'
+            }
+          ]
+        }
+      };
+
+      const result = getTokensProperty(outputs, assetsInfo, cardanoCoinMock);
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: cardanoCoinMock.id,
+            name: cardanoCoinMock.name,
+            ticker: cardanoCoinMock.symbol,
+            amount: (Number(outputs['1'].assets[0].value) + Number(outputs['2'].assets[0].value)).toString()
+          }),
+          expect.objectContaining({
+            id: mockTokenMetadata.fingerprint.toString(),
+            name: mockTokenMetadata.tokenMetadata.name,
+            ticker: mockTokenMetadata.tokenMetadata.ticker,
+            amount: (Number(outputs['1'].assets[1].value) + Number(outputs['2'].assets[1].value)).toString()
+          })
+        ])
+      );
+    });
+
+    test('if the token has no metadata should return ticker and name undefined', () => {
+      const outputs: OutputList = {
+        '1': {
+          address: ' addr_test...',
+          assets: [
+            {
+              id: mockTokenMetadata.assetId.toString(),
+              value: '500'
+            }
+          ]
+        }
+      };
+
+      const info = new Map([
+        [
+          Wallet.Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'),
+          { ...mockTokenMetadata, tokenMetadata: undefined }
+        ]
+      ]);
+
+      const result = getTokensProperty(outputs, info, cardanoCoinMock);
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: mockTokenMetadata.fingerprint.toString(),
+            name: undefined,
+            ticker: undefined,
+            amount: outputs['1'].assets[0].value
+          })
+        ])
+      );
     });
   });
 });

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
@@ -7,65 +7,14 @@ import {
   useBuiltTxState,
   useAnalyticsSendFlowTriggerPoint,
   useOutputs,
-  OutputList
+  TokenAnalyticsProperties
 } from '@views/browser/features/send-transaction';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './TransactionSuccessView.module.scss';
 import { useWalletStore } from '@src/stores';
 import { useObservable } from '@lace/common';
-import BigNumber from 'bignumber.js';
-import { Wallet } from '@lace/cardano';
-import { isNFT } from '@src/utils/is-nft';
-import flatMapDeep from 'lodash/flatMapDeep';
-
-interface TokenAnalyticsProperties {
-  id: string;
-  name?: string;
-  ticker?: string;
-  amount: string;
-}
-
-const getCardanoCoinAnalyticsProperties = (cardanoCoin: Wallet.CoinId, amount: string) => ({
-  id: cardanoCoin.id,
-  name: cardanoCoin.name,
-  ticker: cardanoCoin.symbol,
-  amount
-});
-
-const getAssetAnalyticsProperties = (assetsMap: Wallet.Assets, id: string, amount: string) => {
-  const info = assetsMap.get(Wallet.Cardano.AssetId(id));
-  const name = isNFT(info) ? info?.nftMetadata?.name : info?.tokenMetadata?.name;
-  const ticker = info?.tokenMetadata?.ticker;
-  return { id: info?.fingerprint, amount, name, ticker };
-};
-
-const getTokensProperty = (outputs: OutputList, assetsMap: Wallet.Assets, cardanoCoin: Wallet.CoinId) => {
-  const tokensAnalyticsPropertyMap = new Map<string, TokenAnalyticsProperties>();
-  // gets an array of assets sent in each tx output
-  const sentAssets = Object.values(outputs).map(({ assets }) => assets);
-  // flat the array
-  const flattedSentAssets = flatMapDeep(sentAssets);
-
-  for (const { id: key, value } of flattedSentAssets) {
-    const tokensAnalyticsProperty = tokensAnalyticsPropertyMap.get(key);
-
-    if (tokensAnalyticsProperty) {
-      // if the token exists in the property map, add the amount to the current amount in the map
-      const amount = new BigNumber(tokensAnalyticsProperty.amount).plus(value).toString();
-      tokensAnalyticsPropertyMap.set(key, { ...tokensAnalyticsProperty, amount });
-    } else {
-      // if the token don't exists in the property map, get the properties
-      const properties =
-        key === cardanoCoin.id
-          ? getCardanoCoinAnalyticsProperties(cardanoCoin, value)
-          : getAssetAnalyticsProperties(assetsMap, key, value);
-
-      tokensAnalyticsPropertyMap.set(key, properties);
-    }
-  }
-  return [...tokensAnalyticsPropertyMap.values()];
-};
+import { getTokensProperty } from '../helpers';
 
 export const TransactionSuccessView = ({ footerSlot }: { footerSlot?: React.ReactElement }): React.ReactElement => {
   const { t } = useTranslation();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
@@ -1,23 +1,103 @@
+/* eslint-disable no-lonely-if */
 import { ResultMessage } from '@components/ResultMessage';
 import { TransactionHashBox } from '@components/TransactionHashBox';
 import { useAnalyticsContext } from '@providers';
 import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
-import { useBuiltTxState, useAnalyticsSendFlowTriggerPoint } from '@views/browser/features/send-transaction';
-import React, { useEffect } from 'react';
+import {
+  useBuiltTxState,
+  useAnalyticsSendFlowTriggerPoint,
+  useOutputs,
+  OutputList
+} from '@views/browser/features/send-transaction';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './TransactionSuccessView.module.scss';
+import { useWalletStore } from '@src/stores';
+import { useObservable } from '@lace/common';
+import BigNumber from 'bignumber.js';
+import { Wallet } from '@lace/cardano';
+import { isNFT } from '@src/utils/is-nft';
+import flatMapDeep from 'lodash/flatMapDeep';
+
+interface TokenAnalyticsProperties {
+  id: string;
+  name?: string;
+  ticker?: string;
+  amount: string;
+}
+
+const getCardanoCoinAnalyticsProperties = (cardanoCoin: Wallet.CoinId, amount: string) => ({
+  id: cardanoCoin.id,
+  name: cardanoCoin.name,
+  ticker: cardanoCoin.symbol,
+  amount
+});
+
+const getAssetAnalyticsProperties = (assetsMap: Wallet.Assets, id: string, amount: string) => {
+  const info = assetsMap.get(Wallet.Cardano.AssetId(id));
+  const name = isNFT(info) ? info?.nftMetadata?.name : info?.tokenMetadata?.name;
+  const ticker = info?.tokenMetadata?.ticker;
+  return { id: info?.fingerprint, amount, name, ticker };
+};
+
+const getTokensProperty = (outputs: OutputList, assetsMap: Wallet.Assets, cardanoCoin: Wallet.CoinId) => {
+  const tokensAnalyticsPropertyMap = new Map<string, TokenAnalyticsProperties>();
+  // gets an array of assets sent in each tx output
+  const sentAssets = Object.values(outputs).map(({ assets }) => assets);
+  // flat the array
+  const flattedSentAssets = flatMapDeep(sentAssets);
+
+  for (const { id: key, value } of flattedSentAssets) {
+    const tokensAnalyticsProperty = tokensAnalyticsPropertyMap.get(key);
+
+    if (tokensAnalyticsProperty) {
+      // if the token exists in the property map, add the amount to the current amount in the map
+      const amount = new BigNumber(tokensAnalyticsProperty.amount).plus(value).toString();
+      tokensAnalyticsPropertyMap.set(key, { ...tokensAnalyticsProperty, amount });
+    } else {
+      // if the token don't exists in the property map, get the properties
+      const properties =
+        key === cardanoCoin.id
+          ? getCardanoCoinAnalyticsProperties(cardanoCoin, value)
+          : getAssetAnalyticsProperties(assetsMap, key, value);
+
+      tokensAnalyticsPropertyMap.set(key, properties);
+    }
+  }
+  return [...tokensAnalyticsPropertyMap.values()];
+};
 
 export const TransactionSuccessView = ({ footerSlot }: { footerSlot?: React.ReactElement }): React.ReactElement => {
   const { t } = useTranslation();
   const { builtTxData: { uiTx: { hash } = {} } = {} } = useBuiltTxState();
+  const { uiOutputs } = useOutputs();
   const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
   const analytics = useAnalyticsContext();
+  const {
+    inMemoryWallet,
+    walletUI: { cardanoCoin }
+  } = useWalletStore();
+  const assets = useObservable(inMemoryWallet.assetInfo$);
+  const [customAnalyticsProperties, setCustomAnalyticsProperties] = useState<TokenAnalyticsProperties[]>();
 
   useEffect(() => {
-    // eslint-disable-next-line camelcase
-    analytics.sendEventToPostHog(PostHogAction.SendAllDoneView, { trigger_point: triggerPoint });
+    // run this only when assets value was emitted and customAnalyticsProperties is undefined
+    if (assets && !customAnalyticsProperties) {
+      setCustomAnalyticsProperties(getTokensProperty(uiOutputs, assets, cardanoCoin));
+    }
+  }, [assets, cardanoCoin, customAnalyticsProperties, uiOutputs]);
+
+  useEffect(() => {
+    // send analytics event after customAnalyticsProperties was set
+    if (customAnalyticsProperties) {
+      analytics.sendEventToPostHog(PostHogAction.SendAllDoneView, {
+        // eslint-disable-next-line camelcase
+        trigger_point: triggerPoint,
+        tokens: customAnalyticsProperties
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [customAnalyticsProperties]);
 
   return (
     <>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
@@ -83,3 +83,10 @@ export type SendFlowAnalyticsProperties = {
   trigger_point: SendFlowTriggerPoints;
   // TODO: add rest of the porpeties (LW-7711)
 };
+
+export interface TokenAnalyticsProperties {
+  id: string;
+  name?: string;
+  ticker?: string;
+  amount: string;
+}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/__tests__/CollateralDrawer.test.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/__tests__/CollateralDrawer.test.tsx
@@ -17,6 +17,7 @@ const setSection = jest.fn();
 const mockUseRedirection = jest.fn();
 const mockNotify = jest.fn();
 const mockUseAnalyticsSendFlowTriggerPoint = jest.fn();
+const mockUseOutputs = jest.fn();
 import * as React from 'react';
 import { screen, cleanup, fireEvent, render, within, waitFor } from '@testing-library/react';
 import { CollateralDrawer } from '../CollateralDrawer';
@@ -53,6 +54,7 @@ const txHash = 'e6eb1c8c806ae7f4d9fe148e9c23853607ffba692ef0a464688911ad3374a932
 
 const tokenPrices$ = new BehaviorSubject({});
 const adaPrices$ = new BehaviorSubject({});
+const assetInfo$ = new BehaviorSubject({});
 
 const backgroundService = {
   getBackgroundStorage: mockGetBackgroundStorage,
@@ -76,7 +78,8 @@ jest.mock('@src/views/browser-view/features/send-transaction', () => {
     __esModule: true,
     ...original,
     useBuiltTxState: mockUseBuitTxState,
-    useAnalyticsSendFlowTriggerPoint: mockUseAnalyticsSendFlowTriggerPoint
+    useAnalyticsSendFlowTriggerPoint: mockUseAnalyticsSendFlowTriggerPoint,
+    useOutputs: mockUseOutputs
   };
 });
 
@@ -159,11 +162,15 @@ describe('Testing CollateralDrawer component', () => {
       builtTxData: {} as unknown as sendTx.BuiltTxData
     });
     mockUseAnalyticsSendFlowTriggerPoint.mockReturnValue({ triggerPoint: '', setTriggerPoint: jest.fn() });
+    mockUseOutputs.mockReturnValue({ uiOutputs: {} });
     mockUseCollateral.mockReturnValue(useCollateral);
     mockGetKeyAgentType.mockReturnValue(Wallet.KeyManagement.KeyAgentType.InMemory);
     mockUseWalletStore.mockImplementation(() => ({
       getKeyAgentType: mockGetKeyAgentType,
-      walletUI: {}
+      walletUI: {},
+      inMemoryWallet: {
+        assetInfo$
+      }
     }));
     mockUseSections.mockReturnValue({
       setSection,


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-7747](https://input-output.atlassian.net/browse/LW-7747)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR implements tokens custom property for send flow, where the property has an array of all tokens sent by the user.

The field of each token are:

- Id/Fingerprint
- amount
- Ticker
- Name

## Testing

Follow the send flow until you reach the success step, a `send | all done | view event` should be on post hog Event Explorer section with the property tokens



[LW-7747]: https://input-output.atlassian.net/browse/LW-7747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1478/5866748675/index.html) for [432e8a92](https://github.com/input-output-hk/lace/pull/394/commits/432e8a92c048bfaab9cf952c7b3be5913a95b059)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->