### PR TITLE
fix(common): LW-8396 fix `yarn lint` skipping workspaces, enable eslint `no-console` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,9 @@ module.exports = {
     'no-invalid-this': 0,
     'react/prop-types': 'off',
     'max-len': 'off', // prettier is already handling this automatically,
-    'no-console': 'off', // Fine to disable here, prod webpack config strips console logs
+    // note: prod webpack config strips console logs anyway, nevertheless
+    // we don't want the dev build to be spammed by needless logging
+    'no-console': ['error', { allow: ['warn', 'error', 'info', 'debug'] }],
     'lodash/import-scope': ['error', 'method']
   },
   overrides: [

--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -29,7 +29,7 @@
     "build:dev": "NODE_OPTIONS='--openssl-legacy-provider' rm -rf dist & run -T webpack --config webpack.sw.dev.js --progress & run -T webpack --config webpack.app.dev.js --progress",
     "cleanup": "yarn exec rm -rf dist node_modules",
     "dev": "NODE_OPTIONS='--openssl-legacy-provider' rm -rf dist & run -T webpack --config webpack.sw.dev.js --progress --watch & run -T webpack serve --config webpack.app.dev.js --env RUN_DEV_SERVER=true",
-    "lint": "cd ../.. && extension:lint",
+    "lint": "cd ../.. && yarn extension:lint",
     "prepack": "yarn build",
     "prepare": "ts-patch install -s",
     "prettier": "run -T prettier --write .",

--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -29,7 +29,7 @@
     "build:dev": "NODE_OPTIONS='--openssl-legacy-provider' rm -rf dist & run -T webpack --config webpack.sw.dev.js --progress & run -T webpack --config webpack.app.dev.js --progress",
     "cleanup": "yarn exec rm -rf dist node_modules",
     "dev": "NODE_OPTIONS='--openssl-legacy-provider' rm -rf dist & run -T webpack --config webpack.sw.dev.js --progress --watch & run -T webpack serve --config webpack.app.dev.js --env RUN_DEV_SERVER=true",
-    "lint": "run -T eslint-cmd \"./**/*.{js,ts,tsx}\"",
+    "lint": "cd ../.. && extension:lint",
     "prepack": "yarn build",
     "prepare": "ts-patch install -s",
     "prettier": "run -T prettier --write .",

--- a/apps/browser-extension-wallet/src/components/Announcement/Announcement.tsx
+++ b/apps/browser-extension-wallet/src/components/Announcement/Announcement.tsx
@@ -26,7 +26,7 @@ export const Announcement = ({ visible, onConfirm, version, reason }: Announceme
       try {
         notes = await fetchNotes(version);
       } catch (error) {
-        console.log(error);
+        console.error(error);
       }
     }
     setReleaseNotes(notes);

--- a/apps/browser-extension-wallet/src/components/MigrationContainer/MigrationContainer.tsx
+++ b/apps/browser-extension-wallet/src/components/MigrationContainer/MigrationContainer.tsx
@@ -79,7 +79,7 @@ export const MigrationContainer = ({ children, appMode }: MigrationContainerProp
         setIsLoadingFirstTime(true);
         setMigrationState(value.MIGRATION_STATE as MigrationState);
       })
-      .catch((error) => console.log('Error fetching initial migration state:', error));
+      .catch((error) => console.error('Error fetching initial migration state:', error));
 
     // Observe changes to MIGRATION_STATE in storage
     const observeMigrationState = async (changes: Record<string, Storage.StorageChange>) => {

--- a/apps/browser-extension-wallet/src/features/dapp/components/ConfirmData.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/ConfirmData.tsx
@@ -98,7 +98,7 @@ export const DappConfirmData = (): React.ReactElement => {
         setFormattedData(jsonStructureOrHexString);
       })
       .catch((error) => {
-        console.log(error);
+        console.error(error);
       });
   }, []);
 

--- a/apps/browser-extension-wallet/src/features/dapp/components/ConfirmTransaction.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/ConfirmTransaction.tsx
@@ -88,7 +88,7 @@ export const ConfirmTransaction = withAddressBookContext((): React.ReactElement 
       })
         .then((result) => setAssetsInfo(result))
         .catch((error) => {
-          console.log(error);
+          console.error(error);
         });
     }
   }, [assetIds, assetProvider, assets]);
@@ -131,7 +131,7 @@ export const ConfirmTransaction = withAddressBookContext((): React.ReactElement 
           throw error;
         });
     } catch (error) {
-      console.log('error', error);
+      console.error('error', error);
       cancelTransaction(false);
       redirectToSignFailure();
     }
@@ -146,7 +146,7 @@ export const ConfirmTransaction = withAddressBookContext((): React.ReactElement 
       })
       .catch((error) => {
         setErrorMessage(error);
-        console.log(error);
+        console.error(error);
       });
   }, []);
 

--- a/apps/browser-extension-wallet/src/features/dapp/components/Connect.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/Connect.tsx
@@ -114,7 +114,7 @@ export const Connect = (): React.ReactElement => {
         }
       })
       .catch((error) => {
-        console.log(error);
+        console.error(error);
       });
   }, []);
 

--- a/apps/browser-extension-wallet/src/features/dapp/components/collateral/CollateralContainer.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/collateral/CollateralContainer.tsx
@@ -55,7 +55,7 @@ const collateralRequestResponse = (action: RejectResponse | ResolveResponse) => 
       }
     );
   } catch (error) {
-    console.log(error);
+    console.error(error);
   }
 };
 
@@ -90,7 +90,7 @@ export const DappCollateralContainer = (): React.ReactElement => {
         collateralRequestResponse({ response: ReturnResponse.resolve, utxos });
         redirectToCreateSuccess();
       } catch (error) {
-        console.log(error);
+        console.error(error);
         redirectToCreateFailure();
       }
     },
@@ -139,7 +139,7 @@ export const DappCollateralContainer = (): React.ReactElement => {
           setIsCalculatingCollateral(false);
         });
     } catch (error) {
-      console.log(error);
+      console.error(error);
       redirectToCreateFailure();
     }
   }, []);

--- a/apps/browser-extension-wallet/src/hooks/useCollateral.ts
+++ b/apps/browser-extension-wallet/src/hooks/useCollateral.ts
@@ -90,7 +90,7 @@ export const useCollateral = (): UseCollateralReturn => {
     } catch (error) {
       // redirect to tx fail screen in case of hw
       if (!isInMemory) {
-        console.log('submitCollateralTx fails with:', error?.message);
+        console.error('submitCollateralTx fails with:', error?.message);
         setBuiltTxData({
           uiTx: undefined,
           error: error.message

--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -322,7 +322,7 @@ export const useWalletManager = (): UseWalletManager => {
   const switchNetwork = useCallback(
     async (chainName: Wallet.ChainName): Promise<void> => {
       const chainId = Wallet.Cardano.ChainIds[chainName];
-      console.log('Switching chain to', chainName, AVAILABLE_CHAINS);
+      console.info('Switching chain to', chainName, AVAILABLE_CHAINS);
       if (!chainId || !AVAILABLE_CHAINS.includes(chainName)) throw new Error('Chain not supported');
 
       const backgroundStorage = await backgroundService.getBackgroundStorage();

--- a/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
@@ -45,7 +45,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
 
       return userPromptService.allowSignTx();
     } catch (error) {
-      console.log(error);
+      console.error(error);
       // eslint-disable-next-line unicorn/no-useless-undefined
       dappSignTxData$.next(undefined);
       return Promise.reject(new ApiError(APIErrorCode.InternalError, 'Unable to sign transaction'));
@@ -59,7 +59,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
 
       return userPromptService.allowSignData();
     } catch (error) {
-      console.log(error);
+      console.error(error);
       // eslint-disable-next-line unicorn/no-useless-undefined
       dappSignData$.next(undefined);
       return Promise.reject(new ApiError(APIErrorCode.InternalError, 'Unable to sign data'));

--- a/apps/browser-extension-wallet/src/lib/scripts/background/content.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/content.ts
@@ -2,7 +2,7 @@ import { runtime } from 'webextension-polyfill';
 import { cip30 } from '@cardano-sdk/web-extension';
 // Disable logging in production for performance & security measures
 if (process.env.USE_DAPP_CONNECTOR === 'true') {
-  console.log('initializing content script');
+  console.info('initializing content script');
   cip30.initializeContentScript(
     { injectedScriptSrc: runtime.getURL('./js/inject.js'), walletName: process.env.WALLET_NAME },
     { logger: console, runtime }

--- a/apps/browser-extension-wallet/src/lib/scripts/background/inject.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/inject.ts
@@ -23,7 +23,7 @@ const cip30WalletProperties = {
   walletName: process.env.WALLET_NAME
 };
 if (process.env.USE_DAPP_CONNECTOR === 'true') {
-  console.log('injecting content script');
+  console.info('injecting content script');
   // Disable logging in production for performance & security measures
   initializeInjectedScript(cip30WalletProperties, { logger: console });
 }

--- a/apps/browser-extension-wallet/src/lib/scripts/background/onError.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/onError.ts
@@ -36,7 +36,7 @@ const handleConnectionIssues = async (error: WebRequest.OnErrorOccurredDetailsTy
   )
     return;
 
-  console.log('xmlhttprequest:net::ERR_INTERNET_DISCONNECTED', error);
+  console.error('xmlhttprequest:net::ERR_INTERNET_DISCONNECTED', error);
 
   requestMessage$.next({ type: MessageTypes.HTTP_CONNECTION, data: { connected: false } });
   if (!webRequest.onCompleted.hasListener(handleRequests)) {

--- a/apps/browser-extension-wallet/src/lib/scripts/background/onUpdate.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/onUpdate.ts
@@ -33,7 +33,7 @@ const displayReleaseAnnouncements = async ({ reason }: Runtime.OnInstalledDetail
       [ABOUT_EXTENSION_KEY]: { version: currentVersion, acknowledged: false, reason: updateType } as ExtensionUpdateData
     });
 
-    console.log('extension got updated due to reason:', updateType);
+    console.info('extension got updated due to reason:', updateType);
   }
 };
 
@@ -43,7 +43,7 @@ if (!runtime.onInstalled.hasListener(displayReleaseAnnouncements))
 if (!runtime.onInstalled.hasListener(checkMigrationsOnUpdate)) runtime.onInstalled.addListener(checkMigrationsOnUpdate);
 
 const updateToVersionCallback = (details: Runtime.OnUpdateAvailableDetailsType) => {
-  console.log(`updating to version ${details.version}`);
+  console.info(`updating to version ${details.version}`);
   if (runtime.onUpdateAvailable.hasListener(updateToVersionCallback)) {
     runtime.onUpdateAvailable.removeListener(updateToVersionCallback);
   }

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/dappService.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/dappService.ts
@@ -74,5 +74,5 @@ try {
       throw new Error(error);
     });
 } catch (error) {
-  console.log(error);
+  console.error(error);
 }

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/utilityServices.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/utilityServices.ts
@@ -81,7 +81,7 @@ const handleOpenBrowser = async (data: OpenBrowserData) => {
       path = walletRoutePaths.setup.restore;
       break;
   }
-  await tabs.create({ url: `app.html#${path}` }).catch((error) => console.log(error));
+  await tabs.create({ url: `app.html#${path}` }).catch((error) => console.error(error));
 };
 
 const handleChangeTheme = (data: ChangeThemeData) => requestMessage$.next({ type: MessageTypes.CHANGE_THEME, data });
@@ -118,7 +118,7 @@ const fetchTokenPrices = () => {
       coinPrices.tokenPrices$.next({ tokens: tokenPrices, status: 'fetched' });
     })
     .catch((error) => {
-      console.log('Error fetching coin prices:', error);
+      console.error('Error fetching coin prices:', error);
       coinPrices.tokenPrices$.next({ ...coinPrices.tokenPrices$.value, status: 'error' });
     });
 };
@@ -144,7 +144,7 @@ const fetchAdaPrice = () => {
       });
     })
     .catch(async (error) => {
-      console.log('Error fetching coin prices:', error);
+      console.error('Error fetching coin prices:', error);
       // If for some reason we couldn't fetch the ada price, get it from background store
       const adaPrice = await getADAPriceFromBackgroundStorage();
       if (!adaPrice) return coinPrices.adaPrices$.next({ prices: {}, status: 'error', timestamp: undefined });

--- a/apps/browser-extension-wallet/src/lib/scripts/migrations/__tests__/migrations.test.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/migrations/__tests__/migrations.test.ts
@@ -136,6 +136,7 @@ describe('migrations', () => {
       test('and skip migrations that should be skipped', async () => {
         const withSkipMigrations = [...mockMigrations];
         withSkipMigrations[2].shouldSkip = jest.fn().mockResolvedValue(true);
+        // eslint-disable-next-line no-console
         console.log(withSkipMigrations[2]);
         await applyMigrations({ state: 'not-applied', from: '0.5.0', to: '3.1.5' }, undefined, withSkipMigrations);
         const shouldApply = mockMigrations.filter((_, index) => index !== 2);

--- a/apps/browser-extension-wallet/src/lib/scripts/migrations/migrations.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/migrations/migrations.ts
@@ -73,7 +73,7 @@ export const applyMigrations = async (
     for (const migration of upgradeMigrationsToApply) {
       await pRetry(
         async (attemptNumber) => {
-          console.log(`Applying migration for version ${migration.version} (attempt: ${attemptNumber})`);
+          console.info(`Applying migration for version ${migration.version} (attempt: ${attemptNumber})`);
           const shouldSkip = await migration.shouldSkip?.();
           if (shouldSkip) return;
           const { prepare, assert, persist, rollback } = await migration.upgrade(password);
@@ -96,7 +96,7 @@ export const applyMigrations = async (
           minTimeout: 0,
           retries: MIGRATIONS_RETRIES,
           onFailedAttempt: (error) =>
-            console.log(
+            console.error(
               `Migration attempt ${error.attemptNumber} for ${migration.version} upgrade failed. There are ${error.retriesLeft} retries left.`
             )
         }
@@ -107,7 +107,7 @@ export const applyMigrations = async (
     // Reload app states with updated storage
     window.location.reload();
   } catch (error) {
-    console.log('Error applying migrations:', error);
+    console.error('Error applying migrations:', error);
     await storage.local.set({
       MIGRATION_STATE: { ...migrationState, state: 'error' } as MigrationState
     });

--- a/apps/browser-extension-wallet/src/lib/scripts/migrations/versions/v0_6_0.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/migrations/versions/v0_6_0.ts
@@ -120,7 +120,7 @@ export const v0_6_0: Migration = {
       prepare: async () => {
         // Save temporary storage. Revert and throw if something fails
         try {
-          console.log('Saving temporary migration for', MIGRATION_VERSION);
+          console.info('Saving temporary migration for', MIGRATION_VERSION);
           if (newAppSettings) setItemInLocalStorage('appSettings_tmp', newAppSettings);
           if (newWalletInfo) setItemInLocalStorage('wallet_tmp', newWalletInfo);
           if (newKeyAgentData) setItemInLocalStorage('keyAgentData_tmp', newKeyAgentData);
@@ -128,7 +128,7 @@ export const v0_6_0: Migration = {
           if (newKeyAgentsByChain)
             await setBackgroundStorage({ keyAgentsByChain_tmp: newKeyAgentsByChain } as unknown as BackgroundStorage);
         } catch (error) {
-          console.log(`Error saving temporary migrations for ${MIGRATION_VERSION}, deleting...`, error);
+          console.info(`Error saving temporary migrations for ${MIGRATION_VERSION}, deleting...`, error);
           removeItemFromLocalStorage('appSettings_tmp');
           removeItemFromLocalStorage('wallet_tmp');
           removeItemFromLocalStorage('keyAgentData_tmp');
@@ -138,7 +138,7 @@ export const v0_6_0: Migration = {
         }
       },
       assert: async (): Promise<boolean> => {
-        console.log('Checking migrated data for version', MIGRATION_VERSION);
+        console.info('Checking migrated data for version', MIGRATION_VERSION);
         // Temporary storage
         const tmpWalletInfo = getItemFromLocalStorage<any>('wallet_tmp');
         const tmpAppSettings = getItemFromLocalStorage<any>('appSettings_tmp');
@@ -203,7 +203,7 @@ export const v0_6_0: Migration = {
         return true;
       },
       persist: async () => {
-        console.log(`Persisting migrated data for ${MIGRATION_VERSION} upgrade`);
+        console.info(`Persisting migrated data for ${MIGRATION_VERSION} upgrade`);
         // Get temporary storage
         const tmpAppSettings = getItemFromLocalStorage('appSettings_tmp');
         const tmpWalletInfo = getItemFromLocalStorage('wallet_tmp');
@@ -227,7 +227,7 @@ export const v0_6_0: Migration = {
         await clearBackgroundStorage(['keyAgentsByChain_tmp' as BackgroundStorageKeys]);
       },
       rollback: async () => {
-        console.log(`Rollback migrated data for ${MIGRATION_VERSION} upgrade`);
+        console.info(`Rollback migrated data for ${MIGRATION_VERSION} upgrade`);
         // Restore actual storage to their original values
         if (oldAppSettings) setItemInLocalStorage('appSettings', oldAppSettings);
         if (oldWalletInfo) setItemInLocalStorage('wallet', oldWalletInfo);

--- a/apps/browser-extension-wallet/src/lib/scripts/migrations/versions/v1_0_0.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/migrations/versions/v1_0_0.ts
@@ -27,7 +27,7 @@ export const v_1_0_0: Migration = {
       prepare: () => {
         // Save temporary storage. Revert if something fails
         try {
-          console.log('Saving temporary migration for', MIGRATION_VERSION);
+          console.info('Saving temporary migration for', MIGRATION_VERSION);
 
           if (oldKeyAgentData && !mainnetKeyAgentData) {
             // If there is an active key agent data, it means that we have an unlocked wallet, regardless of lock
@@ -48,7 +48,7 @@ export const v_1_0_0: Migration = {
           // In these cases we don't need to do anything,
           //   if it's locked changing the appSettings should be enough for the wallet to be restored in mainnet on unlock
         } catch (error) {
-          console.log(`Error saving temporary migrations for ${MIGRATION_VERSION}, deleting...`, error);
+          console.info(`Error saving temporary migrations for ${MIGRATION_VERSION}, deleting...`, error);
           removeItemFromLocalStorage('keyAgentData_tmp');
           removeItemFromLocalStorage('appSettings_tmp');
           throw error;
@@ -67,7 +67,7 @@ export const v_1_0_0: Migration = {
         return true;
       },
       persist: () => {
-        console.log(`Persisting migrated data for ${MIGRATION_VERSION} upgrade`);
+        console.info(`Persisting migrated data for ${MIGRATION_VERSION} upgrade`);
         // Get temporary storage
         const tmpAppSettings = getItemFromLocalStorage('appSettings_tmp');
         const tmpKeyAgentData = getItemFromLocalStorage('keyAgentData_tmp');
@@ -79,7 +79,7 @@ export const v_1_0_0: Migration = {
         removeItemFromLocalStorage('keyAgentData_tmp');
       },
       rollback: () => {
-        console.log(`Rollback migrated data for ${MIGRATION_VERSION} upgrade`);
+        console.info(`Rollback migrated data for ${MIGRATION_VERSION} upgrade`);
         // Restore actual storage to their original values
         if (oldAppSettings) setItemInLocalStorage('appSettings', oldAppSettings);
         if (oldKeyAgentData) setItemInLocalStorage('keyAgentData', oldKeyAgentData);

--- a/apps/browser-extension-wallet/src/utils/get-assets-information.ts
+++ b/apps/browser-extension-wallet/src/utils/get-assets-information.ts
@@ -33,7 +33,7 @@ export const getAssetsInformation = async (
         fetchedAssets.push(...fetched);
       } catch (error) {
         // If an error occurs fetching from the provider then just skip this chunk
-        console.log('Error fetching assets info', { error: error.message });
+        console.error('Error fetching assets info', { error: error.message });
       }
     }
     assetsInformation.push(...fetchedAssets);

--- a/apps/browser-extension-wallet/src/utils/validators/__tests__/address-book.test.ts
+++ b/apps/browser-extension-wallet/src/utils/validators/__tests__/address-book.test.ts
@@ -127,7 +127,7 @@ describe('Testing address book validator', () => {
       expect(addressBook.isValidAddress('asd')).toEqual(false);
     });
     test('should return false in case it throws', () => {
-      const logSpy = jest.spyOn(console, 'log');
+      const logSpy = jest.spyOn(console, 'error');
 
       mockIsAddress.mockImplementation(() => {
         throw new Error('error');

--- a/apps/browser-extension-wallet/src/utils/validators/address-book.ts
+++ b/apps/browser-extension-wallet/src/utils/validators/address-book.ts
@@ -62,7 +62,7 @@ export const isValidAddress = (address: string): boolean => {
   try {
     isValid = Wallet.Cardano.isAddress(address);
   } catch (error) {
-    console.log(error.message);
+    console.error(error.message);
     isValid = false;
   }
   return isValid;

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AssetPicker.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/AssetPicker.tsx
@@ -152,7 +152,7 @@ export const AssetPicker = ({ isPopupView }: AssetPickerProps): React.ReactEleme
     if (selectedTokenList.length > 0) {
       isTokenBundleSizeExceedingLimit(selectedTokenList, inMemoryWallet)
         .then((res) => setExceededLimit(res))
-        .catch((error) => console.log(error));
+        .catch((error) => console.error(error));
     }
   }, [selectedTokenList, inMemoryWallet]);
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/NetworkChoice.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/NetworkChoice.tsx
@@ -44,7 +44,7 @@ export const NetworkChoice = (): React.ReactElement => {
         icon: SwithIcon
       });
     } catch (error) {
-      console.log('Error switching networks', error);
+      console.error('Error switching networks', error);
       toast.notify({ text: t('general.errors.somethingWentWrong'), icon: ErrorIcon });
     }
     return event;

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsPreferences/CurrencyDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsPreferences/CurrencyDrawer.tsx
@@ -30,7 +30,7 @@ export const CurrencyDrawer = ({ visible, onClose, popupView = false }: Currency
         icon: SwithIcon
       });
     } catch (error) {
-      console.log('Error updating currency', error);
+      console.error('Error updating currency', error);
       toast.notify({ text: t('general.errors.somethingWentWrong'), icon: ErrorIcon });
     }
     return event;

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -177,7 +177,7 @@ export const HardwareWalletFlow = ({
       );
       navigateTo('finish');
     } catch (error) {
-      console.log('ERROR creating hardware wallet', { error });
+      console.error('ERROR creating hardware wallet', { error });
       showHardwareWalletError('common');
     }
   };
@@ -188,7 +188,7 @@ export const HardwareWalletFlow = ({
       setDeviceConnection(connection);
       setConnectedDevice(model);
     } catch (error) {
-      console.log('ERROR connecting hardware wallet', error);
+      console.error('ERROR connecting hardware wallet', error);
       if (error.innerError?.innerError?.message === 'The device is already open.') {
         setDeviceConnection(deviceConnection);
       } else {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -275,8 +275,7 @@ export const WalletSetupWizard = ({
         moveForward();
       }
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log('Error completing wallet creation', error);
+      console.error('Error completing wallet creation', error);
       throw new Error(error);
     }
   }, [

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-cmd": "eslint --cache --cache-location .cache/eslintcache --cache-strategy metadata --ignore-path ./.eslintignore",
     "extension:lint": "yarn eslint-cmd \"apps/browser-extension-wallet/**/*.{js,ts,tsx}\"",
     "postinstall": "husky install & ts-patch install -s",
-    "lint": "yarn workspaces foreach -ptRv run lint && yarn markdown:lint",
+    "lint": "yarn workspaces foreach -ptv run lint && yarn markdown:lint",
     "markdown:lint": "markdownlint '{packages,apps}/**/*.md' -p .gitignore",
     "markdown:lint:fix": "yarn markdown:lint --fix",
     "staking": "APP_NAME=staking yarn $0",

--- a/packages/core/src/ui/components/AddressFormBrowserView/AddressForm.tsx
+++ b/packages/core/src/ui/components/AddressFormBrowserView/AddressForm.tsx
@@ -49,7 +49,7 @@ export const AddressFormBrowserView = ({
       form.resetFields();
       if (onClose) onClose();
     } catch (error) {
-      console.log('Error while submitting new address', error);
+      console.error('Error while submitting new address', error);
     }
   };
   const Plus = PlusIcon ? <PlusIcon className={styles.icon} /> : <PlusCircleOutlined />;

--- a/packages/e2e-tests/src/data/expectedStakePoolsData.ts
+++ b/packages/e2e-tests/src/data/expectedStakePoolsData.ts
@@ -68,7 +68,7 @@ export const getStakePoolById = (id: string, network?: 'testnet' | 'mainnet'): S
   const expectedPools = network === 'mainnet' ? StakePoolsMainnetArray : StakePoolsArray;
   for (const pool of expectedPools) {
     if (pool.poolId === id) {
-      console.log(`returning pool${pool.poolId} ${pool.name}`);
+      console.info(`returning pool${pool.poolId} ${pool.name}`);
       return pool;
     }
   }

--- a/packages/e2e-tests/src/steps/forgotPasswordSteps.ts
+++ b/packages/e2e-tests/src/steps/forgotPasswordSteps.ts
@@ -43,7 +43,7 @@ Then(/^I switch to tab with restore wallet process$/, async () => {
       result = await browser.switchWindow(/setup\/restore/);
       pageFound = typeof result === 'string';
     } catch {
-      console.log('Page not found. Retrying in 1s ...');
+      console.error('Page not found. Retrying in 1s ...');
       await browser.pause(1000);
     }
     retries--;

--- a/packages/e2e-tests/src/utils/networkManager.ts
+++ b/packages/e2e-tests/src/utils/networkManager.ts
@@ -106,8 +106,7 @@ export class NetworkManager {
             const approximateTimestamp = new Date().toString();
             const combinedFailedRequestInfo = `URL:\n${request.response.url}\n\nRESPONSE CODE:\n${request.response.status}\n\nAPPROXIMATE TIME:\n${approximateTimestamp}\n\nRESPONSE BODY:\n${responseBody}\n\nREQUEST PAYLOAD:\n${requestPayload}`;
             allure.addAttachment('Failed request', combinedFailedRequestInfo, 'text/plain');
-            console.log('Failed request');
-            console.log(combinedFailedRequestInfo);
+            console.error('Failed request', combinedFailedRequestInfo);
           }
         });
       });


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8396
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Currently it's easy to forget a `console.log()` statement in the PR as no eslint check warns the dev about that, leaving up to the dev/reviewer to spot that. Even though webpack drops `console` statements from the prod build, it still seems worthwhile to prevent the dev build console from being spammed by such "forgotten" console.log statements.

In this PR I'm re-enabling the `no-console` eslint rule, keeping it disabled just for `console.debug/warn/error/info` where it seems reasonable to assume that it was the intent of the developer to log something beyond ad-hoc debugging. I took this PR also as a chance to change the existing `console.log` instances to appropriate `console.error` or `console.info` depending on the apparent context around

Additionally, while enabling the `no-console` rule I noticed that `yarn lint` doesn't execute any linting for the underlying workspaces which is also fixed in this PR. The issue seems to have been caused by the `R` flag in the underlying command:

`yarn workspaces foreach -ptRv run lint`

As per the docs the `R` flag runs the recursion for the underlying "dependencies", not "workspaces", resulting in an empty execution as the relevant workspaces are not listed as "dependencies":

> - If `-R,--recursive` is set, Yarn will find workspaces to run the command on by
 recursively evaluating `dependencies` and `devDependencies` fields, instead of
 looking at the `workspaces` fields.

## Testing

1. check that CI passes
2. try adding a `console.log` in the codebase and check that it's caught by `yarn lint`
3. check that `yarn lint` executes properly (i.e. for all workspaces)



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/1988/6146361790/index.html) for [9a3903bc](https://github.com/input-output-hk/lace/pull/521/commits/9a3903bcc10fdf8723ae95efb4f266de7f625c48)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->