### PR TITLE
chore(all): fix yarn 3 upgrade issue in CI

### DIFF
--- a/.github/shared/build/action.yml
+++ b/.github/shared/build/action.yml
@@ -21,7 +21,7 @@ runs:
         key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
     - name: Install dependencies
       shell: bash
-      run: yarn install --immutable --inline-builds
+      run: yarn install --immutable --immutable-cache --inline-builds --mode=skip-build
     - name: Build dist version
       shell: bash
       env:

--- a/.github/workflows/packages-staking.yml
+++ b/.github/workflows/packages-staking.yml
@@ -37,7 +37,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
-        run: yarn install --immutable --inline-builds
+        run: yarn install --immutable --inline-builds --mode=skip-build
       - name: Check for linter issues
         run: yarn workspace @lace/staking lint
       - name: Build dependencies of Staking Center

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -22,20 +22,6 @@ jobs:
         run: ./decrypt_secret.sh
         env:
           WALLET_1_PASSWORD: ${{ secrets.WALLET_PASSWORD_TESTNET }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - name: Node modules cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-      - name: Install dependencies
-        run: yarn install --check-cache --immutable
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:


### PR DESCRIPTION
# Checklist

- [x] JIRA - https://input-output.atlassian.net/browse/LW-8078
- [x] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

With the upgrade to yarn 3 last week, there was a new issue in the CI builds where the error was `error: Error: EEXIST: file already exists, mkdir '/home/runner/work/lace/lace/node_modules/odiff-bin/3'`
This happened because yarn3's install with the immutable flag is more strict, and it so happened in our old github actions [we repeated the same steps of yarn install twice](https://github.com/input-output-hk/lace/blob/main/.github/workflows/smoke-tests.yml#L25-L42) and the old yarn repeated the install unnecessarily.  This removes that unnecessary step.


## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1581/5932665300/index.html) for [42cd878e](https://github.com/input-output-hk/lace/pull/425/commits/42cd878eddf0f03e033113c51fb79f4469f7f70c)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->