### PR TITLE
Lw 8340 disable legacy staking e2e tests

### DIFF
--- a/packages/e2e-tests/src/assert/emptyStateAssert.ts
+++ b/packages/e2e-tests/src/assert/emptyStateAssert.ts
@@ -22,10 +22,8 @@ class EmptyStateAssert {
   }
 
   async assertSeeEmptyStateStaking() {
-    await expect(await FundWalletBanner.getTitle()).to.equal(await t(tWelcome));
-    await expect(await FundWalletBanner.getSubtitle()).to.equal(
-      await t('browserView.staking.fundWalletBanner.subtitle')
-    );
+    await expect(await FundWalletBanner.getTitle()).to.equal(await t('overview.noFunds.title', 'staking'));
+    await expect(await FundWalletBanner.getSubtitle()).to.equal(await t('overview.noFunds.description', 'staking'));
     await this.assertSeeCommonEmptyStateElements();
   }
 

--- a/packages/e2e-tests/src/elements/staking/MultidelegationPage.ts
+++ b/packages/e2e-tests/src/elements/staking/MultidelegationPage.ts
@@ -166,8 +166,10 @@ class MultidelegationPage {
   }
 
   async confirmBetaModal() {
-    await this.multidelegationBetaModalBtnConfirm.waitForClickable();
-    await this.multidelegationBetaModalBtnConfirm.click();
+    if (await this.multidelegationBetaModalBtnConfirm.isDisplayed()) {
+      await this.multidelegationBetaModalBtnConfirm.waitForClickable();
+      await this.multidelegationBetaModalBtnConfirm.click();
+    }
   }
 }
 

--- a/packages/e2e-tests/src/features/MultidelegationDelegatedFundsPopup.feature
+++ b/packages/e2e-tests/src/features/MultidelegationDelegatedFundsPopup.feature
@@ -5,7 +5,6 @@ Feature: Staking Page - Popup View
   Scenario Outline: Popup View - Delegation card displays correct data
     Given I open wallet: "<walletName>" in: popup mode
     When I navigate to Staking popup page
-    And I confirm multidelegation beta modal
     Then I see Delegation title displayed for multidelegation
     And I see Delegation card displaying correct data
     Examples:

--- a/packages/e2e-tests/src/features/MultidelegationDelegatedFundsPopup.feature
+++ b/packages/e2e-tests/src/features/MultidelegationDelegatedFundsPopup.feature
@@ -4,6 +4,7 @@ Feature: Staking Page - Popup View
   @LW-8330
   Scenario Outline: Popup View - Delegation card displays correct data
     Given I open wallet: "<walletName>" in: popup mode
+    And I disable showing Multidelegation beta banner
     When I navigate to Staking popup page
     Then I see Delegation title displayed for multidelegation
     And I see Delegation card displaying correct data

--- a/packages/e2e-tests/src/features/NavigationMainExtended.feature
+++ b/packages/e2e-tests/src/features/NavigationMainExtended.feature
@@ -28,7 +28,7 @@ Feature: Main Navigation - Extended view
   @LW-2696 @Smoke
   Scenario: Extended view - Main Navigation - Staking item click navigates to staking page
     When I navigate to Staking extended page
-    Then I see Staking title and counter with total number of pools displayed
+    Then I see Delegation title displayed for multidelegation
 
   @LW-2606
   Scenario Outline: Extended view - Click Lace logo - <section>
@@ -41,7 +41,7 @@ Feature: Main Navigation - Extended view
       | Tokens       | I see Tokens counter with total number of tokens displayed           |
       | NFTs         | I see NFTs counter with total number of NFTs displayed               |
       | Transactions | Transactions section is displayed                                    |
-      | Staking      | I see Staking title and counter with total number of pools displayed |
+      | Staking      | I see Delegation title displayed for multidelegation                 |
       | Settings     | I see settings page                                                  |
       | Address Book | I see address book title                                             |
 

--- a/packages/e2e-tests/src/features/NavigationMainPopup.feature
+++ b/packages/e2e-tests/src/features/NavigationMainPopup.feature
@@ -27,7 +27,7 @@ Feature: Main Navigation - Popup View
   @LW-2691
   Scenario: Popup View - Main Navigation - Staking item click navigates to staking page
     When I navigate to Staking popup page
-    Then I see Staking title and counter with total number of pools displayed
+    Then I see Delegation title displayed for multidelegation
 
   @LW-2610
   Scenario Outline: Extended view - Click Lace logo - <section>
@@ -41,7 +41,7 @@ Feature: Main Navigation - Popup View
       | Tokens       | I see Tokens counter with total number of tokens displayed |
       | NFTs         | I see NFTs counter with total number of NFTs displayed     |
       | Transactions | Transactions section is displayed                          |
-      | Staking      | I see Staking title displayed                              |
+      | Staking      | I see Delegation title displayed for multidelegation       |
       | Settings     | I see settings page                                        |
       | Address Book | I see address book title                                   |
 

--- a/packages/e2e-tests/src/features/StakingPageDelegatedFundsExtended.feature
+++ b/packages/e2e-tests/src/features/StakingPageDelegatedFundsExtended.feature
@@ -1,4 +1,4 @@
-@Staking-DelegatedFunds-Extended @Testnet @Mainnet
+@Staking-DelegatedFunds-Extended @Testnet @Mainnet @Pending
 Feature: Staking Page - Funds already delegated - Extended Browser View
 
   Background:

--- a/packages/e2e-tests/src/features/StakingPageDelegatedFundsPopup.feature
+++ b/packages/e2e-tests/src/features/StakingPageDelegatedFundsPopup.feature
@@ -1,4 +1,4 @@
-@Staking-DelegatedFunds-Popup @Testnet @Mainnet
+@Staking-DelegatedFunds-Popup @Testnet @Mainnet @Pending
 Feature: Staking Page - Funds already delegated - Popup View
 
   Background:

--- a/packages/e2e-tests/src/features/StakingPageExtended.feature
+++ b/packages/e2e-tests/src/features/StakingPageExtended.feature
@@ -1,4 +1,4 @@
-@Staking-NonDelegatedFunds-Extended
+@Staking-NonDelegatedFunds-Extended @Pending
 Feature: Staking Page - Extended Browser View
 
   Background:

--- a/packages/e2e-tests/src/features/StakingPagePopup.feature
+++ b/packages/e2e-tests/src/features/StakingPagePopup.feature
@@ -1,4 +1,4 @@
-@Staking-Popup @Testnet @Mainnet
+@Staking-Popup @Testnet @Mainnet @Pending
 Feature: Staking Page - Popup View
 
   Background:

--- a/packages/e2e-tests/src/features/analytics/AnalyticsStakingExtended.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsStakingExtended.feature
@@ -1,4 +1,4 @@
-@Staking-SwitchingPools-Extended-E2E @Testnet
+@Analytics-Staking-SwitchingPools-Extended-E2E @Testnet @Pending
 Feature: Analytics - Posthog - Switching pools - Extended View
 
   Background:

--- a/packages/e2e-tests/src/features/analytics/AnalyticsStakingPopup.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsStakingPopup.feature
@@ -1,4 +1,4 @@
-@Staking-SwitchingPools-Popup-E2E @Testnet @Pending
+@Analytics-Staking-SwitchingPools-Popup-E2E @Testnet @Pending
 Feature: Analytics - Posthog - Switching pools - Popup View
 
   Background:

--- a/packages/e2e-tests/src/features/e2e/MultidelegationSwitchingPoolsExtendedE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/MultidelegationSwitchingPoolsExtendedE2E.feature
@@ -4,9 +4,8 @@ Feature: Staking Page - Switching pools - Extended Browser View - E2E
   Background:
     Given Wallet is synced
     And I navigate to Staking extended page
-    And I confirm multidelegation beta modal
 
-  @LW-7819 @Testnet @Pending
+  @LW-7819 @Testnet
   Scenario Outline: Extended View - Multidelegation - Delegate to multiple pools E2E
     When I click Overview tab
     And I wait until delegation info card shows staking to "<pools_before>" pool(s)
@@ -25,9 +24,9 @@ Feature: Staking Page - Switching pools - Extended Browser View - E2E
     And I click Overview tab
     Then I wait until delegation info card shows staking to "<pools_after>" pool(s)
     Examples:
-      | pools_before | pools_after | pools_names                                        | tx_type         |
-      | 1            | 2           | ADA Capital, 8BETA                                 | Delegation      |
-      | 2            | 3           | ADA Capital, 8BETA, Boople Turtle Pool             | Delegation      |
-      | 3            | 4           | ADA Capital, 8BETA, Boople Turtle Pool, ADV        | Delegation      |
-      | 4            | 5           | ADA Capital, 8BETA, Boople Turtle Pool, ADV, BAZAR | Delegation      |
-      | 5            | 1           | ADA Capital                                        | De-Registration |
+      | pools_before | pools_after | pools_names                                        | tx_type                   |
+      | 1            | 2           | ADA Capital, 8BETA                                 | Delegation                |
+      | 2            | 3           | ADA Capital, 8BETA, Boople Turtle Pool             | Delegation                |
+      | 3            | 4           | ADA Capital, 8BETA, Boople Turtle Pool, ADV        | Delegation                |
+      | 4            | 5           | ADA Capital, 8BETA, Boople Turtle Pool, ADV, BAZAR | Delegation                |
+      | 5            | 1           | ADA Capital                                        | Stake Key De-Registration |

--- a/packages/e2e-tests/src/features/e2e/MultidelegationSwitchingPoolsExtendedE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/MultidelegationSwitchingPoolsExtendedE2E.feature
@@ -3,6 +3,7 @@ Feature: Staking Page - Switching pools - Extended Browser View - E2E
 
   Background:
     Given Wallet is synced
+    And I disable showing Multidelegation beta banner
     And I navigate to Staking extended page
 
   @LW-7819 @Testnet

--- a/packages/e2e-tests/src/features/e2e/StakingInitialFundsE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/StakingInitialFundsE2E.feature
@@ -1,4 +1,4 @@
-@Staking-initial-E2E @Testnet
+@Staking-initial-E2E @Testnet @Pending
 Feature: Delegating funds to new pool E2E
 
   @LW-2685 @Smoke

--- a/packages/e2e-tests/src/features/e2e/StakingSwitchingPoolsExtendedE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/StakingSwitchingPoolsExtendedE2E.feature
@@ -1,4 +1,4 @@
-@Staking-SwitchingPools-Extended-E2E @Testnet
+@Staking-SwitchingPools-Extended-E2E @Testnet @Pending
 Feature: Staking Page - Switching pools - Extended Browser View - E2E
 
   Background:

--- a/packages/e2e-tests/src/features/e2e/StakingSwitchingPoolsPopupE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/StakingSwitchingPoolsPopupE2E.feature
@@ -1,4 +1,4 @@
-@Staking-SwitchingPools-Popup-E2E @Testnet
+@Staking-SwitchingPools-Popup-E2E @Testnet @Pending
 Feature: Staking Page - Switching pools - Popup View - E2E
 
   Background:

--- a/packages/e2e-tests/src/pageobject/mainMenuPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/mainMenuPageObject.ts
@@ -1,6 +1,7 @@
 import MenuMainPopup from '../elements/menuMainPopup';
 import MenuMainExtended from '../elements/menuMainExtended';
 import menuHeaderPageObject from './menuHeaderPageObject';
+import MultidelegationPage from '../elements/staking/MultidelegationPage';
 
 class MainMenuPageObject {
   tokens = async (mode: 'extended' | 'popup') =>
@@ -25,6 +26,7 @@ class MainMenuPageObject {
         break;
       case 'Staking':
         await this.staking(mode);
+        await MultidelegationPage.confirmBetaModal();
         break;
       case 'Address Book':
         await menuHeaderPageObject.openAddressBook();

--- a/packages/e2e-tests/src/pageobject/mainMenuPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/mainMenuPageObject.ts
@@ -1,7 +1,6 @@
 import MenuMainPopup from '../elements/menuMainPopup';
 import MenuMainExtended from '../elements/menuMainExtended';
 import menuHeaderPageObject from './menuHeaderPageObject';
-import MultidelegationPage from '../elements/staking/MultidelegationPage';
 
 class MainMenuPageObject {
   tokens = async (mode: 'extended' | 'popup') =>
@@ -26,7 +25,6 @@ class MainMenuPageObject {
         break;
       case 'Staking':
         await this.staking(mode);
-        await MultidelegationPage.confirmBetaModal();
         break;
       case 'Address Book':
         await menuHeaderPageObject.openAddressBook();

--- a/packages/e2e-tests/src/steps/commonSteps.ts
+++ b/packages/e2e-tests/src/steps/commonSteps.ts
@@ -247,3 +247,7 @@ When(/^I set (light|dark) theme mode in Local Storage$/, async (mode: 'light' | 
   await localStorageInitializer.initializeMode(mode);
   await browser.refresh();
 });
+
+Given(/^I disable showing Multidelegation beta banner$/, async () => {
+  await localStorageManager.setItem('multidelegationFirstVisit', 'false');
+});


### PR DESCRIPTION
# Checklist

- [JIRA LW-8340](https://input-output.atlassian.net/browse/LW-8340)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution
- Disabling single staking tests
- Fixing empty state tests for staking
- Fixing navigation tests for staking
- Enable Multidelegation e2e test

Regression results before fix [here](https://dq4ajm5i5q7bz.cloudfront.net/linux/chrome/288/index.html#)
Regression results after fix [here](https://dq4ajm5i5q7bz.cloudfront.net/linux/chrome/295/index.html#)

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1927/6095475394/index.html) for [8305d488](https://github.com/input-output-hk/lace/pull/492/commits/8305d488489423781d8116378ac6eec7d0e62208)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 2      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->