### PR TITLE
Fix/cip30 popups

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
@@ -28,7 +28,7 @@ const dappSetCollateral$ = new BehaviorSubject<{
   collateralRequest: walletCip30.GetCollateralCallbackParams['data'];
 }>(undefined);
 
-const getHostname = (url: string): URL['hostname'] => new URL(url).hostname;
+const getOrigin = (url: string): URL['hostname'] => new URL(url).origin;
 
 export const confirmationCallback: walletCip30.CallbackConfirmation = {
   submitTx: async () =>
@@ -40,7 +40,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
   signTx: pDebounce(async (args) => {
     try {
       const { logo, name, url } = await getDappInfoFromLastActiveTab();
-      dappSignTxData$.next({ dappInfo: { logo, name, url: getHostname(url) }, tx: args.data });
+      dappSignTxData$.next({ dappInfo: { logo, name, url: getOrigin(url) }, tx: args.data });
       await ensureUiIsOpenAndLoaded('#/dapp/sign-tx');
 
       return userPromptService.allowSignTx();
@@ -54,7 +54,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
   signData: pDebounce(async (args) => {
     try {
       const { logo, name, url } = await getDappInfoFromLastActiveTab();
-      dappSignData$.next({ dappInfo: { logo, name, url: getHostname(url) }, sign: args.data });
+      dappSignData$.next({ dappInfo: { logo, name, url: getOrigin(url) }, sign: args.data });
       await ensureUiIsOpenAndLoaded('#/dapp/sign-data');
 
       return userPromptService.allowSignData();
@@ -68,7 +68,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
   getCollateral: pDebounce(async (args) => {
     try {
       const { logo, name, url } = await getDappInfoFromLastActiveTab();
-      dappSetCollateral$.next({ dappInfo: { logo, name, url: getHostname(url) }, collateralRequest: args.data });
+      dappSetCollateral$.next({ dappInfo: { logo, name, url: getOrigin(url) }, collateralRequest: args.data });
       await ensureUiIsOpenAndLoaded('#/dapp/set-collateral');
 
       return userPromptService.getCollateralRequest();

--- a/apps/browser-extension-wallet/src/lib/scripts/background/requestAccess.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/requestAccess.ts
@@ -18,7 +18,7 @@ export const requestAccess: RequestAccess = async (origin: Origin) => {
   const launchingTab = await getLastActiveTab();
   const { logo, name } = await getDappInfoFromLastActiveTab();
   dappInfo$.next({ logo, name, url: origin });
-  await ensureUiIsOpenAndLoaded('#/dapp/connect');
+  await ensureUiIsOpenAndLoaded('#/dapp/connect', false);
   const isAllowed = await userPromptService.allowOrigin(origin);
   if (isAllowed === 'deny') return Promise.reject();
   if (isAllowed === 'allow') {

--- a/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
+++ b/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
@@ -38,11 +38,7 @@ class DAppConnectorAssert {
     await expect(await commonDappPageElements.betaPill.getText()).to.equal(await t('core.dapp.beta'));
   }
 
-  async assertSeeTitleAndDappDetails(
-    expectedTitleKey: string,
-    expectedDappDetails: ExpectedDAppDetails,
-    shouldIncludeFullDAppUrl: boolean
-  ) {
+  async assertSeeTitleAndDappDetails(expectedTitleKey: string, expectedDappDetails: ExpectedDAppDetails) {
     const currentDAppUrl = new URL(expectedDappDetails.url);
     const commonDappPageElements = new CommonDappPageElements();
     await commonDappPageElements.pageTitle.waitForDisplayed();
@@ -51,15 +47,13 @@ class DAppConnectorAssert {
     await commonDappPageElements.dAppName.waitForDisplayed();
     await expect(await commonDappPageElements.dAppName.getText()).to.equal(expectedDappDetails.name);
     await commonDappPageElements.dAppUrl.waitForDisplayed();
-    const expectedUrl = shouldIncludeFullDAppUrl
-      ? currentDAppUrl.href
-      : `${currentDAppUrl.protocol}//${currentDAppUrl.host}`;
+    const expectedUrl = `${currentDAppUrl.protocol}//${currentDAppUrl.host}`;
     await expect(await commonDappPageElements.dAppUrl.getText()).to.equal(expectedUrl);
   }
 
   async assertSeeAuthorizeDAppPage(expectedDappDetails: ExpectedDAppDetails) {
     await this.assertSeeHeader();
-    await this.assertSeeTitleAndDappDetails('dapp.connect.header', expectedDappDetails, false);
+    await this.assertSeeTitleAndDappDetails('dapp.connect.header', expectedDappDetails);
 
     await AuthorizeDAppPage.banner.container.waitForDisplayed();
     await AuthorizeDAppPage.banner.icon.waitForDisplayed();
@@ -224,7 +218,7 @@ class DAppConnectorAssert {
     expectedTransactionData: ExpectedTransactionData
   ) {
     await this.assertSeeHeader();
-    await this.assertSeeTitleAndDappDetails('dapp.confirm.header', expectedDApp, true);
+    await this.assertSeeTitleAndDappDetails('dapp.confirm.header', expectedDApp);
     await ConfirmTransactionPage.transactionTypeTitle.waitForDisplayed();
     await expect(await ConfirmTransactionPage.transactionTypeTitle.getText()).to.equal(
       await t('dapp.confirm.details.header')


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-8376](https://input-output.atlassian.net/browse/LW-8376)
- [x] JIRA - [LW-8357](https://input-output.atlassian.net/browse/LW-8357)
- [x] JIRA - [LW-8377](https://input-output.atlassian.net/browse/LW-8377)
- [x] Screenshots added.

---

## Proposed solution

- Only check keyAgents if required, return a null response if background storage property doesn't exist.
- Show the URL `origin` instead of `hostname` property in popups

## Screenshots

<img width="472" alt="Screenshot 2023-09-07 at 14 04 58" src="https://github.com/input-output-hk/lace/assets/7581002/4e15048c-1ba5-4cf1-ab39-91e7fa9d9bea">
<img width="472" alt="Screenshot 2023-09-07 at 13 59 48" src="https://github.com/input-output-hk/lace/assets/7581002/33c795d0-a10e-475c-9b47-f3f42d7ec4bb">
<img width="472" alt="Screenshot 2023-09-07 at 14 01 16" src="https://github.com/input-output-hk/lace/assets/7581002/9744b950-e450-4720-96c4-a35cb78a6bce">
<img width="472" alt="Screenshot 2023-09-07 at 14 01 55" src="https://github.com/input-output-hk/lace/assets/7581002/0c3eeb29-e280-47d8-9971-e26dbd5028f0">


[LW-8376]: https://input-output.atlassian.net/browse/LW-8376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LW-8357]: https://input-output.atlassian.net/browse/LW-8357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LW-8377]: https://input-output.atlassian.net/browse/LW-8377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1961/6111145929/index.html) for [9b8d87ef](https://github.com/input-output-hk/lace/pull/507/commits/9b8d87ef65e65eb8d333fecda22c7272501d3dbf)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 2      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->