### PR TITLE
Feat/cip30 collateral

### DIFF
--- a/apps/browser-extension-wallet/src/components/MainLoader/MainLoader.module.scss
+++ b/apps/browser-extension-wallet/src/components/MainLoader/MainLoader.module.scss
@@ -5,6 +5,10 @@
   flex-direction: column;
   height: 100%;
   gap: size_unit(2);
+
+  .loaderText {
+    color: var(--text-color-primary);
+  }
 }
 
 .loader {

--- a/apps/browser-extension-wallet/src/components/MainLoader/MainLoader.tsx
+++ b/apps/browser-extension-wallet/src/components/MainLoader/MainLoader.tsx
@@ -13,7 +13,9 @@ export const MainLoader = ({ text }: MainLoaderProps): React.ReactElement => {
   return (
     <div className={styles.loaderContainer} data-testid="main-loader">
       <Loader className={styles.loader} data-testid="main-loader-image" />
-      <p data-testid="main-loader-text">{text ?? t('general.loading')}</p>
+      <p className={styles.loaderText} data-testid="main-loader-text">
+        {text ?? t('general.loading')}
+      </p>
     </div>
   );
 };

--- a/apps/browser-extension-wallet/src/features/dapp/components/collateral/CollateralContainer.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/collateral/CollateralContainer.tsx
@@ -1,0 +1,172 @@
+/* eslint-disable no-magic-numbers, promise/catch-or-return */
+import React, { useCallback, useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { of } from 'rxjs';
+import { runtime } from 'webextension-polyfill';
+import { RemoteApiPropertyType, consumeRemoteApi, exposeApi } from '@cardano-sdk/web-extension';
+
+import { Wallet } from '@lace/cardano';
+import { MainLoader } from '@src/components/MainLoader';
+import { InsufficientFunds } from './InsufficientFunds';
+import { DappDataService } from '@lib/scripts/types';
+import { DAPP_CHANNELS } from '@utils/constants';
+import { UserPromptService } from '@lib/scripts/background/services';
+import { useWalletStore } from '@src/stores';
+import { DappSetCollateral } from './SetCollateral';
+import { CollateralAmount, CollateralAmountWithCollateralAmount } from './types';
+import { CreateCollateral } from './CreateCollateral';
+import { APIErrorCode, ApiError } from '@cardano-sdk/dapp-connector';
+import { useRedirection } from '@hooks';
+import { dAppRoutePaths } from '@routes';
+
+enum ReturnResponse {
+  resolve = 'resolve',
+  reject = 'reject'
+}
+
+interface RejectResponse {
+  response: ReturnResponse.reject;
+  reason: ApiError;
+}
+
+interface ResolveResponse {
+  response: ReturnResponse.resolve;
+  utxos: Wallet.Cardano.Utxo[];
+}
+
+const collateralRequestResponse = (action: RejectResponse | ResolveResponse) => {
+  try {
+    exposeApi<Pick<UserPromptService, 'getCollateralRequest'>>(
+      {
+        api$: of({
+          getCollateralRequest() {
+            if (action.response === ReturnResponse.reject) {
+              return Promise.reject(action.reason);
+            }
+            return Promise.resolve(action.utxos);
+          }
+        }),
+        baseChannel: DAPP_CHANNELS.userPrompt,
+        properties: { getCollateralRequest: RemoteApiPropertyType.MethodReturningPromise }
+      },
+      {
+        logger: console,
+        runtime
+      }
+    );
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+const isInstanceOfCollateralInfoWithCollateralAmount = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  object: any
+): object is CollateralAmountWithCollateralAmount => 'amount' in object;
+
+const reject = (reason: ApiError, close = true) => {
+  collateralRequestResponse({
+    response: ReturnResponse.reject,
+    reason
+  });
+  !!close && setTimeout(() => window.close(), 500);
+};
+
+export const DappCollateralContainer = (): React.ReactElement => {
+  const { t } = useTranslation();
+  const { inMemoryWallet } = useWalletStore();
+  const [isCalculatingCollateral, setIsCalculatingCollateral] = useState(true);
+  const [insufficientBalance, setInsufficientBalance] = useState(false);
+  const [dappInfo, setDappInfo] = useState<Wallet.DappInfo>();
+  const [collateralInfo, setCollateralInfo] = useState<CollateralAmount | CollateralAmountWithCollateralAmount>();
+  const [lockableUtxos, setLockableUtxos] = useState<Wallet.Cardano.Utxo[]>([]);
+  const redirectToCreateSuccess = useRedirection(dAppRoutePaths.dappTxSignSuccess);
+  const redirectToCreateFailure = useRedirection(dAppRoutePaths.dappTxSignFailure);
+
+  const confirmCollateral = useCallback(
+    async (utxos: Wallet.Cardano.Utxo[]) => {
+      try {
+        await inMemoryWallet.utxo.setUnspendable(utxos);
+        collateralRequestResponse({ response: ReturnResponse.resolve, utxos });
+        redirectToCreateSuccess();
+      } catch (error) {
+        console.log(error);
+        redirectToCreateFailure();
+      }
+    },
+    [inMemoryWallet]
+  );
+
+  useEffect(() => {
+    try {
+      consumeRemoteApi<Pick<DappDataService, 'getCollateralRequest'>>(
+        {
+          baseChannel: DAPP_CHANNELS.dappData,
+          properties: {
+            getCollateralRequest: RemoteApiPropertyType.MethodReturningPromise
+          }
+        },
+        { logger: console, runtime }
+      )
+        .getCollateralRequest()
+        .then(({ dappInfo: requestDappInfo, collateralRequest }) => {
+          // Set the summary information needed to display
+          setDappInfo(requestDappInfo);
+          // Determine if collateral can be set without further fragmentation of wallet UTxOs
+          let totalCoins = BigInt(0);
+          const usableUtxos: Wallet.Cardano.Utxo[] = [];
+          for (const utxo of collateralRequest?.utxos) {
+            const { coins } = utxo[1].value;
+            totalCoins += coins;
+            usableUtxos.push(utxo);
+            if (totalCoins >= collateralRequest.amount) {
+              // If total is 100% higher than requested amount, require new tx to create collateral
+              if (totalCoins > collateralRequest.amount * BigInt(2)) {
+                setCollateralInfo(collateralRequest);
+                break;
+              } else {
+                setCollateralInfo({ amount: collateralRequest.amount, lockableAmount: totalCoins });
+                setLockableUtxos(usableUtxos);
+                break;
+              }
+            }
+          }
+          if (totalCoins < collateralRequest.amount) {
+            // Not enough to ADA available to set collateral
+            reject(new ApiError(APIErrorCode.Refused, 'wallet does not have enough ada to set collateral'), false);
+            setInsufficientBalance(true);
+          }
+          setIsCalculatingCollateral(false);
+        });
+    } catch (error) {
+      console.log(error);
+      redirectToCreateFailure();
+    }
+  }, []);
+
+  if (!isCalculatingCollateral) {
+    if (insufficientBalance) {
+      return <InsufficientFunds />;
+    } else if (lockableUtxos.length > 0 && isInstanceOfCollateralInfoWithCollateralAmount(collateralInfo)) {
+      return (
+        <DappSetCollateral
+          dappInfo={dappInfo}
+          collateralInfo={collateralInfo}
+          reject={reject}
+          confirm={() => confirmCollateral(lockableUtxos)}
+        />
+      );
+    }
+    // Allow user to create tx to set collateral
+    return (
+      <CreateCollateral
+        dappInfo={dappInfo}
+        collateralInfo={collateralInfo}
+        confirm={(utxos: Wallet.Cardano.Utxo[]) => confirmCollateral(utxos)}
+        reject={reject}
+      />
+    );
+  }
+
+  return <MainLoader text={t('dapp.collateral.calculating')} />;
+};

--- a/apps/browser-extension-wallet/src/features/dapp/components/collateral/CreateCollateral.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/collateral/CreateCollateral.tsx
@@ -1,0 +1,172 @@
+/* eslint-disable react/no-multi-comp */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { DappCreateCollateralProps } from './types';
+import { DappInfo, RowContainer, renderAmountInfo, renderLabel } from '@lace/core';
+import { APIErrorCode, ApiError } from '@cardano-sdk/dapp-connector';
+import { Wallet } from '@lace/cardano';
+import { useTranslation } from 'react-i18next';
+import { useWalletStore } from '@src/stores';
+import { useFetchCoinPrice, useWalletManager } from '@hooks';
+import { Layout } from '../Layout';
+import { Banner, Button, Password, inputProps, useObservable } from '@lace/common';
+import { firstValueFrom } from 'rxjs';
+import { map, take, filter } from 'rxjs/operators';
+import { isNotNil } from '@cardano-sdk/util';
+import { useCurrencyStore } from '@providers';
+import { cardanoCoin } from '@src/utils/constants';
+import { Spin, Typography } from 'antd';
+import styles from './styles.module.scss';
+
+const { Text } = Typography;
+
+export const CreateCollateral = ({
+  dappInfo,
+  collateralInfo,
+  confirm,
+  reject
+}: DappCreateCollateralProps): React.ReactElement => {
+  const { t } = useTranslation();
+
+  const { executeWithPassword } = useWalletManager();
+  const { inMemoryWallet, getKeyAgentType } = useWalletStore();
+  const addresses = useObservable(inMemoryWallet.addresses$);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [password, setPassword] = useState('');
+  const [isPasswordValid, setIsPasswordValid] = useState(true);
+  const { unlockWallet: validatePassword } = useWalletManager();
+
+  const handleChange: inputProps['onChange'] = ({ target: { value } }) => {
+    setIsPasswordValid(true);
+    setPassword(value);
+  };
+  const { priceResult } = useFetchCoinPrice();
+  const { fiatCurrency } = useCurrencyStore();
+  const keyAgentType = getKeyAgentType();
+  const isInMemory = useMemo(() => keyAgentType === Wallet.KeyManagement.KeyAgentType.InMemory, [keyAgentType]);
+  const [collateralTx, setCollateralTx] = useState<{ fee: bigint; tx: Wallet.UnsignedTx }>();
+
+  useEffect(() => {
+    const getTx = async () => {
+      const output: Wallet.Cardano.TxOut = {
+        address: !!addresses && Wallet.Cardano.PaymentAddress(addresses[0].address),
+        value: {
+          coins: collateralInfo.amount
+        }
+      };
+
+      const builtTx = inMemoryWallet.createTxBuilder().addOutput(output).build();
+      const inspectedTx = await builtTx.inspect();
+      setCollateralTx({ fee: inspectedTx.body.fee, tx: builtTx });
+    };
+
+    getTx();
+  }, [collateralInfo.amount, inMemoryWallet, addresses]);
+
+  const createCollateralTx = useCallback(async () => {
+    setIsSubmitting(true);
+    const submitTx = async () => {
+      const { tx } = await collateralTx.tx.sign();
+      await inMemoryWallet.submitTx(tx);
+      const utxo = await firstValueFrom(
+        inMemoryWallet.utxo.available$.pipe(
+          map((utxos) => utxos.find((o) => o[0].txId === tx.id && o[1].value.coins === collateralInfo.amount)),
+          filter(isNotNil),
+          take(1)
+        )
+      );
+      await inMemoryWallet.utxo.setUnspendable([utxo]);
+      confirm([utxo]);
+    };
+    if (isInMemory) {
+      try {
+        await validatePassword(password);
+        await executeWithPassword(password, submitTx, true);
+      } catch {
+        setPassword('');
+        setIsPasswordValid(false);
+        setIsSubmitting(false);
+      }
+    } else {
+      // submit HW transaction
+      await submitTx();
+    }
+  }, [collateralTx, collateralInfo.amount, isInMemory, inMemoryWallet, password, executeWithPassword, confirm]);
+
+  const confirmButtonLabel = useMemo(() => {
+    if (isInMemory) {
+      return t('browserView.settings.wallet.collateral.confirm');
+    }
+    return t('browserView.settings.wallet.collateral.confirmWithDevice', { hardwareWallet: keyAgentType });
+  }, [isInMemory, keyAgentType, t]);
+
+  return (
+    <Layout
+      pageClassname={styles.spaceBetween}
+      title={t('dapp.collateral.create.header')}
+      data-testid="dapp-create-collateral-layout"
+    >
+      <div className={styles.container}>
+        <DappInfo {...dappInfo} />
+        <div data-testid="collateral-send" className={styles.collateralSend}>
+          <Text className={styles.collateralDescription} data-testid="collateral-description">
+            {t('browserView.settings.wallet.collateral.amountDescription')}
+          </Text>
+          {isInMemory && (
+            <div data-testid="collateral-password">
+              <Spin spinning={false}>
+                <Password
+                  onChange={handleChange}
+                  value={password}
+                  error={isPasswordValid === false}
+                  errorMessage={t('browserView.transaction.send.error.invalidPassword')}
+                  label={t('browserView.transaction.send.password.placeholder')}
+                  autoFocus
+                />
+              </Spin>
+            </div>
+          )}
+          <Banner className={styles.noTopMargin} withIcon message={t('dapp.collateral.amountSeparated')} />
+          {collateralTx?.fee && (
+            <RowContainer>
+              {renderLabel({
+                label: t('staking.confirmation.transactionFee'),
+                dataTestId: 'sp-confirmation-staking-fee',
+                tooltipContent: t('send.theAmountYoullBeChargedToProcessYourTransaction')
+              })}
+              <div>
+                {renderAmountInfo(
+                  `${Wallet.util.lovelacesToAdaString(collateralTx.fee.toString())} ${cardanoCoin.symbol}`,
+                  `${Wallet.util.convertAdaToFiat({
+                    ada: Wallet.util.lovelacesToAdaString(collateralTx.fee.toString()),
+                    fiat: priceResult?.cardano?.price || 0
+                  })} ${fiatCurrency?.code}`
+                )}
+              </div>
+            </RowContainer>
+          )}
+        </div>
+      </div>
+      <div className={styles.footer} style={{ zIndex: 1000 }}>
+        <Button
+          block
+          data-testid="collateral-confirmation-btn"
+          disabled={isSubmitting}
+          loading={isSubmitting}
+          className={styles.footerBtn}
+          size="large"
+          onClick={createCollateralTx}
+        >
+          {confirmButtonLabel}
+        </Button>
+        <Button
+          block
+          className={styles.footerBtn}
+          color="secondary"
+          onClick={() => reject(new ApiError(APIErrorCode.Refused, 'user declined to set collateral'))}
+        >
+          {t('general.button.cancel')}
+        </Button>
+      </div>
+    </Layout>
+  );
+};

--- a/apps/browser-extension-wallet/src/features/dapp/components/collateral/InsufficientFunds.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/collateral/InsufficientFunds.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback } from 'react';
+import { Typography } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+import SadFaceIcon from '@lace/core/src/ui/assets/icons/sad-face.component.svg';
+import styles from './styles.module.scss';
+import { Button } from '@lace/common';
+import { useBackgroundServiceAPIContext } from '@providers';
+import { BrowserViewSections } from '@lib/scripts/types';
+import { Layout } from '../Layout';
+import connectStyles from '../Connect.module.scss';
+
+const { Text } = Typography;
+
+export const InsufficientFunds = (): React.ReactElement => {
+  const { t } = useTranslation();
+  const backgroundServices = useBackgroundServiceAPIContext();
+
+  const close = useCallback(() => {
+    window.close();
+  }, []);
+
+  const rejectAndOpenFunds = useCallback(() => {
+    backgroundServices?.handleOpenBrowser({ section: BrowserViewSections.HOME }).then(close);
+  }, [close, backgroundServices]);
+
+  return (
+    <Layout
+      pageClassname={styles.spaceBetween}
+      title={t('dapp.collateral.insufficientFunds.title')}
+      data-testid="dapp-set-collateral-layout"
+    >
+      <div className={styles.insufficientFunds}>
+        <SadFaceIcon className={styles.sadFace} data-testid="collateral-sad-face-icon" />
+        <Text className={styles.sadFaceDescription} data-testid="collateral-not-enough-ada-error">
+          {t('dapp.collateral.insufficientFunds.description')}
+        </Text>
+      </div>
+      <div className={connectStyles.footer}>
+        <Button block onClick={rejectAndOpenFunds}>
+          {t('dapp.collateral.insufficientFunds.add')}
+        </Button>
+        <Button block color="secondary" onClick={close}>
+          {t('general.button.cancel')}
+        </Button>
+      </div>
+    </Layout>
+  );
+};

--- a/apps/browser-extension-wallet/src/features/dapp/components/collateral/SetCollateral.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/collateral/SetCollateral.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { APIErrorCode, ApiError } from '@cardano-sdk/dapp-connector';
+import { Banner, Button } from '@lace/common';
+import { DappInfo } from '@lace/core';
+
+import { Layout } from '../Layout';
+import { DappSetCollateralProps } from './types';
+import { Wallet } from '@lace/cardano';
+import { useWalletStore } from '@src/stores';
+import styles from '../Connect.module.scss';
+import collateralStyles from './styles.module.scss';
+
+export const DappSetCollateral = ({
+  dappInfo,
+  collateralInfo,
+  confirm,
+  reject
+}: DappSetCollateralProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const {
+    walletUI: { cardanoCoin }
+  } = useWalletStore();
+
+  return (
+    <Layout
+      pageClassname={styles.spaceBetween}
+      title={t('dapp.collateral.set.header')}
+      data-testid="dapp-set-collateral-layout"
+    >
+      <div className={collateralStyles.container}>
+        <DappInfo {...dappInfo} />
+        <div className={collateralStyles.collateralDescription} data-testid="collateral-modal-description">
+          {t('dapp.collateral.request', {
+            dapp: dappInfo.url,
+            requestedAmount: Wallet.util.lovelacesToAdaString(collateralInfo.amount.toString()),
+            lockableAmount: Wallet.util.lovelacesToAdaString(collateralInfo.lockableAmount.toString()),
+            symbol: cardanoCoin.symbol
+          })}
+        </div>
+        <div className={styles.bannerContainer}>
+          <Banner withIcon message={t('dapp.collateral.amountSeparated')} />
+        </div>
+        <div className={styles.footer}>
+          <Button block data-testid="collateral-set-accept" onClick={confirm}>
+            {t('browserView.settings.wallet.collateral.confirm')}
+          </Button>
+          <Button
+            block
+            data-testid="collateral-set-cancel"
+            onClick={() => reject(new ApiError(APIErrorCode.Refused, 'User declined to set collateral'))}
+            color="secondary"
+          >
+            {t('general.button.cancel')}
+          </Button>
+        </div>
+      </div>
+    </Layout>
+  );
+};

--- a/apps/browser-extension-wallet/src/features/dapp/components/collateral/index.ts
+++ b/apps/browser-extension-wallet/src/features/dapp/components/collateral/index.ts
@@ -1,0 +1,1 @@
+export * from './CollateralContainer';

--- a/apps/browser-extension-wallet/src/features/dapp/components/collateral/styles.module.scss
+++ b/apps/browser-extension-wallet/src/features/dapp/components/collateral/styles.module.scss
@@ -1,0 +1,69 @@
+@import '../../../../styles/rules/flex.scss';
+@import '../../../../../../../packages/common/src/ui/styles/theme.scss';
+@import '../../../../../../../packages/common/src/ui/styles/abstracts/typography';
+
+.spaceBetween {
+  justify-content: space-between;
+  padding-top: size_unit(2);
+}
+
+.container {
+  justify-content: space-between;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+
+  .collateralSend {
+    display: flex;
+    flex-direction: column;
+    gap: size_unit(3);
+    padding: size_unit(2) 0;
+  }
+
+  .collateralDescription {
+    @include text-body-medium;
+    color: var(--text-color-primary);
+  }
+
+  .noTopMargin {
+    margin-top: 0;
+  }
+}
+
+.footer {
+  background-color: var(--bg-color-body);
+  @extend %flex-column;
+  justify-content: center;
+  gap: size_unit(1);
+  padding: size_unit(2);
+  border-top: 2px solid var(--light-mode-light-grey-plus, var(--dark-mode-mid-grey));
+  margin: 0 size_unit(-4);
+  position: sticky;
+  margin: 0 -24px;
+  padding: size_unit(2);
+  gap: size_unit(1);
+  bottom: 0;
+  .footerBtn {
+    width: 100%;
+  }
+}
+
+.insufficientFunds {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0 size_unit(3);
+}
+
+.sadFace {
+  width: size_unit(14);
+  height: size_unit(14);
+}
+
+.sadFaceDescription {
+  @include text-body-medium;
+  color: var(--text-color-secondary) !important;
+  text-align: center;
+}

--- a/apps/browser-extension-wallet/src/features/dapp/components/collateral/types.ts
+++ b/apps/browser-extension-wallet/src/features/dapp/components/collateral/types.ts
@@ -1,0 +1,26 @@
+import { ApiError } from '@cardano-sdk/dapp-connector';
+import { Wallet } from '@lace/cardano';
+import { cip30 as walletCip30 } from '@cardano-sdk/wallet';
+
+interface BaseCollateralProps {
+  dappInfo: Wallet.DappInfo;
+  collateralInfo: { amount: walletCip30.GetCollateralCallbackParams['data']['amount'] };
+  reject: (reason: ApiError) => void;
+}
+
+export interface DappSetCollateralProps extends BaseCollateralProps {
+  collateralInfo: BaseCollateralProps['collateralInfo'] & { lockableAmount: BigInt };
+  confirm: () => void;
+}
+
+export interface DappCreateCollateralProps extends BaseCollateralProps {
+  confirm: (utxos?: Wallet.Cardano.Utxo[]) => void;
+}
+
+export interface CollateralAmount {
+  amount: walletCip30.GetCollateralCallbackParams['data']['amount'];
+}
+
+export interface CollateralAmountWithCollateralAmount extends CollateralAmount {
+  lockableAmount: BigInt;
+}

--- a/apps/browser-extension-wallet/src/features/dapp/components/index.ts
+++ b/apps/browser-extension-wallet/src/features/dapp/components/index.ts
@@ -6,3 +6,4 @@ export * from './NoWallet';
 export * from './ConfirmData';
 export * from './BetaPill';
 export * from './SignDataFlowContainer';
+export * from './collateral';

--- a/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
@@ -1,7 +1,6 @@
 import { cip30 as walletCip30 } from '@cardano-sdk/wallet';
 import { ensureUiIsOpenAndLoaded, getDappInfoFromLastActiveTab } from './util';
 import { userPromptService } from './services/dappService';
-import { Wallet } from '@lace/cardano';
 import { authenticator } from './authenticator';
 import { wallet$ } from './wallet';
 import { runtime } from 'webextension-polyfill';
@@ -10,32 +9,38 @@ import { DAPP_CHANNELS } from '../../../utils/constants';
 import { DappDataService } from '../types';
 import { BehaviorSubject, of } from 'rxjs';
 import { dappInfo$ } from './requestAccess';
+import { APIErrorCode, ApiError } from '@cardano-sdk/dapp-connector';
+import { Wallet } from '@lace/cardano';
+import pDebounce from 'p-debounce';
 
-const dappSignTxData$ = new BehaviorSubject<{ dappInfo: Wallet.DappInfo; tx: Wallet.Cardano.Tx }>(undefined);
+const DEBOUNCE_THROTTLE = 500;
+
+const dappSignTxData$ = new BehaviorSubject<{
+  dappInfo: Wallet.DappInfo;
+  tx: walletCip30.SignTxCallbackParams['data'];
+}>(undefined);
 const dappSignData$ = new BehaviorSubject<{
   dappInfo: Wallet.DappInfo;
-  sign: { addr: Wallet.Cardano.PaymentAddress; payload: Wallet.HexBlob };
+  sign: walletCip30.SignDataCallbackParams['data'];
+}>(undefined);
+const dappSetCollateral$ = new BehaviorSubject<{
+  dappInfo: Wallet.DappInfo;
+  collateralRequest: walletCip30.GetCollateralCallbackParams['data'];
 }>(undefined);
 
-export const confirmationCallback: walletCip30.CallbackConfirmation = {
-  signData: async (args) => {
-    try {
-      const { logo, name, url } = await getDappInfoFromLastActiveTab();
-      dappSignData$.next({ dappInfo: { logo, name, url }, sign: args.data });
-      await ensureUiIsOpenAndLoaded('#/dapp/sign-data');
+const getHostname = (url: string): URL['hostname'] => new URL(url).hostname;
 
-      return userPromptService.allowSignData();
-    } catch (error) {
-      console.log(error);
-      // eslint-disable-next-line unicorn/no-useless-undefined
-      dappSignData$.next(undefined);
-      return false;
-    }
-  },
-  signTx: async (args) => {
+export const confirmationCallback: walletCip30.CallbackConfirmation = {
+  submitTx: async () =>
+    // We don't need another callback for this callback, so long as we ensure callbacks for signing tx's
+    // Remove this method once it is dropped from the SDK in future build
+    // Also transactions can be submitted by the dApps externally
+    // once they've got the witnesss keys if they construct their own transactions
+    Promise.resolve(true),
+  signTx: pDebounce(async (args) => {
     try {
       const { logo, name, url } = await getDappInfoFromLastActiveTab();
-      dappSignTxData$.next({ dappInfo: { logo, name, url }, tx: args.data });
+      dappSignTxData$.next({ dappInfo: { logo, name, url: getHostname(url) }, tx: args.data });
       await ensureUiIsOpenAndLoaded('#/dapp/sign-tx');
 
       return userPromptService.allowSignTx();
@@ -43,18 +48,40 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
       console.log(error);
       // eslint-disable-next-line unicorn/no-useless-undefined
       dappSignTxData$.next(undefined);
-      return Promise.reject();
+      return Promise.reject(new ApiError(APIErrorCode.InternalError, 'Unable to sign transaction'));
     }
-  },
-  submitTx: async () =>
-    // We don't need another callback for this callback, so long as we ensure callbacks for signing tx's
-    // Remove this method once it is dropped from the SDK in future build
-    // Also transactions can be submitted by the dApps externally
-    // once they've got the witnesss keys if they construct their own transactions
-    Promise.resolve(true)
+  }, DEBOUNCE_THROTTLE),
+  signData: pDebounce(async (args) => {
+    try {
+      const { logo, name, url } = await getDappInfoFromLastActiveTab();
+      dappSignData$.next({ dappInfo: { logo, name, url: getHostname(url) }, sign: args.data });
+      await ensureUiIsOpenAndLoaded('#/dapp/sign-data');
+
+      return userPromptService.allowSignData();
+    } catch (error) {
+      console.log(error);
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      dappSignData$.next(undefined);
+      return Promise.reject(new ApiError(APIErrorCode.InternalError, 'Unable to sign data'));
+    }
+  }, DEBOUNCE_THROTTLE),
+  getCollateral: pDebounce(async (args) => {
+    try {
+      const { logo, name, url } = await getDappInfoFromLastActiveTab();
+      dappSetCollateral$.next({ dappInfo: { logo, name, url: getHostname(url) }, collateralRequest: args.data });
+      await ensureUiIsOpenAndLoaded('#/dapp/set-collateral');
+
+      return userPromptService.getCollateralRequest();
+    } catch (error) {
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      dappSetCollateral$.next(undefined);
+      throw new Error(error);
+    }
+  }, DEBOUNCE_THROTTLE)
 };
 
 const walletApi = walletCip30.createWalletApi(wallet$, confirmationCallback, { logger: console });
+
 cip30.initializeBackgroundScript(
   { walletName: process.env.WALLET_NAME },
   { authenticator, logger: console, runtime, walletApi }
@@ -66,12 +93,14 @@ exposeApi<DappDataService>(
     properties: {
       getSignTxData: RemoteApiPropertyType.MethodReturningPromise,
       getSignDataData: RemoteApiPropertyType.MethodReturningPromise,
-      getDappInfo: RemoteApiPropertyType.MethodReturningPromise
+      getDappInfo: RemoteApiPropertyType.MethodReturningPromise,
+      getCollateralRequest: RemoteApiPropertyType.MethodReturningPromise
     },
     api$: of({
       getSignTxData: () => Promise.resolve(dappSignTxData$.value),
       getSignDataData: () => Promise.resolve(dappSignData$.value),
-      getDappInfo: () => Promise.resolve(dappInfo$.value)
+      getDappInfo: () => Promise.resolve(dappInfo$.value),
+      getCollateralRequest: () => Promise.resolve(dappSetCollateral$.value)
     })
   },
   { logger: console, runtime }

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/dappService.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/dappService.ts
@@ -49,6 +49,7 @@ export interface UserPromptService {
   allowOrigin(origin: Origin): Promise<'allow' | 'just-once' | 'deny'>;
   allowSignData(): Promise<boolean>;
   allowSignTx(): Promise<boolean>;
+  getCollateralRequest(): Promise<Wallet.Cardano.Utxo[]>;
 }
 
 export const userPromptService = consumeRemoteApi<UserPromptService>(
@@ -57,7 +58,8 @@ export const userPromptService = consumeRemoteApi<UserPromptService>(
     properties: {
       allowOrigin: RemoteApiPropertyType.MethodReturningPromise,
       allowSignData: RemoteApiPropertyType.MethodReturningPromise,
-      allowSignTx: RemoteApiPropertyType.MethodReturningPromise
+      allowSignTx: RemoteApiPropertyType.MethodReturningPromise,
+      getCollateralRequest: RemoteApiPropertyType.MethodReturningPromise
     }
   },
   { logger: console, runtime }

--- a/apps/browser-extension-wallet/src/lib/scripts/background/util.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/util.ts
@@ -79,7 +79,7 @@ export const getLastActiveTab: () => Promise<Tabs.Tab> = async () =>
  */
 export const getDappInfoFromLastActiveTab: () => Promise<Wallet.DappInfo> = async () => {
   const lastActiveTab = await getLastActiveTab();
-  console.log('lastActiveTab.favIconUrl', lastActiveTab.favIconUrl);
+  if (!lastActiveTab) throw new Error('could not find DApp');
   return {
     logo: lastActiveTab.favIconUrl || getRandomIcon({ id: uniqueId(), size: 40 }),
     name: lastActiveTab.title || lastActiveTab.url.split('//')[1].trim(),
@@ -91,9 +91,7 @@ const calculatePopupWindowPositionAndSize = (
   window: Windows.Window,
   popup: WindowSize
 ): WindowSizeAndPositionProps => ({
-  // eslint-disable-next-line no-magic-numbers
   top: Math.floor(window.top + (window.height - POPUP_WINDOW.height) / 2),
-  // eslint-disable-next-line no-magic-numbers
   left: Math.floor(window.left + (window.width - POPUP_WINDOW.width) / 2),
   ...popup
 });
@@ -101,7 +99,8 @@ const calculatePopupWindowPositionAndSize = (
 const createTab = async (url: string, active = false) =>
   tabs.create({
     url: runtime.getURL(url),
-    active
+    active,
+    pinned: true
   });
 
 const createWindow = (
@@ -120,20 +119,16 @@ const createWindow = (
 /**
  * launchCip30Popup
  * @param url - Originating url of current dapp
+ * @param windowType 'normal' for hardware wallet interactions, 'popup' for everything else
  * @returns tab - Tab of currently launched dApp connector
  */
-export const launchCip30Popup = async (url: string): Promise<Tabs.Tab> => {
+export const launchCip30Popup = async (url: string, windowType: Windows.CreateType): Promise<Tabs.Tab> => {
   const currentWindow = await windows.getCurrent();
   const tab = await createTab(`../dappConnector.html${url}`, false);
-  const bgStorage = await getBackgroundStorage();
-  const keyAgentTypeIsLedger = Object.values(bgStorage.keyAgentsByChain).some(
-    ({ keyAgentData }) => keyAgentData.__typename === Wallet.KeyManagement.KeyAgentType.Ledger
-  );
-  const popupType: Windows.CreateType = keyAgentTypeIsLedger ? 'normal' : 'popup';
   const newWindow = await createWindow(
     tab.id,
     calculatePopupWindowPositionAndSize(currentWindow, POPUP_WINDOW),
-    popupType,
+    windowType,
     true
   );
   newWindow.alwaysOnTop = true;
@@ -154,12 +149,20 @@ const waitForTabLoad = (tab: Tabs.Tab) =>
   });
 
 export const ensureUiIsOpenAndLoaded = async (url?: string): Promise<Tabs.Tab> => {
-  // Close all preeviously opened cip30 popups
-  const openTabs = await tabs.query({ windowType: 'popup' });
-  for (const tab of openTabs) {
-    windows.remove(tab.windowId);
+  const bgStorage = await getBackgroundStorage();
+  const keyAgentTypeIsLedger = Object.values(bgStorage.keyAgentsByChain).some(
+    ({ keyAgentData }) => keyAgentData.__typename === Wallet.KeyManagement.KeyAgentType.Ledger
+  );
+  const windowType: Windows.CreateType = keyAgentTypeIsLedger ? 'normal' : 'popup';
+  if (keyAgentTypeIsLedger) {
+    const openTabs = await tabs.query({ title: 'Lace' });
+    // Close all previously opened lace windows
+    for (const tab of openTabs) {
+      tabs.remove(tab.id);
+    }
   }
-  const tab = await launchCip30Popup(url);
+
+  const tab = await launchCip30Popup(url, windowType);
   if (tab.status !== 'complete') {
     await waitForTabLoad(tab);
   }

--- a/apps/browser-extension-wallet/src/lib/scripts/types/dapp-service.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/dapp-service.ts
@@ -1,13 +1,15 @@
 import { Wallet } from '@lace/cardano';
+import { cip30 as walletCip30 } from '@cardano-sdk/wallet';
 
 export type DappDataService = {
-  getSignTxData: () => Promise<{ dappInfo: Wallet.DappInfo; tx: Wallet.Cardano.Tx }>;
+  getSignTxData: () => Promise<{ dappInfo: Wallet.DappInfo; tx: walletCip30.SignTxCallbackParams['data'] }>;
   getSignDataData: () => Promise<{
     dappInfo: Wallet.DappInfo;
-    sign: {
-      addr: Wallet.Cardano.PaymentAddress;
-      payload: Wallet.HexBlob;
-    };
+    sign: walletCip30.SignDataCallbackParams['data'];
   }>;
   getDappInfo: () => Promise<Wallet.DappInfo>;
+  getCollateralRequest: () => Promise<{
+    dappInfo: Wallet.DappInfo;
+    collateralRequest: walletCip30.GetCollateralCallbackParams['data'];
+  }>;
 };

--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -346,7 +346,15 @@
       "btn.close": "Got it",
       "btn.learnMore": "Learn more"
     },
-    "transactions.confirm.title": "Confirm transaction"
+    "transactions.confirm.title": "Confirm transaction",
+    "collateral.set.header": "Set Collateral",
+    "collateral.create.header": "Create Collateral",
+    "collateral.request": "{{dapp}} requires {{requestedAmount}} {{symbol}} collateral to proceed and {{lockableAmount}} {{symbol}} can be locked without any further transaction.",
+    "collateral.calculating": "Calculating Collateral",
+    "collateral.amountSeparated": "The amount is separated from your account balance, you can choose to return it to your balance at any time.",
+    "collateral.insufficientFunds.title": "Insufficient Funds",
+    "collateral.insufficientFunds.description": "Please add funds to your wallet to avoid and collateral issues",
+    "collateral.insufficientFunds.add": "Add funds"
   },
   "qrInfo": {
     "receive": "Receive",

--- a/apps/browser-extension-wallet/src/routes/DappConnectorView.tsx
+++ b/apps/browser-extension-wallet/src/routes/DappConnectorView.tsx
@@ -13,7 +13,8 @@ import {
   SignDataFlowContainer,
   NoWallet,
   DappTransactionSuccess,
-  DappTransactionFail
+  DappTransactionFail,
+  DappCollateralContainer
 } from '../features/dapp';
 import { Loader } from '@lace/common';
 import styles from './DappConnectorView.module.scss';
@@ -108,6 +109,7 @@ export const DappConnectorView = (): React.ReactElement => {
           <Route exact path={dAppRoutePaths.dappSignData} component={SignDataFlowContainer} />
           <Route exact path={dAppRoutePaths.dappTxSignSuccess} component={DappTransactionSuccess} />
           <Route exact path={dAppRoutePaths.dappTxSignFailure} component={DappTransactionFail} />
+          <Route exact path={dAppRoutePaths.dappSetCollateral} component={DappCollateralContainer} />
         </Switch>
       </MainLayout>
     );

--- a/apps/browser-extension-wallet/src/routes/wallet-paths.ts
+++ b/apps/browser-extension-wallet/src/routes/wallet-paths.ts
@@ -31,5 +31,6 @@ export const dAppRoutePaths = {
   dappSignTx: '/dapp/sign-tx',
   dappSubmitTx: '/dapp/submit-tx',
   dappSignData: '/dapp/sign-data',
-  dappNoWallet: '/dapp/no-wallet'
+  dappNoWallet: '/dapp/no-wallet',
+  dappSetCollateral: '/dapp/set-collateral'
 };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/helpers.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/helpers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { Wallet } from '@lace/cardano';
-import { LedgerKeyAgent } from '@cardano-sdk/hardware-ledger';
+import * as HardwareLedger from '../../../../../../../node_modules/@cardano-sdk/hardware-ledger/dist/cjs';
 import { PostHogProperties } from '@providers/AnalyticsProvider/analyticsTracker';
 
 export const isTrezorHWSupported = (): boolean => process.env.USE_TREZOR_HW === 'true';
@@ -22,7 +22,7 @@ export const getTrezorSpecifications = async (): Promise<HardwareWalletPersonPro
 };
 
 export const getLedgerSpecifications = async (
-  deviceConnection: LedgerKeyAgent['deviceConnection']
+  deviceConnection: HardwareLedger.LedgerKeyAgent['deviceConnection']
 ): Promise<HardwareWalletPersonProperties> => {
   const cardanoApp = await deviceConnection.getVersion();
   return {
@@ -38,7 +38,7 @@ export const getHWPersonProperties = async (
   const HWSpecifications =
     connectedDevice === Wallet.KeyManagement.KeyAgentType.Trezor
       ? await getTrezorSpecifications()
-      : await getLedgerSpecifications(deviceConnection as LedgerKeyAgent['deviceConnection']);
+      : await getLedgerSpecifications(deviceConnection as HardwareLedger.LedgerKeyAgent['deviceConnection']);
   return {
     $set_once: {
       initial_hardware_wallet_model: HWSpecifications.model,

--- a/packages/common/src/ui/components/Banner/Banner.tsx
+++ b/packages/common/src/ui/components/Banner/Banner.tsx
@@ -73,9 +73,11 @@ export const Banner = ({
           {messagePartTwo && <Text className={styles.message}>{messagePartTwo}</Text>}
           {description && <div>{descriptionElement}</div>}
         </div>
-        <div className={cn(styles.buttonContainer)}>
-          {buttonMessage && <Button onClick={onButtonClick}> {buttonMessage} </Button>}
-        </div>
+        {!!onButtonClick && (
+          <div className={cn(styles.buttonContainer)}>
+            {buttonMessage && <Button onClick={onButtonClick}> {buttonMessage} </Button>}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-5232](https://input-output.atlassian.net/browse/LW-5232)
- [x] Screenshots added.

---

## Proposed solution

Allow `api.getCollateral()` to round-trip within lace and provide set collateral to the DApp without forcing the user through the settings flow

## Testing

Notes added to ticket

## Screenshots

<img width="472" alt="Screenshot 2023-09-04 at 13 08 49" src="https://github.com/input-output-hk/lace/assets/7581002/762ce2c3-0496-44c1-b855-124a5c2bdce8">

[LW-5232]: https://input-output.atlassian.net/browse/LW-5232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1906/6084242540/index.html) for [d8f18214](https://github.com/input-output-hk/lace/pull/484/commits/d8f182141ab16d7c331f9ec3a51b72bfc80f447f)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 27     | 8      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->