### PR TITLE
[LW-8176] align center hovered items in address book

### DIFF
--- a/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.module.scss
+++ b/packages/core/src/ui/components/WalletAddresses/WalletAddressItem.module.scss
@@ -8,7 +8,7 @@
 }
 
 .listItemContainer {
-  align-items: center;
+  align-content: center;
   background: transparent;
   border-radius: size_unit(2);
   box-sizing: border-box;
@@ -28,6 +28,7 @@
     height: size_unit(8);
     padding: 0 size_unit(2) 0 size_unit(1);
   }
+
 
   &:hover {
     background: var(--light-mode-light-grey, var(--dark-mode-mid-grey, #333333));


### PR DESCRIPTION
# Checklist

- [x] JIRA - lw-8176
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution
Add `align-content` center for items in popup view to be aligned.

## Testing
- Open popupview of Address book and add contacts, hover over them, make sure they are centered.

## Screenshots
<img width="359" alt="Screenshot 2023-08-25 at 10 39 41" src="https://github.com/input-output-hk/lace/assets/4052063/2b20fed8-4f24-4705-9f87-7915f44b0c8e">



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1702/5974374064/index.html) for [d5372d22](https://github.com/input-output-hk/lace/pull/449/commits/d5372d224b9509e315caef9f4b44bf880a2f449f)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 35     | 0      | 0       | 0     | 35    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->