### PR TITLE
feat(staking): show user staking preference on the PieChart (management drawer) [LW-8322]

### DIFF
--- a/packages/staking/src/features/drawer/StakePoolPreferences.tsx
+++ b/packages/staking/src/features/drawer/StakePoolPreferences.tsx
@@ -47,11 +47,11 @@ export const StakePoolPreferences = () => {
     setIsDrawerVisible: store.setIsDrawerVisible,
   }));
 
-  const displayData = draftPortfolio.map(({ name, weight, id }, i) => ({
+  const displayData = draftPortfolio.map(({ name, id }, i) => ({
     color: PIE_CHART_DEFAULT_COLOR_SET[i] as PieChartColor,
     id,
     name: name || '',
-    value: weight,
+    value: 1,
   }));
   const addPoolButtonDisabled = draftPortfolio.length === MAX_POOLS_COUNT;
   const onAddPoolButtonClick = () => {


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8322

---

## Proposed solution
Render equal split (preference) on the pie chart in the management drawer.

## Testing
PieChart should render the correct preference, even if the portfolio has drifted.

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1864/6072553642/index.html) for [1ffed89d](https://github.com/input-output-hk/lace/pull/483/commits/1ffed89d1187adfb96f71d6040437a62e15831a7)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 34     | 1      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->