### PR TITLE
test(extension): add token count check to popup tx history

### DIFF
--- a/packages/e2e-tests/src/assert/transactionsPageAssert.ts
+++ b/packages/e2e-tests/src/assert/transactionsPageAssert.ts
@@ -4,6 +4,7 @@ import { t } from '../utils/translationService';
 import testContext from '../utils/testContext';
 import { expect } from 'chai';
 import { browser } from '@wdio/globals';
+import { isPopupMode } from '../utils/pageUtils';
 
 export type ExpectedTransactionRowAssetDetails = {
   type: string;
@@ -135,6 +136,17 @@ class TransactionsPageAssert {
     expect(await TransactionsPage.transactionsTableItemTimestamp(rowIndex).getText()).to.match(
       TestnetPatterns.TIMESTAMP_REGEX
     );
+
+    if ((await isPopupMode()) && expectedTransactionRowAssetDetails.tokensCount > 1) {
+      const actualTokensCount = await TransactionsPage.transactionsTableItemTokensAmount(rowIndex)
+        .getText()
+        .then((val) => val.split('+')[1]);
+      const expectedTokensCount = expectedTransactionRowAssetDetails.tokensCount - 1;
+      expect(Number(actualTokensCount)).to.equal(
+        expectedTokensCount,
+        `Tokens count actual/expected: ${actualTokensCount}/${expectedTokensCount.toString()}`
+      );
+    }
   }
 
   assertSeeMoreTransactions = async () => {

--- a/packages/e2e-tests/src/assert/transactionsPageAssert.ts
+++ b/packages/e2e-tests/src/assert/transactionsPageAssert.ts
@@ -142,10 +142,7 @@ class TransactionsPageAssert {
         .getText()
         .then((val) => val.split('+')[1]);
       const expectedTokensCount = expectedTransactionRowAssetDetails.tokensCount - 1;
-      expect(Number(actualTokensCount)).to.equal(
-        expectedTokensCount,
-        `Tokens count actual/expected: ${actualTokensCount}/${expectedTokensCount.toString()}`
-      );
+      expect(Number(actualTokensCount)).to.equal(expectedTokensCount);
     }
   }
 


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution
Add checking for additional tokens number in popup when sending more than just ADA.


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1531/5892477401/index.html) for [d4534f5c](https://github.com/input-output-hk/lace/pull/410/commits/d4534f5cdbbb8d74d9b2828d68a276ab3318fafd)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->