### PR TITLE
chore(all): revert the replacement of wsrun with yarn3 workspaces command

### DIFF
--- a/.github/shared/build/action.yml
+++ b/.github/shared/build/action.yml
@@ -26,4 +26,4 @@ runs:
       shell: bash
       env:
         LACE_EXTENSION_KEY: ${{ inputs.LACE_EXTENSION_KEY }}
-      run: yarn build
+      run: yarn browser build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY  }}
         run: |
           eval "set -x ; $(cat apps/browser-extension-wallet/.env.* | grep ^USE_ | sed -r 's/false/true/' | sort --unique | sed -r 's/^/export /' | tr '\n' ';') set +x"
-          yarn build
+          yarn browser build
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "packages/ui"
   ],
   "scripts": {
-    "base-command-for-build-scripts": "yarn workspaces foreach -ptvi --topological-dev --exclude lace ${APP_NAME:+--include \"@lace/$APP_NAME\"} ${EXCLUDE_APP:+--exclude \"@lace/$APP_NAME\"} ${EXCLUDE_BROWSER:+--exclude \"@lace/browser-extension-wallet\"}",
+    "base-command-for-build-scripts": "wsrun --prefix -tram ${APP_NAME:+-p \"@lace/$APP_NAME\"} ${EXCLUDE_APP:+-x \"@lace/$APP_NAME\"} ${EXCLUDE_BROWSER:+-x \"@lace/browser-extension-wallet\"}",
     "browser": "APP_NAME=browser-extension-wallet yarn $0",
     "build": "yarn base-command-for-build-scripts run build",
     "build-all": "yarn workspaces foreach -ptv --topological-dev --exclude 'lace' run build",
@@ -205,7 +205,8 @@
     "webpack-cli": "4.7.2",
     "webpack-dev-server": "^4.9.3",
     "webpack-merge": "5.8.0",
-    "webpack-subresource-integrity": "^5.1.0"
+    "webpack-subresource-integrity": "^5.1.0",
+    "wsrun": "^5.2.4"
   },
   "packageManager": "yarn@3.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -26,9 +26,8 @@
   "scripts": {
     "base-command-for-build-scripts": "wsrun --prefix -tram ${APP_NAME:+-p \"@lace/$APP_NAME\"} ${EXCLUDE_APP:+-x \"@lace/$APP_NAME\"} ${EXCLUDE_BROWSER:+-x \"@lace/browser-extension-wallet\"}",
     "browser": "APP_NAME=browser-extension-wallet yarn $0",
-    "build": "yarn base-command-for-build-scripts run build",
-    "build-all": "yarn workspaces foreach -ptv --topological-dev --exclude 'lace' run build",
-    "build-deps": "yarn workspaces foreach -ptvi --include '{@lace/common,@lace/core,@lace/cardano,@lace/ui,@lace/staking}' ${APP_NAME:+--exclude \"@lace/$APP_NAME\"} run build",
+    "build": "yarn base-command-for-build-scripts -c build",
+    "build-deps": "EXCLUDE_APP=true yarn build",
     "cardano:lint": "yarn eslint-cmd \"packages/cardano/**/*.{js,ts,tsx}\"",
     "chromatic": "ENV=development yarn build-storybook; chromatic --exit-zero-on-changes --project-token=e28776c940b9 -d storybook-static/",
     "cleanup": "yarn workspaces foreach run cleanup && yarn exec rm -rf node_modules storybook-static && rm -rf .cache/eslintcache",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7776,6 +7776,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/types@npm:^24.9.0":
+  version: 24.9.0
+  resolution: "@jest/types@npm:24.9.0"
+  dependencies:
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^1.1.1
+    "@types/yargs": ^13.0.0
+  checksum: 603698f774cf22f9d16a0e0fac9e10e7db21052aebfa33db154c8a5940e0eb1fa9c079a8c91681041ad3aeee2adfa950608dd0c663130316ba034b8bca7b301c
+  languageName: node
+  linkType: hard
+
 "@jest/types@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/types@npm:26.6.2"
@@ -14514,6 +14525,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/istanbul-reports@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "@types/istanbul-reports@npm:1.1.2"
+  dependencies:
+    "@types/istanbul-lib-coverage": "*"
+    "@types/istanbul-lib-report": "*"
+  checksum: 00866e815d1e68d0a590d691506937b79d8d65ad8eab5ed34dbfee66136c7c0f4ea65327d32046d5fe469f22abea2b294987591dc66365ebc3991f7e413b2d78
+  languageName: node
+  linkType: hard
+
 "@types/istanbul-reports@npm:^3.0.0":
   version: 3.0.1
   resolution: "@types/istanbul-reports@npm:3.0.1"
@@ -15260,6 +15281,15 @@ __metadata:
   version: 20.2.1
   resolution: "@types/yargs-parser@npm:20.2.1"
   checksum: 1d039e64494a7a61ddd278349a3dc60b19f99ff0517425696e796f794e4252452b9d62178e69755ad03f439f9dc0c8c3d7b3a1201b3a24e134bac1a09fa11eaa
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^13.0.0":
+  version: 13.0.12
+  resolution: "@types/yargs@npm:13.0.12"
+  dependencies:
+    "@types/yargs-parser": "*"
+  checksum: 4eb34d8c071892299646e5a3fb02a643f5a5ea8da8f4d1817001882ebbcfa4fbda235b8978732f8eb55fa16433296e2087907fe69678a69125f0dca627a91426
   languageName: node
   linkType: hard
 
@@ -18843,7 +18873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bluebird@npm:^3.3.5, bluebird@npm:^3.5.5":
+"bluebird@npm:^3.3.5, bluebird@npm:^3.5.1, bluebird@npm:^3.5.5":
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
   checksum: 869417503c722e7dc54ca46715f70e15f4d9c602a423a02c825570862d12935be59ed9c7ba34a9b31f186c017c23cac6b54e35446f8353059c101da73eac22ef
@@ -19944,7 +19974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.0.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
+"chalk@npm:^2.0.0, chalk@npm:^2.3.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -29927,6 +29957,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-changed-files@npm:^24.9.0":
+  version: 24.9.0
+  resolution: "jest-changed-files@npm:24.9.0"
+  dependencies:
+    "@jest/types": ^24.9.0
+    execa: ^1.0.0
+    throat: ^4.0.0
+  checksum: f40e901e6ac2e6f47730b610c3dbef44a9235d556ba53b23926d45e6334c1c5989fd255140753d3270d5e63371ae69084e0867c11b8322030edab51e1ff1b8b7
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-changed-files@npm:28.1.3"
@@ -31545,6 +31586,7 @@ __metadata:
     webpack-dev-server: ^4.9.3
     webpack-merge: 5.8.0
     webpack-subresource-integrity: ^5.1.0
+    wsrun: ^5.2.4
   languageName: unknown
   linkType: soft
 
@@ -42497,7 +42539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"split@npm:^1.0.0":
+"split@npm:^1.0.0, split@npm:^1.0.1":
   version: 1.0.1
   resolution: "split@npm:1.0.1"
   dependencies:
@@ -44059,6 +44101,13 @@ __metadata:
   version: 0.12.7
   resolution: "third-party-web@npm:0.12.7"
   checksum: 65af50cab714c84cf3c0bcb4a60e091f9d27b4f4ce93963229ac16b225390b63e311d608819da07df711a3220aa71a98807743f8ede0ee68ffa4d66fd8978d4f
+  languageName: node
+  linkType: hard
+
+"throat@npm:^4.0.0, throat@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "throat@npm:4.1.0"
+  checksum: 43519b0cea6d3b2a8fe056fcbc319e289037be67d2204d4d33513d20d6ee9da6255f7ba8c89e2ec8c97b0f188a910b8666def38d1058d2bf4a39613812c36d98
   languageName: node
   linkType: hard
 
@@ -47727,6 +47776,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wsrun@npm:^5.2.4":
+  version: 5.2.4
+  resolution: "wsrun@npm:5.2.4"
+  dependencies:
+    bluebird: ^3.5.1
+    chalk: ^2.3.0
+    glob: ^7.1.2
+    jest-changed-files: ^24.9.0
+    lodash: ^4.17.4
+    minimatch: ^3.0.4
+    split: ^1.0.1
+    throat: ^4.1.0
+    yargs: ^13.0.0
+  bin:
+    wsrun: bin/wsrun.js
+  checksum: b89cb436c3463e7bd3020cb00f29ae3448f5cf26ad6a0eaaff4733020ae9b1b9080eb85dca86baf2eab6d975a638ab44265f84477621443091af4c27c4b11b19
+  languageName: node
+  linkType: hard
+
 "x-default-browser@npm:^0.4.0":
   version: 0.4.0
   resolution: "x-default-browser@npm:0.4.0"
@@ -47825,6 +47893,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^13.1.2":
+  version: 13.1.2
+  resolution: "yargs-parser@npm:13.1.2"
+  dependencies:
+    camelcase: ^5.0.0
+    decamelize: ^1.2.0
+  checksum: c8bb6f44d39a4acd94462e96d4e85469df865de6f4326e0ab1ac23ae4a835e5dd2ddfe588317ebf80c3a7e37e741bd5cb0dc8d92bcc5812baefb7df7c885e86b
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^15.0.1":
   version: 15.0.3
   resolution: "yargs-parser@npm:15.0.3"
@@ -47908,6 +47986,24 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
   checksum: 3d8a43c336a4942bc68080768664aca85c7bd406f018bad362fd255c41c8f4e650277f42fd65d543fce99e084124ddafee7bbfc1a5c6a8fda4cec78609dcf8d4
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^13.0.0":
+  version: 13.3.2
+  resolution: "yargs@npm:13.3.2"
+  dependencies:
+    cliui: ^5.0.0
+    find-up: ^3.0.0
+    get-caller-file: ^2.0.1
+    require-directory: ^2.1.1
+    require-main-filename: ^2.0.0
+    set-blocking: ^2.0.0
+    string-width: ^3.0.0
+    which-module: ^2.0.0
+    y18n: ^4.0.0
+    yargs-parser: ^13.1.2
+  checksum: 75c13e837eb2bb25717957ba58d277e864efc0cca7f945c98bdf6477e6ec2f9be6afa9ed8a876b251a21423500c148d7b91e88dee7adea6029bdec97af1ef3e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8088

---

## Proposed solution

Revert part of #159 in order to fix the development experience with `yarn watch` command.

## Testing

Not required.


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1561/5925201288/index.html) for [079e63a1](https://github.com/input-output-hk/lace/pull/421/commits/079e63a1e8fb5e406b59b26935dc0b755888b3b8)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->