### PR TITLE
fix(ci): cherry pick labeler job fix for release 1.5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,13 +5,15 @@ browser:
   - any: ['apps/browser-extension-wallet/**/*']
 # Staking
 staking:
-  - any: ['packages/staking/**/*', '.github/workflows/packages-staking.yml']
+  - any: ['packages/staking/**/*']
+  - any: ['.github/workflows/packages-staking.yml']
+
 # UI Toolkit
 ui-toolkit:
   - any: ['packages/ui/**/*']
 # E2E
 e2e:
-  - any: ['features/**/*', 'packages/e2e-tests/**/*']
+  - any: ['packages/e2e-tests/**/*']
 # Docs
 documentation:
   - any: ['docs/**/*', '**/*.md']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,10 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/labeler@v4
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           sync-labels: true
+          dot: true
+


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Labeler job is ran based on its config on the target branch, as explained in docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target Cherry pick labeler fix from main branch to make labeler job work also for the current release branch, see original PR for context: #465 


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1953/6107473403/index.html) for [306f4b78](https://github.com/input-output-hk/lace/pull/504/commits/306f4b78db03439a06cf7a59b9f2f232da973211)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 28     | 4      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->