### PR TITLE
chore(extension): bump version to 1.4.1 and added new release notes

### DIFF
--- a/apps/browser-extension-wallet/manifest.json
+++ b/apps/browser-extension-wallet/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Lace",
   "description": "One fast, accessible, and secure platform for digital assets, DApps, NFTs, and DeFi.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "manifest_version": 3,
   "key": "$LACE_EXTENSION_KEY",
   "icons": {

--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lace/browser-extension-wallet",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A fully capable wallet packaged as browser extensions for Chrome, Firefox, and Edge",
   "homepage": "https://github.com/input-output-hk/lace/blob/master/apps/browser-extension-wallet/README.md",
   "bugs": {

--- a/apps/browser-extension-wallet/src/release-notes/1_4_1.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_4_1.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+import React from 'react';
+
+const ReleaseNote_1_4_1 = (): React.ReactElement => (
+  <>
+    <p>Introducing Lace 1.4.1 This hotfix version supports the following:</p>
+    <ul style={{ listStyleType: 'disc', margin: 0 }}>
+      <li />
+    </ul>
+    <p>
+      Check out the details in the{' '}
+      <a href="https://www.lace.io/blog/lace-1-4-release" target="_blank">
+        blog
+      </a>
+    </p>
+  </>
+);
+
+export default ReleaseNote_1_4_1;

--- a/apps/browser-extension-wallet/src/release-notes/1_4_1.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_4_1.tsx
@@ -3,9 +3,11 @@ import React from 'react';
 
 const ReleaseNote_1_4_1 = (): React.ReactElement => (
   <>
-    <p>Introducing Lace 1.4.1 This hotfix version supports the following:</p>
+    <p>Introducing Lace 1.4.1 This hotfix version solves the following:</p>
     <ul style={{ listStyleType: 'disc', margin: 0 }}>
-      <li />
+      <li>Bugfix: fixed an issue where wallets with burned assets were displaying all NFTs as duplicates</li>
+      <li>Bugfix: fixed a minor wrong copy when a bookmark item had an outdated handle</li>
+      <li>Bugfix: fixed a minor user interface error when sending funds to a handle</li>
     </ul>
     <p>
       Check out the details in the{' '}


### PR DESCRIPTION
This PR update relevant changes from the release 1.4.1

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1653/5952593701/index.html) for [00e69b4e](https://github.com/input-output-hk/lace/pull/439/commits/00e69b4eb6b770c7ddc4c07dbfd5661d93c973e2)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 33     | 2      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->