### PR TITLE
fix/LW-8182 - Alignment Issues

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolsTable/StakePoolsTable.modules.scss
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolsTable/StakePoolsTable.modules.scss
@@ -10,26 +10,6 @@
     display: flex;
     flex-direction: column;
   }
-  .search {
-    background: var(--light-mode-light-grey, var(--dark-mode-dark-grey)) !important;
-    border-radius: size_unit(2) !important;
-    height: size_unit(8) !important;
-    margin-top: size_unit(3);
-    padding-left: size_unit(3) !important;
-    padding-right: size_unit(3) !important;
-    transition: none;
-    :global {
-      .ant-input {
-        transition: none;
-        font-weight: 400 !important;
-        font-size: var(--bodyLarge) !important;
-        ::placeholder {
-          font-weight: 400 !important;
-          font-size: var(--bodyLarge) !important;
-        }
-      }
-    }
-  }
   .title {
     color: var(--text-color-primary);
     @include text-subHeading-semi-bold;

--- a/packages/common/src/ui/components/Search/Search.module.scss
+++ b/packages/common/src/ui/components/Search/Search.module.scss
@@ -28,7 +28,14 @@ $button_size: 52px;
   border: 1.5px solid transparent !important;
   padding-bottom: 0px;
   padding-right: 5px;
-  
+  margin-top: size_unit(3);
+  transition: none;
+
+
+  @media (max-width: $breakpoint-popup) {
+    padding: 0 size_unit(0.75) 0 size_unit(2.5) !important;
+  }
+
   :global {
     .ant-input-affix-wrapper-borderless {
       background-color: transparent !important;
@@ -43,7 +50,8 @@ $button_size: 52px;
       flex: 1;
       background-color: transparent !important;
       border: none !important;
-      
+      transition: none;
+
       &::placeholder {
         @include text-bodyLarge-semi-bold;
         color: var(--text-color-secondary) !important;
@@ -81,7 +89,9 @@ $button_size: 52px;
 
   .searchIcon {
     font-size: $font-size-bodyLarge !important;
-    width: 18px !important;
+    width: size_unit(3) !important;
+    height: size_unit(3) !important;
+    margin-left: size_unit(3);
   }
 }
 
@@ -207,6 +217,7 @@ button.clear {
 .loaderContainer {
   display: flex;
   z-index: 2;
+  margin-right: size_unit(2);
 }
 .loader {
   @include spin-animation();

--- a/packages/core/src/ui/components/EditAddressForm/EditAddressForm.module.scss
+++ b/packages/core/src/ui/components/EditAddressForm/EditAddressForm.module.scss
@@ -138,7 +138,6 @@ $drawer-width: 664px;
 
 :global(.anticon) {
   font-size: size_unit(2.5);
-  margin-right: size_unit(1);
   
   &.valid {
     color: var(--text-color-green);

--- a/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolsTable.module.scss
+++ b/packages/staking/src/features/browse-pools/stake-pools-table/StakePoolsTable.module.scss
@@ -10,26 +10,6 @@
     display: flex;
     flex-direction: column;
   }
-  .search {
-    background: var(--light-mode-light-grey, var(--dark-mode-dark-grey)) !important;
-    border-radius: size_unit(2) !important;
-    height: size_unit(8) !important;
-    margin-top: size_unit(3);
-    padding-left: size_unit(3) !important;
-    padding-right: size_unit(3) !important;
-    transition: none;
-    :global {
-      .ant-input {
-        transition: none;
-        font-weight: 400 !important;
-        font-size: var(--bodyLarge) !important;
-        ::placeholder {
-          font-weight: 400 !important;
-          font-size: var(--bodyLarge) !important;
-        }
-      }
-    }
-  }
   .title {
     color: var(--text-color-primary);
     @include text-subHeading-semi-bold;


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8182
- [x] Screenshots added.

---

## Proposed solution

- Remove ` margin-right: size_unit(1)` from `:global(.anticon)` in `EditAddressForm.module.scss` as it is already in `AddressDetailDrawer.module.scss`
- `StakePoolsTable.modules.scss` is duplicated in both `browser-extension-wallet` app and `staking` package, but the rules in `.search` were not being applied when doing `<Search className={styles.search}` from the `staking` package. Move those rules to `Search.module.scss` in `common` package instead

## Screenshots

![image](https://github.com/input-output-hk/lace/assets/57540576/47acbc09-0fb2-4499-a0aa-5cd4ce44ef93)

![image](https://github.com/input-output-hk/lace/assets/57540576/5efa260e-01c7-402b-812d-380cfd78dd4a)

![image](https://github.com/input-output-hk/lace/assets/57540576/f1d231a0-d895-4c27-80fe-88f8f7551e28)


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1833/6039061019/index.html) for [44575525](https://github.com/input-output-hk/lace/pull/460/commits/44575525a3cfb2233358b2e1b69c898807d20236)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 33     | 2      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->