### PR TITLE
test(extension): fix nft analytics scenarios

### DIFF
--- a/packages/e2e-tests/src/features/analytics/AnalyticsEventProperitesExtended.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsEventProperitesExtended.feature
@@ -1,7 +1,8 @@
 @NFTs-Extended @Analytics @Testnet @Mainnet
 Feature: Analytics - Posthog - Event properties
 
-  Given Wallet is synced
+  Background:
+    Given Wallet is synced
 
   @LW-7703
   Scenario: Analytics - Verify event properties
@@ -20,7 +21,7 @@ Feature: Analytics - Posthog - Event properties
   Scenario: Analytics -Extended View - Verify event properties - Send - Send NFT button
     Given I set up request interception for posthog analytics request(s)
     And I am on NFTs extended page
-    And I left click on the NFT with name "Ibilecoin_1" on NFTs page
+    And I left click on the NFT with name "Bison Coin" on NFTs page
     When I click "Send NFT" button on NFT details drawer
     Then I validate that the event includes "trigger_point" property
     And I validate that the "send | send | click" event includes property "trigger_point" with value "nfts page" in posthog

--- a/packages/e2e-tests/src/features/analytics/AnalyticsEventProperitesPopup.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsEventProperitesPopup.feature
@@ -1,7 +1,8 @@
 @NFTs-Popup @Testnet @Mainnet
 Feature: Analytics - Posthog - Event properties
 
-  Given Wallet is synced
+  Background:
+    Given Wallet is synced
 
   @LW-8352
   Scenario: Analytics - Popup View - Verify event properties - Send - Send button
@@ -14,7 +15,7 @@ Feature: Analytics - Posthog - Event properties
   Scenario: Analytics - Popup View - Verify event properties - Send - Send NFT button
     Given I set up request interception for posthog analytics request(s)
     And I am on NFTs popup page
-    And I left click on the NFT with name "Ibilecoin_1" on NFTs page
+    And I left click on the NFT with name "Bison Coin" on NFTs page
     When I click "Send NFT" button on NFT details drawer
     Then I validate latest analytics single event "send | send | click"
     And I validate that the "send | send | click" event includes property "trigger_point" with value "nfts page" in posthog

--- a/packages/e2e-tests/src/features/analytics/AnalyticsNFTsExtended.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsNFTsExtended.feature
@@ -9,7 +9,7 @@ Feature: Analytics - Posthog - NFTs - Extended view
     Given I set up request interception for posthog analytics request(s)
     And I am on NFTs extended page
     Then I validate latest analytics single event "nft | nfts | click"
-    And I left click on the NFT with name "Ibilecoin" on NFTs page
-    And I am on a NFT details on the extended view for NFT with name: "Ibilecoin"
+    And I left click on the NFT with name "Bison Coin" on NFTs page
+    And I am on a NFT details on the extended view for NFT with name: "Bison Coin"
     Then I validate latest analytics single event "nft | nfts | nft image | click"
     And I validate that 2 analytics event(s) have been sent

--- a/packages/e2e-tests/src/features/analytics/AnalyticsNFTsPopup.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsNFTsPopup.feature
@@ -9,7 +9,7 @@ Feature: Analytics - Posthog - NFTs - Popup view
     Given I set up request interception for posthog analytics request(s)
     And I am on NFTs popup page
     Then I validate latest analytics single event "nft | nfts | click"
-    And I left click on the NFT with name "Ibilecoin" on NFTs page
-    And I am on a NFT details on the popup view for NFT with name: "Ibilecoin"
+    And I left click on the NFT with name "Bison Coin" on NFTs page
+    And I am on a NFT details on the popup view for NFT with name: "Bison Coin"
     Then I validate latest analytics single event "nft | nfts | nft image | click"
     And I validate that 2 analytics event(s) have been sent

--- a/packages/e2e-tests/src/steps/sendTransactionSimpleSteps.ts
+++ b/packages/e2e-tests/src/steps/sendTransactionSimpleSteps.ts
@@ -203,14 +203,15 @@ Then(/^click "(Add|Remove) address" button (\d*) in address bar$/, async (_ignor
 When(
   /^I fill bundle (\d+) with "([^"]*)" address with following assets:$/,
   async (bundleIndex, receivingAddress, options) => {
+    await browser.pause(500);
     await transactionExtendedPageObject.fillAddress(
       receivingAddress === 'CopiedAddress'
         ? String(await clipboard.read())
         : String(getTestWallet(receivingAddress).address),
       bundleIndex
     );
-    await browser.pause(1000);
     for (const entry of options.hashes()) {
+      await browser.pause(500);
       switch (entry.type) {
         case 'ADA':
           break;


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1966/6120195075/index.html) for [b99a7ef6](https://github.com/input-output-hk/lace/pull/510/commits/b99a7ef6e0b5e275585e4d69688be18e65a345a7)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->