### PR TITLE
feat(extension): new event props on send transact

### DIFF
--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -114,6 +114,11 @@ export enum ExtensionViews {
   Popup = 'popup'
 }
 
+export enum TxRecipientType {
+  AdaHandle = 'ADA Handle',
+  RegularAddress = 'regular address'
+}
+
 export type OnboardingFlows = 'create' | 'restore' | 'hw' | 'forgot_password';
 export type PostHogActionsKeys =
   | 'SETUP_OPTION_CLICK'

--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/helpers/__tests__/pending-tx-transformer.test.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/helpers/__tests__/pending-tx-transformer.test.ts
@@ -5,7 +5,7 @@ let actualLovelacesToAdaString: any;
 /* eslint-disable import/imports-first */
 /* eslint-disable max-len */
 /* eslint-disable no-magic-numbers */
-import { pendingTxTransformer, getFormattedAmount, getFormattedFiatAmount } from '../pending-tx-transformer';
+import { pendingTxTransformer, getFormattedFiatAmount } from '../pending-tx-transformer';
 import { Wallet } from '@lace/cardano';
 import { cardanoCoin } from '@utils/constants';
 import { TxCBOR } from '@cardano-sdk/core';
@@ -116,17 +116,6 @@ describe('Testing tx transformers utils', () => {
           type: 'local'
         })
       });
-    });
-  });
-
-  describe('getFormattedAmount', () => {
-    test('shoud return properly formatted amount', () => {
-      const mockLovelacesToAdaStringResult = 'mockLovelacesToAdaString';
-      mockLovelacesToAdaString.mockReturnValue(mockLovelacesToAdaStringResult);
-
-      expect(getFormattedAmount({ amount: 'amount', cardanoCoin })).toEqual(
-        `${mockLovelacesToAdaStringResult} ${cardanoCoin.symbol}`
-      );
     });
   });
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/helpers/pending-tx-transformer.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/helpers/pending-tx-transformer.ts
@@ -25,11 +25,6 @@ export interface TxTransformerInput {
   date?: string;
 }
 
-export const getFormattedAmount = ({ amount, cardanoCoin }: { amount: string; cardanoCoin: Wallet.CoinId }): string => {
-  const adaStringAmount = Wallet.util.lovelacesToAdaString(amount);
-  return `${adaStringAmount} ${cardanoCoin.symbol}`;
-};
-
 export const getFormattedFiatAmount = ({
   amount,
   fiatPrice,
@@ -100,7 +95,7 @@ export const txTransformer = ({
     depositReclaim,
     fee: Wallet.util.lovelacesToAdaString(tx.body.fee.toString()),
     status,
-    amount: getFormattedAmount({ amount: outputAmount.toString(), cardanoCoin }),
+    amount: Wallet.util.getFormattedAmount({ amount: outputAmount.toString(), cardanoCoin }),
     fiatAmount: getFormattedFiatAmount({ amount: outputAmount, fiatCurrency, fiatPrice }),
     assets: assetsEntries,
     assetsNumber: (assets?.size ?? 0) + 1,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/helpers/tx-history-transformer.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/helpers/tx-history-transformer.ts
@@ -6,12 +6,7 @@ import { AssetActivityItemProps } from '@lace/core';
 import dayjs from 'dayjs';
 import { formatDate } from '@src/utils/format-date';
 import { getTxDirection, inspectTxType } from '@src/utils/tx-inspection';
-import {
-  getFormattedAmount,
-  getFormattedFiatAmount,
-  txTransformer,
-  TxTransformerInput
-} from './pending-tx-transformer';
+import { getFormattedFiatAmount, txTransformer, TxTransformerInput } from './pending-tx-transformer';
 import { TxDirections } from '@types';
 import {
   isDelegationWithDeregistrationTx,
@@ -96,7 +91,7 @@ export const txHistoryTransformer = ({
       {
         type: 'rewards',
         direction: 'Incoming',
-        amount: getFormattedAmount({ amount: rewardsAmount, cardanoCoin }),
+        amount: Wallet.util.getFormattedAmount({ amount: rewardsAmount, cardanoCoin }),
         fiatAmount: getFormattedFiatAmount({
           amount: new BigNumber(tx?.body?.withdrawals[0]?.quantity?.toString() || '0'),
           fiatCurrency,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
@@ -1,13 +1,15 @@
 /* eslint-disable no-lonely-if */
+import uniq from 'lodash/uniq';
 import { ResultMessage } from '@components/ResultMessage';
 import { TransactionHashBox } from '@components/TransactionHashBox';
 import { useAnalyticsContext } from '@providers';
-import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
+import { PostHogAction, TxRecipientType } from '@providers/AnalyticsProvider/analyticsTracker';
 import {
   useBuiltTxState,
   useAnalyticsSendFlowTriggerPoint,
   useOutputs,
-  TokenAnalyticsProperties
+  TokenAnalyticsProperties,
+  useMetadata
 } from '@views/browser/features/send-transaction';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,10 +17,11 @@ import styles from './TransactionSuccessView.module.scss';
 import { useWalletStore } from '@src/stores';
 import { useObservable } from '@lace/common';
 import { getTokensProperty } from '../helpers';
+import { Wallet } from '@lace/cardano';
 
 export const TransactionSuccessView = ({ footerSlot }: { footerSlot?: React.ReactElement }): React.ReactElement => {
   const { t } = useTranslation();
-  const { builtTxData: { uiTx: { hash } = {} } = {} } = useBuiltTxState();
+  const { builtTxData: { uiTx: { hash, fee } = {} } = {} } = useBuiltTxState();
   const { uiOutputs } = useOutputs();
   const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
   const analytics = useAnalyticsContext();
@@ -28,6 +31,7 @@ export const TransactionSuccessView = ({ footerSlot }: { footerSlot?: React.Reac
   } = useWalletStore();
   const assets = useObservable(inMemoryWallet.assetInfo$);
   const [customAnalyticsProperties, setCustomAnalyticsProperties] = useState<TokenAnalyticsProperties[]>();
+  const [metadata] = useMetadata();
 
   useEffect(() => {
     // run this only when assets value was emitted and customAnalyticsProperties is undefined
@@ -39,10 +43,25 @@ export const TransactionSuccessView = ({ footerSlot }: { footerSlot?: React.Reac
   useEffect(() => {
     // send analytics event after customAnalyticsProperties was set
     if (customAnalyticsProperties) {
+      const recipientTypes = Object.values(uiOutputs).map((row) =>
+        row.handle ? TxRecipientType.AdaHandle : TxRecipientType.RegularAddress
+      );
+      const recipientTypesUnique = uniq(recipientTypes);
       analytics.sendEventToPostHog(PostHogAction.SendAllDoneView, {
         // eslint-disable-next-line camelcase
         trigger_point: triggerPoint,
-        tokens: customAnalyticsProperties
+        tokens: customAnalyticsProperties,
+        // eslint-disable-next-line camelcase
+        transaction_fee:
+          fee &&
+          Wallet.util.getFormattedAmount({
+            amount: fee.toString(),
+            cardanoCoin
+          }),
+        // eslint-disable-next-line camelcase
+        metadata_defined: !!metadata,
+        // eslint-disable-next-line camelcase
+        recipient_type: recipientTypesUnique
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/__tests__/CollateralDrawer.test.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/__tests__/CollateralDrawer.test.tsx
@@ -19,6 +19,7 @@ const mockNotify = jest.fn();
 const mockUseAnalyticsSendFlowTriggerPoint = jest.fn();
 const mockUseOutputs = jest.fn();
 const mockGetUserIdService = jest.fn();
+const mockUseMetadata = jest.fn();
 import * as React from 'react';
 import { screen, cleanup, fireEvent, render, within, waitFor } from '@testing-library/react';
 import { CollateralDrawer } from '../CollateralDrawer';
@@ -81,7 +82,8 @@ jest.mock('@src/views/browser-view/features/send-transaction', () => {
     ...original,
     useBuiltTxState: mockUseBuitTxState,
     useAnalyticsSendFlowTriggerPoint: mockUseAnalyticsSendFlowTriggerPoint,
-    useOutputs: mockUseOutputs
+    useOutputs: mockUseOutputs,
+    useMetadata: mockUseMetadata
   };
 });
 
@@ -178,6 +180,7 @@ describe('Testing CollateralDrawer component', () => {
       setSection,
       currentSection: {}
     });
+    mockUseMetadata.mockReturnValue([]);
   });
 
   afterEach(() => {

--- a/packages/cardano/src/wallet/util/__tests__/unit-converters.test.ts
+++ b/packages/cardano/src/wallet/util/__tests__/unit-converters.test.ts
@@ -3,7 +3,8 @@ import {
   lovelacesToAdaString,
   convertLovelaceToFiat,
   convertAdaToFiat,
-  adaToLovelacesString
+  adaToLovelacesString,
+  getFormattedAmount
 } from '../unit-converters';
 
 describe('Testing lovelacesToAdaString function', () => {
@@ -50,5 +51,18 @@ describe('Testing convertAdaToFiat function', () => {
       const adaValue = adaToLovelacesString('20.035');
       expect(adaValue).toEqual('20035000');
     });
+  });
+});
+
+describe('Testing getFormattedAmount function', () => {
+  test('should format amount and concatenate currency symbol', async () => {
+    const cardanoCoin = {
+      id: 'id',
+      symbol: 'symbol',
+      name: 'name',
+      decimals: 2
+    };
+    const result = getFormattedAmount({ amount: '2000000', cardanoCoin });
+    expect(result).toBe('2.00 symbol');
   });
 });

--- a/packages/cardano/src/wallet/util/unit-converters.ts
+++ b/packages/cardano/src/wallet/util/unit-converters.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { CoinId } from '../types';
 
 const LOVELACE_VALUE = 1_000_000;
 const DEFAULT_DECIMALS = 2;
@@ -17,3 +18,8 @@ export const convertLovelaceToFiat = (
   fields: { lovelaces: string; fiat: number },
   decimalValues: number = DEFAULT_DECIMALS
 ): string => convertAdaToFiat({ ada: lovelacesToAdaString(fields.lovelaces), fiat: fields.fiat }, decimalValues);
+
+export const getFormattedAmount = ({ amount, cardanoCoin }: { amount: string; cardanoCoin: CoinId }): string => {
+  const adaStringAmount = lovelacesToAdaString(amount);
+  return `${adaStringAmount} ${cardanoCoin.symbol}`;
+};


### PR DESCRIPTION
# Checklist

- [x] JIRA - [\<link>](https://input-output.atlassian.net/browse/LW-7711)
- [x] Proper tests implemented
- [ ] Screenshots added.

---
## Proposed solution
New event properties added on successful transaction.

## Testing
check single and bundle transaction

## Screenshots
---


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2013/6161895849/index.html) for [09231a7c](https://github.com/input-output-hk/lace/pull/514/commits/09231a7c6c113c7b9c0e1479b4b27b5e08a6e53b)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 0      | 0       | 0     | 32    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->