### PR TITLE
fix: lw-8342 lace takes null for not existent handles

### DIFF
--- a/apps/browser-extension-wallet/src/utils/validators/address-book.ts
+++ b/apps/browser-extension-wallet/src/utils/validators/address-book.ts
@@ -20,7 +20,7 @@ export const verifyHandle = async (
 ): Promise<ValidationResult & { handles?: HandleResolution[] }> => {
   try {
     const resolvedHandles = await handleResolver.resolveHandles({ handles: [value.slice(1)] });
-    if (resolvedHandles.length === 0) {
+    if (resolvedHandles.length === 0 || resolvedHandles === null) {
       return { valid: false };
     }
     return { valid: true, handles: resolvedHandles };


### PR DESCRIPTION
# Checklist

- [x] JIRA - lw-8342
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution
We are handling a resolution of `null` from the SDK on handles, as a handle not found. 

## Testing
Currently test that nothing has changed when validating handles at the time of sending a transaction or adding a handle to the address book. 
In the future, make sure it works when the new TypeOrm starts being used. 

## Screenshots
N/A. 


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1956/6108223611/index.html) for [be56e655](https://github.com/input-output-hk/lace/pull/500/commits/be56e655bb67de9b954a71bd68d996e9a3fac3b4)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->