### PR TITLE
fix(extension): nav menu overlap on staking screen LW-7778

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/components/Layout/Layout.module.scss
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/Layout/Layout.module.scss
@@ -66,7 +66,6 @@ $main-gap: 49px;
   grid-template-areas:
     'nav side-panel'
     'nav main';
-  justify-content: center;
   margin-right: size_unit(4);
   grid-template-columns: $navigation-col-width-collapsed 1fr;
   grid-template-rows: $row-height 1fr;


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-7778
- [x] Screenshots added.

---

## The issue:

https://github.com/input-output-hk/lace/assets/172414/5b7f4d33-e9b3-4abf-8772-4fd9c6eee4c3

## Proposed solution

This PR fixes the grid layout by removing `justify-content: center;` which seems to have caused this issue.

## Testing

- Set up a wallet and start staking to any pool with a very long name (ellipsis must be present on smaller screens)
- Reduce screen size and the "Staking" headline should never be cut-off by the nav bar like in the video above


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1750/6001732186/index.html) for [2afeff6b](https://github.com/input-output-hk/lace/pull/456/commits/2afeff6bde773d39ec75f4d36fb78dc1057a27ef)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->