### PR TITLE
ci(all): remove --immutable-cache flag (yarn3) [LW-8078]

### DIFF
--- a/.github/shared/build/action.yml
+++ b/.github/shared/build/action.yml
@@ -21,7 +21,7 @@ runs:
         key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
     - name: Install dependencies
       shell: bash
-      run: yarn install --immutable --immutable-cache --inline-builds --mode=skip-build
+      run: yarn install --immutable --inline-builds --mode=skip-build
     - name: Build dist version
       shell: bash
       env:


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution
This PR removes the `--immutable-cache` line, which was causing building to fail on the staking GH actions. We don't need this line, because it refers to the caching of the new version of yarn's "plug n play" modules, which we aren't using yet. We are currently still using our own method of caching `node_modules`.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1612/5943546460/index.html) for [0a95ce2f](https://github.com/input-output-hk/lace/pull/431/commits/0a95ce2fb8d2ade98ff29e43e29b03db420718e4)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 33     | 2      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->