### PR TITLE
test(extension): e2e - move de-authorise DApps step before the test

### DIFF
--- a/packages/e2e-tests/src/features/DAppConnector.feature
+++ b/packages/e2e-tests/src/features/DAppConnector.feature
@@ -3,6 +3,7 @@ Feature: DAppConnector - Common
 
   Background:
     Given Wallet is synced
+    And I de-authorize all DApps in extended mode
 
   @LW-3760 @Testnet @Mainnet
   Scenario: Extended View - Limited wallet information when wallet is not connected
@@ -53,7 +54,6 @@ Feature: DAppConnector - Common
     And I open test DApp
     Then I see Lace wallet info in DApp when connected
     And I don't see DApp window
-    And I de-authorize all DApps in extended mode
 
   @LW-3807 @Testnet @Mainnet
   Scenario: "No wallet" modal displayed after trying to connect Dapp when there is no wallet
@@ -153,7 +153,6 @@ Feature: DAppConnector - Common
     Then I see test DApp on the Authorized DApps list
     When I open test DApp
     Then I don't see DApp window
-    And I de-authorize all DApps in extended mode
 
   @LW-4070
   Scenario: Authorize Dapp with 'Only once' and leaving/closing DApp

--- a/packages/e2e-tests/src/features/DAppConnectorExtended.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorExtended.feature
@@ -3,6 +3,7 @@ Feature: DAppConnector - Extended view
 
   Background:
     Given Wallet is synced
+    And I de-authorize all DApps in extended mode
 
   @LW-6688 @Testnet @Mainnet
   Scenario: Extended view - Authorized DApps section - empty state
@@ -17,7 +18,6 @@ Feature: DAppConnector - Extended view
     And I open settings from header menu
     When I click on "Authorized DApps" setting
     Then I see test DApp on the Authorized DApps list
-    And I de-authorize all DApps in extended mode
 
   @LW-6690 @Testnet @Mainnet
   Scenario: Extended View - Authorized DApp is not displayed in Lace Authorized DApps section after clicking "Once"
@@ -41,7 +41,6 @@ Feature: DAppConnector - Extended view
     Then I see test DApp on the Authorized DApps list
     When I open test DApp
     Then I don't see DApp window
-    And I de-authorize all DApps in extended mode
 
   @LW-6880 @Testnet @Mainnet
   Scenario: Extended view - Remove authorized DApp, DApp requires authorization

--- a/packages/e2e-tests/src/features/DAppConnectorPopup.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorPopup.feature
@@ -3,6 +3,7 @@ Feature: DAppConnector - Popup view
 
   Background:
     Given Wallet is synced
+    And I de-authorize all DApps in popup mode
 
   @LW-6685 @Testnet @Mainnet
   Scenario: Popup view - Authorized DApps section - empty state
@@ -17,7 +18,6 @@ Feature: DAppConnector - Popup view
     And I open settings from header menu
     When I click on "Authorized DApps" setting
     Then I see test DApp on the Authorized DApps list
-    And I de-authorize all DApps in popup mode
 
   @LW-6687 @Testnet @Mainnet
   Scenario: Popup View - Authorized DApp is not displayed in Lace Authorized DApps section after clicking "Once"
@@ -41,7 +41,6 @@ Feature: DAppConnector - Popup view
     Then I see test DApp on the Authorized DApps list
     When I open test DApp
     Then I don't see DApp window
-    And I de-authorize all DApps in extended mode
 
   @LW-6882 @Testnet @Mainnet
   Scenario: Popup view - Remove authorized DApp, DApp requires authorization

--- a/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
+++ b/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
@@ -10,6 +10,8 @@ import AllDonePage from '../elements/dappConnector/dAppTransactionAllDonePage';
 import TestDAppPage from '../elements/dappConnector/testDAppPage';
 import WalletUnlockScreenAssert from '../assert/walletUnlockScreenAssert';
 import CommonAssert from '../assert/commonAssert';
+import extendedView from '../page/extendedView';
+import popupView from '../page/popupView';
 
 const testDAppDetails: ExpectedDAppDetails = {
   hasLogo: true,
@@ -138,6 +140,7 @@ When(/^I open and authorize test DApp with "(Always|Only once)" setting$/, async
 
 Then(/^I de-authorize all DApps in (extended|popup) mode$/, async (mode: 'extended' | 'popup') => {
   await DAppConnectorPageObject.deauthorizeAllDApps(mode);
+  mode === 'extended' ? await extendedView.visit() : await popupView.visit();
 });
 
 Then(/^I de-authorize test DApp in (extended|popup) mode$/, async (mode: 'extended' | 'popup') => {


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1965/6119948291/index.html) for [9ce425cb](https://github.com/input-output-hk/lace/pull/509/commits/9ce425cbdbcc82cefc71dbf71d7f32147525c606)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 2      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->