### PR TITLE
fix(ui): [LW-6898] fix incorrect tab button active state and tab navigation

### DIFF
--- a/packages/staking/src/features/staking/Navigation.tsx
+++ b/packages/staking/src/features/staking/Navigation.tsx
@@ -16,14 +16,30 @@ export const Navigation = ({ children }: NavigationProps) => {
   }));
   const { t } = useTranslation();
   const onValueChange = (value: string) => {
+    console.log(value);
     if (isValueAValidSubPage(value)) setActivePage(value);
   };
 
   return (
     <>
-      <SubNavigation.Root aria-label={t('root.nav.title')} value={activePage} onValueChange={onValueChange}>
-        <SubNavigation.Item name={t('root.nav.overviewTitle')} value={Page.overview} data-testid="overview-tab" />
-        <SubNavigation.Item name={t('root.nav.browsePoolsTitle')} value={Page.browsePools} data-testid="browse-tab" />
+      <SubNavigation.Root
+        aria-label={t('root.nav.title')}
+        value={activePage}
+        onValueChange={onValueChange}
+        tabIndex={-1}
+      >
+        <SubNavigation.Item
+          name={t('root.nav.overviewTitle')}
+          value={Page.overview}
+          data-testid="overview-tab"
+          tabIndex={0}
+        />
+        <SubNavigation.Item
+          name={t('root.nav.browsePoolsTitle')}
+          value={Page.browsePools}
+          data-testid="browse-tab"
+          tabIndex={0}
+        />
       </SubNavigation.Root>
       {children(activePage)}
     </>

--- a/packages/ui/src/design-system/sub-navigation/sub-navigation-item.css.ts
+++ b/packages/ui/src/design-system/sub-navigation/sub-navigation-item.css.ts
@@ -29,7 +29,7 @@ export const disabled = style([
 
 const labelContainerFocused = {
   borderRadius: vars.radius.$tiny,
-  boxShadow: `0 0 0 1px ${vars.colors.$sub_navigation_container_outlineColor}`,
+  boxShadow: `0 0 0 3px ${vars.colors.$sub_navigation_container_outlineColor}`,
 };
 
 export const labelContainer = style([
@@ -44,9 +44,8 @@ export const labelContainer = style([
   }),
   {
     selectors: {
-      [`${root}:focus:not(:active) &`]: labelContainerFocused,
-      [`${root}:focus:not(${active}) &`]: labelContainerFocused,
-      [`${root}:focus-visble:not(:active) &`]: labelContainerFocused,
+      [`${root}:focus-visible:not(${active}) &`]: labelContainerFocused,
+      [`${root}:focus-visible:not(:active) &`]: labelContainerFocused,
     },
   },
 ]);
@@ -60,17 +59,23 @@ export const label = style([
       [`${root}:hover &`]: {
         color: vars.colors.$sub_navigation_item_label_color_hover,
       },
+      [`${root}:focus-visible:not(${active}) &`]: {
+        color: vars.colors.$sub_navigation_item_label_color_focused,
+      },
+      [`${root}:focus-visible:not(:active) &`]: {
+        color: vars.colors.$sub_navigation_item_label_color_focused,
+      },
+      [`${root}:focus-visible:is(${active}) &`]: {
+        color: vars.colors.$sub_navigation_item_label_color_pressed,
+      },
+      [`${root}:focus-visible:is(:active) &`]: {
+        color: vars.colors.$sub_navigation_item_label_color_pressed,
+      },
       [`${root}:active &`]: {
         color: vars.colors.$sub_navigation_item_label_color_pressed,
       },
       [`${active} &`]: {
         color: vars.colors.$sub_navigation_item_label_color_pressed,
-      },
-      [`${root}:focus &`]: {
-        color: vars.colors.$sub_navigation_item_label_color_focused,
-      },
-      [`${root}:focus-visble &`]: {
-        color: vars.colors.$sub_navigation_item_label_color_focused,
       },
     },
   },

--- a/packages/ui/src/design-system/sub-navigation/sub-navigation.component.tsx
+++ b/packages/ui/src/design-system/sub-navigation/sub-navigation.component.tsx
@@ -27,6 +27,7 @@ export const SubNavigation = ({
     defaultValue={defaultValue}
     value={value}
     onValueChange={onValueChange}
+    activationMode="manual"
   >
     <Tabs.List {...props}>{children}</Tabs.List>
   </Tabs.Root>


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-6898
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Fix tab label coloring and border to be black when button is active/focused. While fixing the purple border around the active & not focused tab button I realized that the tab navigation doesn't work as one would normally expect, because on TAB key press only one of the tabs got focused and the other skipped, so this PR is fixing also that

## Testing

In the expanded view go to the "Staking" section and try clicking between tabs, try navigation by pressing TAB/Enter and check that it behaves reasonably (correct tab is focused - purple border shown and after pressing ENTER it gets selected)

Check that the tab label/border colors match the FIgma designs (see Jira tickets for reference)

## Screenshots

There are multiple states of the tab button, I'd just recommend checking Figma and verifying that the UI in this PR matches that
