### PR TITLE
test(extension): e2e - add test for ada handle nft folders

### DIFF
--- a/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
+++ b/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
@@ -108,6 +108,32 @@ class NftCreateFolderAssert {
     expect(ownedNftNames).to.have.ordered.members(displayedNftNames);
   }
 
+  async verifySeeAllAdaHandles() {
+    const ownedAdaHandleNames: string[] = testContext.load('displayedAdaHandleNames');
+    const displayedNfts = await new TokenSelectionPage().nftContainers;
+
+    const displayedAdaHandleNames: string[] = [];
+    for (const nftContainer of displayedNfts) {
+      displayedAdaHandleNames.push(await nftContainer.getText());
+    }
+    expect(ownedAdaHandleNames).to.have.all.members(displayedAdaHandleNames);
+  }
+
+  async verifySeeAllAdaImages() {
+    const adaHandleImages: string[] = testContext.load('displayedAdaHandleImages');
+    const displayedAdaHandleImages = await new TokenSelectionPage().nftImages;
+
+    for (const displayedAdaHandleImage of displayedAdaHandleImages) {
+      displayedAdaHandleImage.waitForDisplayed();
+    }
+
+    const displayedAdaHandleImagesSrc: string[] = await new TokenSelectionPage().nftImages.map(
+      async (item) => await item.getAttribute('src')
+    );
+
+    expect(displayedAdaHandleImagesSrc).to.have.all.members(adaHandleImages);
+  }
+
   async verifyNoneNftIsSelected() {
     await new TokenSelectionPage().nftItemSelectedCheckmark.waitForDisplayed({ reverse: true });
   }

--- a/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
+++ b/packages/e2e-tests/src/assert/nftCreateFolderAssert.ts
@@ -124,7 +124,7 @@ class NftCreateFolderAssert {
     const displayedAdaHandleImages = await new TokenSelectionPage().nftImages;
 
     for (const displayedAdaHandleImage of displayedAdaHandleImages) {
-      displayedAdaHandleImage.waitForDisplayed();
+      await displayedAdaHandleImage.waitForDisplayed();
     }
 
     const displayedAdaHandleImagesSrc: string[] = await new TokenSelectionPage().nftImages.map(

--- a/packages/e2e-tests/src/assert/walletAddressPageAssert.ts
+++ b/packages/e2e-tests/src/assert/walletAddressPageAssert.ts
@@ -3,6 +3,7 @@ import { WalletConfig } from '../support/walletConfiguration';
 import { t } from '../utils/translationService';
 import { expect } from 'chai';
 import extensionUtils from '../utils/utils';
+import testContext from '../utils/testContext';
 
 class WalletAddressPageAssert {
   async assertSeeWalletAddressPage(mode: 'extended' | 'popup') {
@@ -34,6 +35,23 @@ class WalletAddressPageAssert {
     const address = String(extensionUtils.isMainnet() ? wallet.mainnetAddress : wallet.address);
     const expectedAddress = mode === 'extended' ? address : `${address.slice(0, 7)}...${address.slice(-8)}`;
     await expect(await WalletAddressPage.walletAddress.getText()).to.equal(expectedAddress);
+  }
+
+  async getSrc(item) {
+    return await item.$('img').getAttribute('src');
+  }
+  async assertSeeAdaHandle() {
+    const displayedAdaHandleNames: string[] = [];
+    let displayedAdaHandleImages: string[] = [];
+    const displayedAdaHandleNamesElementArray = await WalletAddressPage.addressCardHandleName;
+    displayedAdaHandleImages = await WalletAddressPage.addressCardHandleImage.map(this.getSrc);
+
+    for (const displayedAdaHandleNamesElement of displayedAdaHandleNamesElementArray) {
+      await displayedAdaHandleNamesElement.waitForDisplayed();
+      displayedAdaHandleNames.push(await displayedAdaHandleNamesElement.getText());
+    }
+    testContext.save('displayedAdaHandleNames', displayedAdaHandleNames);
+    testContext.save('displayedAdaHandleImages', displayedAdaHandleImages);
   }
 }
 

--- a/packages/e2e-tests/src/assert/walletAddressPageAssert.ts
+++ b/packages/e2e-tests/src/assert/walletAddressPageAssert.ts
@@ -43,9 +43,8 @@ class WalletAddressPageAssert {
   }
   async assertSeeAdaHandle() {
     const displayedAdaHandleNames: string[] = [];
-    let displayedAdaHandleImages: string[] = [];
     const displayedAdaHandleNamesElementArray = await WalletAddressPage.addressCardHandleName;
-    displayedAdaHandleImages = await WalletAddressPage.addressCardHandleImage.map(this.getSrc);
+    const displayedAdaHandleImages = await WalletAddressPage.addressCardHandleImage.map(this.getSrc);
 
     for (const displayedAdaHandleNamesElement of displayedAdaHandleNamesElementArray) {
       await displayedAdaHandleNamesElement.waitForDisplayed();

--- a/packages/e2e-tests/src/assert/walletAddressPageAssert.ts
+++ b/packages/e2e-tests/src/assert/walletAddressPageAssert.ts
@@ -37,8 +37,9 @@ class WalletAddressPageAssert {
     await expect(await WalletAddressPage.walletAddress.getText()).to.equal(expectedAddress);
   }
 
-  async getSrc(item) {
-    return await item.$('img').getAttribute('src');
+  // eslint-disable-next-line no-undef
+  async getSrc(item: WebdriverIO.Element) {
+    return item.$('img').getAttribute('src');
   }
   async assertSeeAdaHandle() {
     const displayedAdaHandleNames: string[] = [];

--- a/packages/e2e-tests/src/elements/newTransaction/tokenSelectionPage.ts
+++ b/packages/e2e-tests/src/elements/newTransaction/tokenSelectionPage.ts
@@ -22,6 +22,7 @@ export class TokenSelectionPage extends WebElement {
   private CLEAR_BUTTON = '[data-testid="clear-button"]';
   private SELECT_MULTIPLE_BUTTON = '[data-testid="select-multiple-button"]';
   private ADD_TO_TRANSACTION_BUTTON = '[data-testid="add-to-transaction-button"]';
+  private NFT_IMAGE = '[data-testid="nft-image"]';
 
   constructor() {
     super();
@@ -29,6 +30,10 @@ export class TokenSelectionPage extends WebElement {
 
   get tokensButton(): ChainablePromiseElement<WebdriverIO.Element> {
     return $(this.TOKENS_BUTTON).parentElement().parentElement();
+  }
+
+  get nftImages() {
+    return this.assetSelectorContainer.$$(this.NFT_IMAGE);
   }
 
   tokenItem(): WebElement {

--- a/packages/e2e-tests/src/elements/walletAddressPage.ts
+++ b/packages/e2e-tests/src/elements/walletAddressPage.ts
@@ -1,4 +1,5 @@
 import CommonDrawerElements from './CommonDrawerElements';
+import { ChainablePromiseArray } from 'webdriverio/build/types';
 
 class WalletAddressPage extends CommonDrawerElements {
   private ADDRESS_CARD = '[data-testid="address-card"]';
@@ -17,7 +18,8 @@ class WalletAddressPage extends CommonDrawerElements {
     return $$(this.ADDRESS_CARD_HANDLE_NAME);
   }
 
-  get addressCardHandleImage() {
+  // eslint-disable-next-line no-undef
+  get addressCardHandleImage(): ChainablePromiseArray<WebdriverIO.ElementArray> {
     return $$(this.ADDRESS_CARD_HANDLE_IMAGE);
   }
 

--- a/packages/e2e-tests/src/elements/walletAddressPage.ts
+++ b/packages/e2e-tests/src/elements/walletAddressPage.ts
@@ -6,9 +6,19 @@ class WalletAddressPage extends CommonDrawerElements {
   private WALLET_NAME = '[data-testid="address-card-name"]';
   private WALLET_ADDRESS = '[data-testid="address-card-address"]';
   private COPY_BUTTON = '[data-testid="copy-address-btn"]';
+  private ADDRESS_CARD_HANDLE_NAME = '[data-testid="address-card-handle-name"]';
+  private ADDRESS_CARD_HANDLE_IMAGE = '[data-testid="address-card-handle-image"]';
 
   get addressCard() {
     return $(this.ADDRESS_CARD);
+  }
+
+  get addressCardHandleName() {
+    return $$(this.ADDRESS_CARD_HANDLE_NAME);
+  }
+
+  get addressCardHandleImage() {
+    return $$(this.ADDRESS_CARD_HANDLE_IMAGE);
   }
 
   get qrCode() {

--- a/packages/e2e-tests/src/features/AdaHandleExtended.feature
+++ b/packages/e2e-tests/src/features/AdaHandleExtended.feature
@@ -1,6 +1,10 @@
 @AdaHandle-extended @Testnet
 Feature: ADA handle - extended view
 
+  Background:
+    Given Wallet is synced
+    And all NFT folders are removed
+
   @LW-7331
   Scenario: Extended view - Add a valid ADA handle to the address book
     Given I am on Address Book extended page
@@ -55,3 +59,31 @@ Feature: ADA handle - extended view
     Then Green tick icon is displayed next to ADA handle
     And I click "Done" button on "Edit address" drawer
     And I see a toast with message: "addressBook.errors.givenAddressAlreadyExist"
+
+  @LW-7428
+  Scenario: Extended View - Validate custom image from a handle on the "Select NFT" (folder) screen
+      Given I navigate to NFTs extended page
+      And I click "Receive" button on page header
+      And I see handle listed on the "Receive" screen
+      And I close the drawer by clicking close button
+      And I navigate to NFTs extended page
+      And I click "Create folder" button on NFTs page
+      And I enter a folder name "Sample NFT folder" into "Folder name" input
+      And I click "Next" button on "Name your folder" page
+      Then I can see the handle listed on the "Select NFT" screen
+      And the corresponding custom image is displayed
+
+  @LW-7429
+  Scenario: Extended View - Validate custom image from a handle on the NFT folder
+    Given I navigate to NFTs extended page
+    And I click "Receive" button on page header
+    And I see handle listed on the "Receive" screen
+    And I close the drawer by clicking close button
+    And I navigate to NFTs extended page
+    And I create folder with name: "Ada Handle folder" that contains 4 NFTs
+    When I left click on the NFT folder with name "Ada Handle folder"
+    Then I see "Ada Handle folder" NFT folder page in extended mode
+    And I see NFT with name "$test_handle_1" on the NFT folder page
+    And I see NFT with name "$test_handle_2" on the NFT folder page
+    And I see NFT with name "$test_handle_3" on the NFT folder page
+    And I see NFT with name "$t_h_1" on the NFT folder page

--- a/packages/e2e-tests/src/features/AdaHandlePopup.feature
+++ b/packages/e2e-tests/src/features/AdaHandlePopup.feature
@@ -1,6 +1,10 @@
 @AdaHandle-popup @Testnet
 Feature: ADA handle - popup view
 
+  Background:
+    Given Wallet is synced
+    And all NFT folders are removed
+
   @LW-7332
   Scenario: Popup view - Add a valid ADA handle to the address book
     Given I am on Address Book popup page
@@ -55,3 +59,29 @@ Feature: ADA handle - popup view
     Then Green tick icon is displayed next to ADA handle
     And I click "Done" button on "Edit address" drawer
     And I see a toast with message: "addressBook.errors.givenAddressAlreadyExist"
+
+  @LW-7433
+  Scenario: Popup View - Validate custom image from a handle on the "Select NFT" (folder) screen
+    Given I click "Receive" button on Tokens page in popup mode
+    And I see handle listed on the "Receive" screen
+    And I close the drawer by clicking close button
+    And I navigate to NFTs popup page
+    And I click "Create folder" button on NFTs page
+    And I enter a folder name "Ada Handle folder" into "Folder name" input
+    When I click "Next" button on "Name your folder" page
+    Then I can see the handle listed on the "Select NFT" screen
+    And the corresponding custom image is displayed
+
+  @LW-7434
+  Scenario: Popup View - Validate custom image from a handle on the NFT folder
+    Given I click "Receive" button on Tokens page in popup mode
+    And I see handle listed on the "Receive" screen
+    And I close the drawer by clicking close button
+    And I navigate to NFTs popup page
+    And I create folder with name: "Ada Handle folder" that contains 4 NFTs
+    When I left click on the NFT folder with name "Ada Handle folder"
+    Then I see "Ada Handle folder" NFT folder page in popup mode
+    And I see NFT with name "$test_handle_1" on the NFT folder page
+    And I see NFT with name "$test_handle_2" on the NFT folder page
+    And I see NFT with name "$test_handle_3" on the NFT folder page
+    And I see NFT with name "$t_h_1" on the NFT folder page

--- a/packages/e2e-tests/src/steps/navigationTopSteps.ts
+++ b/packages/e2e-tests/src/steps/navigationTopSteps.ts
@@ -4,6 +4,7 @@ import menuHeaderPageObject from '../pageobject/menuHeaderPageObject';
 import menuHeaderNetwork from '../elements/menuHeaderNetwork';
 import MenuHeader from '../elements/menuHeader';
 import { browser } from '@wdio/globals';
+import walletAddressPageAssert from '../assert/walletAddressPageAssert';
 
 When(/I click the menu button/, async () => {
   await menuHeaderPageObject.clickMenuButton();
@@ -128,6 +129,10 @@ When(/^I click "(Receive|Send)" button on page header$/, async (button: 'Receive
     default:
       throw new Error(`Unsupported button name: ${button}`);
   }
+});
+
+When(/^I see handle listed on the "Receive" screen$/, async () => {
+  await walletAddressPageAssert.assertSeeAdaHandle();
 });
 
 Then(/^I (see|do not see) a button to open the right side panel$/, async (shouldSee: 'see' | 'do not see') => {

--- a/packages/e2e-tests/src/steps/nftFoldersSteps.ts
+++ b/packages/e2e-tests/src/steps/nftFoldersSteps.ts
@@ -100,6 +100,14 @@ Then(/^"Select NFTs" page is showing all NFTs that I have$/, async () => {
   await nftCreateFolderAssert.verifySeeAllOwnedNfts();
 });
 
+Then(/^I can see the handle listed on the "Select NFT" screen$/, async () => {
+  await nftCreateFolderAssert.verifySeeAllAdaHandles();
+});
+
+Then(/^the corresponding custom image is displayed$/, async () => {
+  await nftCreateFolderAssert.verifySeeAllAdaImages();
+});
+
 Then(/^No NFT is selected$/, async () => {
   await nftCreateFolderAssert.verifyNoneNftIsSelected();
 });


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1959/6110658771/index.html) for [d680a4b4](https://github.com/input-output-hk/lace/pull/498/commits/d680a4b455ecd9494c7f6acc05eee68e8b3b5bdc)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->