### PR TITLE
feat(extension): add flag for disable opted out user tracking

### DIFF
--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -23,6 +23,9 @@ USE_HANDLE_SEND_UPDATE=false
 USE_DATA_CHECK=false
 USE_POSTHOG_ANALYTICS=false
 
+USE_POSTHOG_ANALYTICS_FOR_OPTED_OUT=false
+USE_MATOMO_ANALYTICS_FOR_OPTED_OUT=false
+
 # In App URLs
 CATALYST_GOOGLE_PLAY_URL=https://play.google.com/store/apps/details?id=io.iohk.vitvoting
 CATALYST_APP_STORE_URL=https://apps.apple.com/fr/app/catalyst-voting/id1517473397?l=en

--- a/apps/browser-extension-wallet/.env.example
+++ b/apps/browser-extension-wallet/.env.example
@@ -23,7 +23,8 @@ USE_HANDLE_AB=false
 USE_DATA_CHECK=false
 USE_POSTHOG_ANALYTICS=false
 USE_HANDLE_SEND_UPDATE=false
-
+USE_POSTHOG_ANALYTICS_FOR_OPTED_OUT=false
+USE_MATOMO_ANALYTICS_FOR_OPTED_OUT=false
 # In App URLs
 CATALYST_GOOGLE_PLAY_URL=https://play.google.com/store/apps/details?id=io.iohk.vitvoting
 CATALYST_APP_STORE_URL=https://apps.apple.com/fr/app/catalyst-voting/id1517473397?l=en

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.test.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.test.ts
@@ -28,45 +28,51 @@ describe('AnalyticsTracker', () => {
   describe('construction', () => {
     it('should setup both clients with the user id service', () => {
       // eslint-disable-next-line no-new
-      new AnalyticsTracker({ chain: preprodChain }, false, true);
+      new AnalyticsTracker({ extensionParams: { chain: preprodChain }, isPostHogEnabled: true });
       expect(getUserIdService).toHaveBeenCalledTimes(1);
       expect(MatomoClient).toHaveBeenCalledWith(preprodChain, userIdServiceMock);
       expect(PostHogClient).toHaveBeenCalledWith(preprodChain, userIdServiceMock, undefined);
     });
     it('should only setup matomo client if posthog is disabled', () => {
       // eslint-disable-next-line no-new
-      new AnalyticsTracker({ chain: preprodChain }, false, false);
+      new AnalyticsTracker({ extensionParams: { chain: preprodChain }, isPostHogEnabled: false });
       expect(getUserIdService).toHaveBeenCalledTimes(1);
       expect(MatomoClient).toHaveBeenCalledWith(preprodChain, userIdServiceMock);
       expect(PostHogClient).not.toHaveBeenCalled();
     });
     it('should not setup anything if analytics are disabled', () => {
       // eslint-disable-next-line no-new
-      new AnalyticsTracker({ chain: preprodChain }, true);
+      new AnalyticsTracker({ extensionParams: { chain: preprodChain }, analyticsDisabled: true });
       expect(getUserIdService).not.toHaveBeenCalled();
       expect(MatomoClient).not.toHaveBeenCalled();
       expect(PostHogClient).not.toHaveBeenCalled();
     });
     it('should setup Post Hog client with view = popup', () => {
       // eslint-disable-next-line no-new
-      new AnalyticsTracker({ chain: preprodChain, view: ExtensionViews.Popup }, false, true);
+      new AnalyticsTracker({
+        extensionParams: { chain: preprodChain, view: ExtensionViews.Popup },
+        isPostHogEnabled: true
+      });
       expect(PostHogClient).toHaveBeenCalledWith(preprodChain, userIdServiceMock, ExtensionViews.Popup);
     });
     it('should setup Post Hog client with view = extended', () => {
       // eslint-disable-next-line no-new
-      new AnalyticsTracker({ chain: preprodChain, view: ExtensionViews.Extended }, false, true);
+      new AnalyticsTracker({
+        extensionParams: { chain: preprodChain, view: ExtensionViews.Extended },
+        isPostHogEnabled: true
+      });
       expect(PostHogClient).toHaveBeenCalledWith(preprodChain, userIdServiceMock, ExtensionViews.Extended);
     });
   });
 
   describe('setOptedInForEnhancedAnalytics', () => {
     it('should make the user id persistent if user opted-in', async () => {
-      const tracker = new AnalyticsTracker({ chain: preprodChain });
+      const tracker = new AnalyticsTracker({ extensionParams: { chain: preprodChain } });
       await tracker.setOptedInForEnhancedAnalytics(EnhancedAnalyticsOptInStatus.OptedIn);
       expect(userIdServiceMock.makePersistent).toHaveBeenCalledTimes(1);
     });
     it('should make the user id temporary if user opted-out', async () => {
-      const tracker = new AnalyticsTracker({ chain: preprodChain });
+      const tracker = new AnalyticsTracker({ extensionParams: { chain: preprodChain } });
       await tracker.setOptedInForEnhancedAnalytics(EnhancedAnalyticsOptInStatus.OptedOut);
       expect(userIdServiceMock.makeTemporary).toHaveBeenCalledTimes(1);
     });
@@ -74,7 +80,7 @@ describe('AnalyticsTracker', () => {
 
   describe('sendPageNavigationEvent', () => {
     it('should use the posthog client to send a page navigation event', async () => {
-      const tracker = new AnalyticsTracker({ chain: preprodChain }, false, true);
+      const tracker = new AnalyticsTracker({ extensionParams: { chain: preprodChain }, isPostHogEnabled: true });
       const mockedPostHogClient = (PostHogClient as jest.Mock<PostHogClient>).mock.instances[0];
       await tracker.sendPageNavigationEvent();
       expect(mockedPostHogClient.sendPageNavigationEvent).toHaveBeenCalledTimes(1);
@@ -83,7 +89,7 @@ describe('AnalyticsTracker', () => {
 
   describe('sendEvent', () => {
     it('should use the matomo client to send an event', async () => {
-      const tracker = new AnalyticsTracker({ chain: preprodChain });
+      const tracker = new AnalyticsTracker({ extensionParams: { chain: preprodChain } });
       const mockedMatomoClient = (MatomoClient as jest.Mock<MatomoClient>).mock.instances[0];
       const event = {
         category: MatomoEventCategories.WALLET_RESTORE,
@@ -99,7 +105,7 @@ describe('AnalyticsTracker', () => {
 
   describe('sendEventToPostHog', () => {
     it('should use the posthog client to send an event', async () => {
-      const tracker = new AnalyticsTracker({ chain: preprodChain }, false, true);
+      const tracker = new AnalyticsTracker({ extensionParams: { chain: preprodChain }, isPostHogEnabled: true });
       const mockedPostHogClient = (PostHogClient as jest.Mock<PostHogClient>).mock.instances[0];
       const event = PostHogAction.OnboardingCreateClick;
       await tracker.sendEventToPostHog(event);
@@ -111,7 +117,7 @@ describe('AnalyticsTracker', () => {
 
   describe('setChain', () => {
     it('should set the chain on both clients', async () => {
-      const tracker = new AnalyticsTracker({ chain: preprodChain }, false, true);
+      const tracker = new AnalyticsTracker({ extensionParams: { chain: preprodChain }, isPostHogEnabled: true });
       const mockedPostHogClient = (PostHogClient as jest.Mock<PostHogClient>).mock.instances[0];
       const mockedMatomoClient = (MatomoClient as jest.Mock<MatomoClient>).mock.instances[0];
       const previewChain = Wallet.Cardano.ChainIds.Preview;

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
@@ -46,10 +46,13 @@ export const AnalyticsProvider = ({
   const analyticsTracker = useMemo(
     () =>
       tracker ||
-      new AnalyticsTracker(
-        { chain: currentChain, view: view === 'popup' ? ExtensionViews.Popup : ExtensionViews.Extended },
+      new AnalyticsTracker({
+        extensionParams: {
+          chain: currentChain,
+          view: view === 'popup' ? ExtensionViews.Popup : ExtensionViews.Extended
+        },
         analyticsDisabled
-      ),
+      }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [tracker, analyticsDisabled]
   );

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/matomo/config.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/matomo/config.ts
@@ -1,6 +1,7 @@
 import { Wallet } from '@lace/cardano';
 
 export const ENHANCED_ANALYTICS_OPT_IN_STATUS_LS_KEY = 'analyticsAccepted';
+export const MATOMO_OPTED_OUT_EVENTS_DISABLED = process.env.USE_MATOMO_ANALYTICS_FOR_OPTED_OUT === 'false';
 export const MATOMO_API_ENDPOINT = process.env.MATOMO_API_ENDPOINT;
 export const NETWORK_ID_TO_ANALYTICS_SITE_ID_MAP: Record<Wallet.Cardano.NetworkId, number> = {
   [Wallet.Cardano.NetworkId.Mainnet]: 14,

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/matomo/index.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/matomo/index.ts
@@ -1,1 +1,2 @@
 export { MatomoClient } from './MatomoClient';
+export { MATOMO_OPTED_OUT_EVENTS_DISABLED } from './config';

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/config.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/config.ts
@@ -1,6 +1,7 @@
 import { Wallet } from '@lace/cardano';
 
 export const POSTHOG_ENABLED = process.env.USE_POSTHOG_ANALYTICS === 'true';
+export const POSTHOG_OPTED_OUT_EVENTS_DISABLED = process.env.USE_POSTHOG_ANALYTICS_FOR_OPTED_OUT === 'false';
 export const PUBLIC_POSTHOG_HOST = process.env.PUBLIC_POSTHOG_HOST;
 export const PRODUCTION_TRACKING_MODE_ENABLED = process.env.PRODUCTION_MODE_TRACKING === 'true';
 

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/index.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/index.ts
@@ -1,2 +1,2 @@
 export { PostHogClient } from './PostHogClient';
-export { POSTHOG_ENABLED } from './config';
+export { POSTHOG_ENABLED, POSTHOG_OPTED_OUT_EVENTS_DISABLED } from './config';

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsSecurity.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsSecurity.tsx
@@ -6,7 +6,7 @@ import { Typography } from 'antd';
 import styles from './SettingsLayout.module.scss';
 import { useWalletStore } from '@src/stores';
 import { useLocalStorage } from '@src/hooks';
-import { useAppSettingsContext, useBackgroundServiceAPIContext } from '@providers';
+import { useAnalyticsContext, useAppSettingsContext, useBackgroundServiceAPIContext } from '@providers';
 import { PHRASE_FREQUENCY_OPTIONS } from '@src/utils/constants';
 import { EnhancedAnalyticsOptInStatus } from '@providers/AnalyticsProvider/analyticsTracker';
 import { ENHANCED_ANALYTICS_OPT_IN_STATUS_LS_KEY } from '@providers/AnalyticsProvider/matomo/config';
@@ -37,6 +37,7 @@ export const SettingsSecurity = ({
     EnhancedAnalyticsOptInStatus.OptedOut
   );
   const backgroundService = useBackgroundServiceAPIContext();
+  const analytics = useAnalyticsContext();
 
   const showPassphraseVerification = process.env.USE_PASSWORD_VERIFICATION === 'true';
 
@@ -44,6 +45,7 @@ export const SettingsSecurity = ({
     setEnhancedAnalyticsOptInStatus(
       isOptedIn ? EnhancedAnalyticsOptInStatus.OptedIn : EnhancedAnalyticsOptInStatus.OptedOut
     );
+    analytics.setIsOptedInUser(isOptedIn);
   };
 
   const isMnemonicAvailable = useCallback(async () => {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -231,6 +231,7 @@ export const WalletSetupWizard = ({
     analytics.setOptedInForEnhancedAnalytics(
       isAccepted ? EnhancedAnalyticsOptInStatus.OptedIn : EnhancedAnalyticsOptInStatus.OptedOut
     );
+    analytics.setIsOptedInUser(isAccepted);
 
     const postHogAnalyticsAgreeAction = postHogOnboardingActions[setupType]?.ANALYTICS_AGREE_CLICK;
     const postHogAnalyticcSkipAction = postHogOnboardingActions[setupType]?.ANALYTICS_SKIP_CLICK;


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-8082](https://input-output.atlassian.net/browse/LW-8082)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR implements a flag for enable/disable tracking for opted out users.
This adds two environment variables, one for Post Hog and another for Matomo

`USE_POSTHOG_ANALYTICS_FOR_OPTED_OUT`
`USE_MATOMO_ANALYTICS_FOR_OPTED_OUT`

## Testing

**Disable opted out users tracking**
By default the tracking for opted out user is disabled.
Try to send an event as an opted out user, there shouldn't be any event in Post Hog and any network request to Post Hog in the network tab.

**Enable opted out users tracking**
set `USE_POSTHOG_ANALYTICS_FOR_OPTED_OUT` to `true` in the `.env` file.
Send an event as an opted out user, there should be an event in Post Hog and a network request to Post Hog in the network tab.



