### PR TITLE
chore(staking): update copy of disabled bin button

### DIFF
--- a/packages/staking/src/features/i18n/translations/en.ts
+++ b/packages/staking/src/features/i18n/translations/en.ts
@@ -55,7 +55,7 @@ export const en: Translations = {
   'drawer.preferences.addPoolButton': 'Add stake pool',
   'drawer.preferences.nextButton': 'Next',
   'drawer.preferences.percentageOfBalance': '~{{value}} ADA (~{{percentage}}%)',
-  'drawer.preferences.pickMorePools': 'Please pick more stake pools.',
+  'drawer.preferences.pickMorePools': 'You need to stake at least to one pool.',
   'drawer.preferences.selectedStakePools': 'Selected stake pools ({{count}})',
   'drawer.sign.confirmation.title': 'Staking confirmation',
   'drawer.sign.enterWalletPasswordToConfirmTransaction': 'Enter your wallet password to confirm transaction',


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-8147)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

- Updates copy for the stake delete button when there's just one pool selected to draft.

## Screenshots

<img width="286" alt="image" src="https://github.com/input-output-hk/lace/assets/16132011/15df60ae-dd8d-46a8-8694-1f2683453a63">


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1948/6098884384/index.html) for [dbe30d7f](https://github.com/input-output-hk/lace/pull/481/commits/dbe30d7f97ba0ec4f363267d7701d39aee9e70f5)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->