### PR TITLE
fix(staking): fix incorrect stake distribution display

### DIFF
--- a/packages/staking/src/features/store/delegationPortfolio.ts
+++ b/packages/staking/src/features/store/delegationPortfolio.ts
@@ -30,10 +30,12 @@ export const useDelegationPortfolioStore = create<DelegationPortfolioStore>((set
       if (!rewardAccountInfo || rewardAccountInfo.length === 0) return;
 
       const delegatees = rewardAccountInfo
+        .filter((r) => r.keyStatus === Wallet.Cardano.StakeKeyStatus.Registered)
         .map((r) => r.delegatee)
-        .filter((item): item is Wallet.Cardano.Delegatee => !!item);
+        .filter((item): item is Wallet.Cardano.Delegatee => !!item && !!item.nextNextEpoch);
+
       const stakePools = delegatees
-        .map(({ currentEpoch, nextEpoch, nextNextEpoch }) => nextNextEpoch || nextEpoch || currentEpoch)
+        .map(({ nextNextEpoch }) => nextNextEpoch)
         .filter((item): item is Wallet.Cardano.StakePool => !!item);
 
       const currentPortfolio = stakePools.map((stakePool) => ({


### PR DESCRIPTION
# Checklist

- [ x] JIRA - \<link>
---

Currently Lace is determining the user portfolio incorrectly which causes unexpected pools to be display on the stake expanded view.

## Proposed solution

Fix the way the portfolio is created from the information available in the reward account info.

## Testing



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1506/5886893098/index.html) for [f1bf4a84](https://github.com/input-output-hk/lace/pull/404/commits/f1bf4a8451cb7db8d74d351401eed13aaaac9f6c)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 17     | 18     | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->