### PR TITLE
chore(all): remove --mode=skip-build during CI install step

### DIFF
--- a/.github/shared/build/action.yml
+++ b/.github/shared/build/action.yml
@@ -21,7 +21,7 @@ runs:
         key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
     - name: Install dependencies
       shell: bash
-      run: yarn install --immutable --inline-builds --mode=skip-build
+      run: yarn install --immutable --inline-builds
     - name: Build dist version
       shell: bash
       env:

--- a/.github/workflows/packages-staking.yml
+++ b/.github/workflows/packages-staking.yml
@@ -37,7 +37,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
-        run: yarn install --immutable --inline-builds --mode=skip-build
+        run: yarn install --immutable --inline-builds
       - name: Check for linter issues
         run: yarn workspace @lace/staking lint
       - name: Build dependencies of Staking Center


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8131

---

## Proposed solution

Remove `--mode=skip-build` flag from `yarn install` step in CI. Most probably it fails to work due to the `node-gyp` (required by `node-sass`) which builds in postinstall step. This flag was introduced as a fix for `odiff-bin` postinstall build which caused some other problems. Note: `odiff-bin` is a part of the `lost-pixel` package which we used for visual regression in the `staking` package but currently we had to disable it, so it's no longer present in our dependencies.

## Testing

Not required.

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1620/5948909079/index.html) for [15ea1914](https://github.com/input-output-hk/lace/pull/435/commits/15ea19142f21a6cd7fa1eb1aed72aa9bbe5d8a47)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->