### PR TITLE
fix(staking): check rewardAccounts availability on the Overview page [LW-8215]

### DIFF
--- a/packages/staking/src/features/overview/Overview.tsx
+++ b/packages/staking/src/features/overview/Overview.tsx
@@ -45,7 +45,12 @@ export const Overview = () => {
 
   const totalCoinBalance = balancesBalance?.total?.coinBalance;
 
-  if (!totalCoinBalance || !protocolParameters?.stakeKeyDeposit || !balancesBalance?.available?.coinBalance) {
+  if (
+    !totalCoinBalance ||
+    !protocolParameters?.stakeKeyDeposit ||
+    !balancesBalance?.available?.coinBalance ||
+    !rewardAccounts
+  ) {
     return <Skeleton loading />;
   }
 

--- a/packages/staking/src/features/overview/OverviewPopup.tsx
+++ b/packages/staking/src/features/overview/OverviewPopup.tsx
@@ -31,7 +31,12 @@ export const OverviewPopup = () => {
 
   const totalCoinBalance = balancesBalance?.total?.coinBalance || '0';
 
-  if (!totalCoinBalance || !protocolParameters?.stakeKeyDeposit || !balancesBalance?.available?.coinBalance) {
+  if (
+    !totalCoinBalance ||
+    !protocolParameters?.stakeKeyDeposit ||
+    !balancesBalance?.available?.coinBalance ||
+    !rewardAccounts
+  ) {
     return <Skeleton loading />;
   }
 


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8215

---

## Proposed solution
Ensure that `rewardAccounts` are loaded and available on the Overview page.

## Testing

Reload the app on the staking screen and ensure it doesn't break.

## Screenshots
Before:
![image](https://github.com/input-output-hk/lace/assets/17825044/43b685fb-30f0-4e65-85b5-6566e7bea25d)


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1907/6084320758/index.html) for [b39273f2](https://github.com/input-output-hk/lace/pull/490/commits/b39273f27964077c6ff4f5f112976d9657f8dc93)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 28     | 7      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->