### PR TITLE
[LW-8265] Remove unnecesary Posthog properties

### DIFF
--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -145,7 +145,6 @@ export type PostHogPersonProperties = {
 export type PostHogMetadata = {
   distinct_id?: string;
   alias_id?: string;
-  url: string;
   view: ExtensionViews;
   sent_at_local: string;
   posthog_project_id: number;

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -6,8 +6,8 @@ import {
   ExtensionViews,
   PostHogAction,
   PostHogMetadata,
-  PostHogProperties,
   PostHogPersonProperties,
+  PostHogProperties,
   UserTrackingType
 } from '../analyticsTracker';
 import {
@@ -46,7 +46,13 @@ export class PostHogClient {
       disable_persistence: true,
       disable_cookie: true,
       persistence: 'memory',
-      property_blacklist: ['$autocapture_disabled_server_side', '$device_id', '$time']
+      property_blacklist: [
+        '$autocapture_disabled_server_side',
+        '$console_log_recording_enabled_server_side',
+        '$device_id',
+        '$session_recording_recorder_version_server_side',
+        '$time'
+      ]
     });
   }
 

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/postHog/PostHogClient.ts
@@ -102,7 +102,6 @@ export class PostHogClient {
 
   protected async getEventMetadata(): Promise<PostHogMetadata> {
     return {
-      url: window.location.href,
       view: this.view,
       sent_at_local: dayjs().format(),
       distinct_id: await this.userIdService.getUserId(this.chain.networkMagic),


### PR DESCRIPTION
# Checklist

- [x] JIRA - https://input-output.atlassian.net/browse/LW-8265
- [ ] Proper tests implemented
- [x] ~Screenshots added.~

---

## Proposed solution

This PR removes `url`, `$console_log_recording_enabled_server_side` and `$session_recording_recorder_version_server_side` PostHog properties as outlined in the acceptance criteria.

## Testing

Perform various tracked interaction with PostHog and make sure properties listed above are no longer captured.

## Screenshots

n/a

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1826/6036500830/index.html) for [d6b42de7](https://github.com/input-output-hk/lace/pull/469/commits/d6b42de7f2c302c18ff4dc21238b980bd22c34a1)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->