### PR TITLE
Chore/bump main to 1.5

### DIFF
--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -43,7 +43,7 @@ TERMS_OF_USE_URL=https://www.lace.io/lace-terms-of-use.pdf
 # events tracking
 MATOMO_API_ENDPOINT=https://matomo.cw.iog.io/matomo.php
 PUBLIC_POSTHOG_HOST=https://eu.posthog.com
-PRODUCTION_MODE_TRACKING=false
+PRODUCTION_MODE_TRACKING=true
 
 # Cardano Services
 CARDANO_SERVICES_URL_MAINNET=https://backend.live-mainnet.eks.lw.iog.io

--- a/apps/browser-extension-wallet/manifest.json
+++ b/apps/browser-extension-wallet/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Lace",
   "description": "One fast, accessible, and secure platform for digital assets, DApps, NFTs, and DeFi.",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "manifest_version": 3,
   "key": "$LACE_EXTENSION_KEY",
   "icons": {

--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lace/browser-extension-wallet",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A fully capable wallet packaged as browser extensions for Chrome, Firefox, and Edge",
   "homepage": "https://github.com/input-output-hk/lace/blob/master/apps/browser-extension-wallet/README.md",
   "bugs": {

--- a/apps/browser-extension-wallet/src/release-notes/1_5_0.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_5_0.tsx
@@ -5,7 +5,10 @@ const ReleaseNote_1_5_0 = (): React.ReactElement => (
   <>
     <p>Introducing Lace 1.5.0 This version supports the following features:</p>
     <ul style={{ listStyleType: 'disc', margin: 0 }}>
-      <li></li>
+      <li>Feature: Stake to multiple pools</li>
+      <li>Feature: More Ledger support</li>
+      <li>Feature: Update handles when sending funds</li>
+      <li>Feature: Easier collateral setup</li>
     </ul>
     <p>
       Check out the details in the{' '}

--- a/apps/browser-extension-wallet/src/release-notes/1_5_0.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_5_0.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+import React from 'react';
+
+const ReleaseNote_1_5_0 = (): React.ReactElement => (
+  <>
+    <p>Introducing Lace 1.5.0 This version supports the following features:</p>
+    <ul style={{ listStyleType: 'disc', margin: 0 }}>
+      <li></li>
+    </ul>
+    <p>
+      Check out the details in the{' '}
+      <a href="https://www.lace.io/blog/lace-1-5-release" target="_blank">
+        blog
+      </a>
+    </p>
+  </>
+);
+
+export default ReleaseNote_1_5_0;


### PR DESCRIPTION
Also enables tracking by default, which was only enabled in the release branch due to pending legal approval


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2016/6170612487/index.html) for [60637d81](https://github.com/input-output-hk/lace/pull/525/commits/60637d812a913c960a8bbae7443b48319f6547c3)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 2      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->