### PR TITLE
feat(extension): add posthog_project_id property to events

### DIFF
--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -148,6 +148,7 @@ export type PostHogMetadata = {
   url: string;
   view: ExtensionViews;
   sent_at_local: string;
+  posthog_project_id: number;
 } & PostHogPersonProperties;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -11,7 +11,9 @@ import {
   UserTrackingType
 } from '../analyticsTracker';
 import {
+  DEV_NETWORK_ID_TO_POSTHOG_PROJECT_ID_MAP,
   DEV_NETWORK_ID_TO_POSTHOG_TOKEN_MAP,
+  PRODUCTION_NETWORK_ID_TO_POSTHOG_PROJECT_ID_MAP,
   PRODUCTION_NETWORK_ID_TO_POSTHOG_TOKEN_MAP,
   PRODUCTION_TRACKING_MODE_ENABLED,
   PUBLIC_POSTHOG_HOST
@@ -79,6 +81,7 @@ export class PostHogClient {
 
   setChain(chain: Wallet.Cardano.ChainId): void {
     const token = this.getApiToken(chain);
+    this.chain = chain;
     console.debug('[ANALYTICS] Changing PostHog API token', token);
     posthog.set_config({
       token
@@ -91,12 +94,19 @@ export class PostHogClient {
       : DEV_NETWORK_ID_TO_POSTHOG_TOKEN_MAP[chain.networkMagic];
   }
 
+  protected getProjectID(): number {
+    return PRODUCTION_TRACKING_MODE_ENABLED
+      ? PRODUCTION_NETWORK_ID_TO_POSTHOG_PROJECT_ID_MAP[this.chain.networkMagic]
+      : DEV_NETWORK_ID_TO_POSTHOG_PROJECT_ID_MAP[this.chain.networkMagic];
+  }
+
   protected async getEventMetadata(): Promise<PostHogMetadata> {
     return {
       url: window.location.href,
       view: this.view,
       sent_at_local: dayjs().format(),
       distinct_id: await this.userIdService.getUserId(this.chain.networkMagic),
+      posthog_project_id: this.getProjectID(),
       ...(await this.getPersonProperties())
     };
   }

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -94,7 +94,7 @@ export class PostHogClient {
       : DEV_NETWORK_ID_TO_POSTHOG_TOKEN_MAP[chain.networkMagic];
   }
 
-  protected getProjectID(): number {
+  protected getProjectId(): number {
     return PRODUCTION_TRACKING_MODE_ENABLED
       ? PRODUCTION_NETWORK_ID_TO_POSTHOG_PROJECT_ID_MAP[this.chain.networkMagic]
       : DEV_NETWORK_ID_TO_POSTHOG_PROJECT_ID_MAP[this.chain.networkMagic];
@@ -106,7 +106,7 @@ export class PostHogClient {
       view: this.view,
       sent_at_local: dayjs().format(),
       distinct_id: await this.userIdService.getUserId(this.chain.networkMagic),
-      posthog_project_id: this.getProjectID(),
+      posthog_project_id: this.getProjectId(),
       ...(await this.getPersonProperties())
     };
   }

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/config.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/config.ts
@@ -15,3 +15,15 @@ export const PRODUCTION_NETWORK_ID_TO_POSTHOG_TOKEN_MAP: Record<Wallet.Cardano.N
   [Wallet.Cardano.NetworkMagics.Preprod]: 'phc_5sVVmLJ5x6IuipMBZwjudVk5bQcfcBSMjgEOe5gTOh0',
   [Wallet.Cardano.NetworkMagics.Preview]: 'phc_p7GeKELpQtkValRMvzUXX38TPGhKQYItO7aBRYJfvhW'
 };
+
+export const DEV_NETWORK_ID_TO_POSTHOG_PROJECT_ID_MAP: Record<Wallet.Cardano.NetworkMagic, number> = {
+  [Wallet.Cardano.NetworkMagics.Mainnet]: 6315,
+  [Wallet.Cardano.NetworkMagics.Preprod]: 6316,
+  [Wallet.Cardano.NetworkMagics.Preview]: 4874
+};
+
+export const PRODUCTION_NETWORK_ID_TO_POSTHOG_PROJECT_ID_MAP: Record<Wallet.Cardano.NetworkMagic, number> = {
+  [Wallet.Cardano.NetworkMagics.Mainnet]: 6621,
+  [Wallet.Cardano.NetworkMagics.Preprod]: 6620,
+  [Wallet.Cardano.NetworkMagics.Preview]: 6619
+};


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-8081](https://input-output.atlassian.net/browse/LW-8081)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR implements `posthog_project_id` for all Post Hog event. This property contains the ID of each project

## Testing

Send an event to Post Hog, `posthog_project_id` should be visible in the event property list.
To verify if the project ID is correct, go to the `Project settings` section and look for `Project ID`, this should be the same as the ID in the event.



[LW-8081]: https://input-output.atlassian.net/browse/LW-8081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1732/5999090604/index.html) for [5d13d95e](https://github.com/input-output-hk/lace/pull/432/commits/5d13d95e577a38250775caff05cc030aa5de0958)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->