### PR TITLE
fix(staking): fix translation key for the old staking flow (confirmation summary) [LW-8368]

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolDetails/StakePoolConfirmation.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolDetails/StakePoolConfirmation.tsx
@@ -149,7 +149,9 @@ export const StakePoolConfirmation = ({ popupView }: StakePoolConfirmationProps)
 
           {popupView && <div className={styles.divider} />}
 
-          <h1 className={styles.totalCostTitle}>{t('browserView.staking.details.confirmation.totalCost.title')}</h1>
+          <h1 className={styles.totalCostTitle}>
+            {t('browserView.staking.details.confirmation.transactionCost.title')}
+          </h1>
           <div className={styles.txCostContainer} data-testid="summary-fee-container">
             {deposit && (
               <RowContainer>


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8368
- [x] Screenshots added.

---

## Proposed solution
Fix the translation key for the old staking flow:
`browserView.staking.details.confirmation.totalCost.title`
⬇️
`browserView.staking.details.confirmation.transactionCost.title`

## Testing
Please ensure that the text is rendered properly.

## Screenshots
Before:
![image](https://github.com/input-output-hk/lace/assets/17825044/0db9038c-e07a-4b77-81b4-a6fb1a565e4b)

After:
<img width="632" alt="image" src="https://github.com/input-output-hk/lace/assets/17825044/dcf930c7-c0f1-4b20-8d4f-dcefc255ee30">



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1957/6109045932/index.html) for [81cd4b7d](https://github.com/input-output-hk/lace/pull/506/commits/81cd4b7d49e9f82d17e5eda99aed861046e0d79e)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->