### PR TITLE
test(extension): disable showing multidelegation beta banner for lw-3446

### DIFF
--- a/packages/e2e-tests/src/features/FullExperiencePopup.feature
+++ b/packages/e2e-tests/src/features/FullExperiencePopup.feature
@@ -12,7 +12,8 @@ Feature: Full experience - popup view
 
   @LW-3446
   Scenario Outline: Popup View - <page> opened - "Expand" button click
-    Given I am on <page> popup page
+    Given I disable showing Multidelegation beta banner
+    And I am on <page> popup page
     When I click on "Expand" button
     Then the <page> page is displayed on a new tab in extended view
     Examples:


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution
Disable showing multidelegation beta banner for lw-3446

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1952/6107355784/index.html) for [26011a6c](https://github.com/input-output-hk/lace/pull/503/commits/26011a6c6751238a48f7b36bfdc750713e5bbfdf)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->