### PR TITLE
ci(staking): fix running eslint/pretter

### DIFF
--- a/.github/workflows/packages-staking.yml
+++ b/.github/workflows/packages-staking.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable --inline-builds
       - name: Check for linter issues
-        run: yarn workspace @lace/staking lint
+        run: yarn workspace @lace/staking lint:all
       - name: Build dependencies of Staking Center
         run: yarn staking build-deps
       - name: Run tests


### PR DESCRIPTION
## Proposed solution
Use the correct command `lint:all` in staking CI.

## Testing
Not required.
