### PR TITLE
Fix/missing send flow events popup

### DIFF
--- a/apps/browser-extension-wallet/src/features/nfts/components/NftDetail.tsx
+++ b/apps/browser-extension-wallet/src/features/nfts/components/NftDetail.tsx
@@ -9,12 +9,13 @@ import { nftDetailSelector } from '@src/views/browser-view/features/nfts/selecto
 import { NftDetail as NftDetailView } from '@lace/core';
 import { Wallet } from '@lace/cardano';
 import { useTranslation } from 'react-i18next';
-import { useOutputInitialState } from '@src/views/browser-view/features/send-transaction';
+import { SendFlowTriggerPoints, useOutputInitialState } from '@src/views/browser-view/features/send-transaction';
 import { DEFAULT_WALLET_BALANCE, SEND_NFT_DEFAULT_AMOUNT } from '@src/utils/constants';
 import {
   MatomoEventActions,
   MatomoEventCategories,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { useAnalyticsContext } from '@providers';
 import { buttonIds } from '@hooks/useEnterKeyPress';
@@ -48,6 +49,8 @@ export const NftDetail = (): React.ReactElement => {
       action: MatomoEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.ViewNFTs.SEND_NFT_POPUP
     });
+    // eslint-disable-next-line camelcase
+    analytics.sendEventToPostHog(PostHogAction.SendClick, { trigger_point: SendFlowTriggerPoints.NFTS });
     setSendInitialState(id, SEND_NFT_DEFAULT_AMOUNT);
     redirectToSend({ params: { id } });
   };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetsPortfolio/AssetsPortfolio.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetsPortfolio/AssetsPortfolio.tsx
@@ -22,6 +22,7 @@ import {
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import styles from './AssetsPortfolio.module.scss';
 import BigNumber from 'bignumber.js';
+import { SendFlowTriggerPoints } from '../../../send-transaction';
 
 const MINUTES_UNTIL_WARNING_BANNER = 3;
 
@@ -74,7 +75,8 @@ export const AssetsPortfolio = ({
       action: MatomoEventActions.CLICK_EVENT,
       name: AnalyticsEventNames.SendTransaction.SEND_TX_BUTTON_POPUP
     });
-    analytics.sendEventToPostHog(PostHogAction.SendClick);
+    // eslint-disable-next-line camelcase
+    analytics.sendEventToPostHog(PostHogAction.SendClick, { trigger_point: SendFlowTriggerPoints.SEND_BUTTON });
     redirectToSend({ params: { id: '1' } });
   };
 


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-8347](https://input-output.atlassian.net/browse/LW-8347) | [LW-8348](https://input-output.atlassian.net/browse/LW-8348)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR adds missing post hog properties and events to send flow on popup view

3733dede56d4edb507ac96171a204eef58f611d3 adds `send | send | click` event to send button in NFT details drawer popup view
3c06d54dfc24d6f8f52e68728a72221ae7f84bf0 adds `trigger_point` property to `send | send | click` event on send button popup view



[LW-8347]: https://input-output.atlassian.net/browse/LW-8347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LW-8348]: https://input-output.atlassian.net/browse/LW-8348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1919/6088440107/index.html) for [3c06d54d](https://github.com/input-output-hk/lace/pull/495/commits/3c06d54dfc24d6f8f52e68728a72221ae7f84bf0)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 27     | 8      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->