### PR TITLE
fix: center align side-drawer header text when back button is absent

### DIFF
--- a/packages/ui/src/design-system/side-drawer/side-drawer-content-header.component.tsx
+++ b/packages/ui/src/design-system/side-drawer/side-drawer-content-header.component.tsx
@@ -27,14 +27,20 @@ export const Header = ({
       justifyContent="space-between"
     >
       {onBackClick !== undefined && (
-        <NavigationButtons.Back onClick={onBackClick} />
+        <Flex w="$40">
+          <NavigationButtons.Back onClick={onBackClick} />
+        </Flex>
       )}
-      <Typography.Body.Large weight="$bold" className={cx.text}>
-        {text}
-      </Typography.Body.Large>
-      <Close>
-        <NavigationButtons.Close onClick={onCloseClick} />
-      </Close>
+      <Flex justifyContent="center" w="$fill">
+        <Typography.Body.Large weight="$bold" className={cx.text}>
+          {text}
+        </Typography.Body.Large>
+      </Flex>
+      <Flex w="$40">
+        <Close>
+          <NavigationButtons.Close onClick={onCloseClick} />
+        </Close>
+      </Flex>
     </Flex>
     <Box mb="$32">
       <Separator />


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7549
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

When the back button is not available, Align contents using flexbox

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

#### Before

<img width="680" alt="Screenshot 2023-09-05 at 21 53 59" src="https://github.com/input-output-hk/lace/assets/48496855/046e69a5-9f69-4078-9cb1-111d464046a8">

#### After

<img width="682" alt="Screenshot 2023-09-06 at 09 46 58" src="https://github.com/input-output-hk/lace/assets/48496855/5ac8e982-da3d-4871-ac81-2e96be6afbb4">


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1923/6089840498/index.html) for [da81ef4d](https://github.com/input-output-hk/lace/pull/497/commits/da81ef4d3d04504deffd4d58dd922604f65c97c1)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 28     | 7      | 0       | 0     | 35    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->