### PR TITLE
fix(extension): LW-8325 fix loss of timezone info when formatting time as local

### DIFF
--- a/apps/browser-extension-wallet/src/utils/__tests__/format-date.test.ts
+++ b/apps/browser-extension-wallet/src/utils/__tests__/format-date.test.ts
@@ -30,12 +30,12 @@ describe('Testing format-date functions', () => {
 
     expect(formatDate({ date, type: 'utc' })).toEqual(result);
     expect(mockdayjsinner).toBeCalledWith(date);
-    expect(utcMock).toBeCalledWith(false);
+    expect(utcMock).toBeCalled();
     expect(formatMock).toBeCalledWith(DEFAULT_DATE_FORMAT);
 
     const format = 'format';
     expect(formatDate({ date, format, type: 'utc' })).toEqual(result);
-    expect(utcMock).toBeCalledWith(false);
+    expect(utcMock).toBeCalled();
     expect(formatMock).toBeCalledWith(format);
 
     mockdayjsinner.mockReset();
@@ -45,25 +45,20 @@ describe('Testing format-date functions', () => {
   test('should return formatted date (local)', async () => {
     const result = 'result';
 
-    const utcMock = jest.fn();
     const formatMock = jest.fn();
-    mockdayjsinner.mockReturnValue({ utc: utcMock });
-    utcMock.mockReturnValue({ format: formatMock });
+    mockdayjsinner.mockReturnValue({ format: formatMock });
     formatMock.mockReturnValue(result);
     const date = new Date();
 
     expect(formatDate({ date, type: 'local' })).toEqual(result);
     expect(mockdayjsinner).toBeCalledWith(date);
-    expect(utcMock).toBeCalledWith(true);
     expect(formatMock).toBeCalledWith(DEFAULT_DATE_FORMAT);
 
     const format = 'format';
     expect(formatDate({ date, format, type: 'local' })).toEqual(result);
-    expect(utcMock).toBeCalledWith(true);
     expect(formatMock).toBeCalledWith(format);
 
     mockdayjsinner.mockReset();
-    utcMock.mockReset();
     formatMock.mockReset();
   });
   test('should return formatted time (UTC)', async () => {
@@ -78,11 +73,13 @@ describe('Testing format-date functions', () => {
 
     expect(formatTime({ date, type: 'utc' })).toEqual(result);
     expect(mockdayjsinner).toBeCalledWith(date);
+    expect(utcMock).toBeCalled();
     expect(formatMock).toBeCalledWith(DEFAULT_TIME_FORMAT);
 
     const format = 'format';
     expect(formatDate({ date, format, type: 'utc' })).toEqual(result);
     expect(formatMock).toBeCalledWith(format);
+    expect(utcMock).toBeCalled();
 
     mockdayjsinner.mockReset();
     utcMock.mockReset();

--- a/apps/browser-extension-wallet/src/utils/format-date.ts
+++ b/apps/browser-extension-wallet/src/utils/format-date.ts
@@ -12,12 +12,14 @@ type FormatDateTimeParams = {
   type: 'utc' | 'local';
 };
 
+const formatDateTime = ({ date, format, type }: FormatDateTimeParams): string => {
+  const dayJsDate = type === 'utc' ? dayjs(date).utc() : dayjs(date);
+
+  return dayJsDate.format(format ?? DEFAULT_DATE_FORMAT);
+};
+
 export const formatDate = ({ date, format, type }: FormatDateTimeParams): string =>
-  dayjs(date)
-    .utc(type === 'local')
-    .format(format ?? DEFAULT_DATE_FORMAT);
+  formatDateTime({ date, format: format ?? DEFAULT_DATE_FORMAT, type });
 
 export const formatTime = ({ date, format, type }: FormatDateTimeParams): string =>
-  dayjs(date)
-    .utc(type === 'local')
-    .format(format ?? DEFAULT_TIME_FORMAT);
+  formatDateTime({ date, format: format ?? DEFAULT_TIME_FORMAT, type });


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8325
- [x] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

As pointed out in https://github.com/input-output-hk/lace/pull/472#discussion_r1314831035 , the `formatDate/Time()` helper, by using the `utc()` method even for local time resulted in the loss of info about the timezone. This is not an issue in the current code which doesn't include the timezone in the format, but might be in the future, so this PR removes the `utc()` transformation when formatting time as local.  

## Testing

Check that time in transaction details and activity is shown with no changes

## Screenshots

These are the screens that were impacted by this change

![activity](https://user-images.githubusercontent.com/4980147/264687215-bdcd39f4-2a76-43f6-9fce-c7a2943c4f4d.png)

![tx detail](https://user-images.githubusercontent.com/4980147/264687212-583b3780-dd0a-4971-8c4f-d69fddc0e159.png)


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1964/6119325675/index.html) for [ac832cfe](https://github.com/input-output-hk/lace/pull/508/commits/ac832cfe889e743eb72be421ff7554a711db980c)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->