### PR TITLE
fix(staking): fix eslint warnings, staking workflow not executing for labeled PRs

### DIFF
--- a/.github/workflows/packages-staking.yml
+++ b/.github/workflows/packages-staking.yml
@@ -7,6 +7,7 @@ name: packages/staking
 
 on:
   pull_request:
+    types: [synchronize, labeled]
   push:
     branches:
       - main

--- a/packages/staking/src/features/overview/FundWalletBanner.tsx
+++ b/packages/staking/src/features/overview/FundWalletBanner.tsx
@@ -117,7 +117,11 @@ export const FundWalletBanner = ({
   const boundingBox = useBoundingBox(container);
 
   return (
-    <div data-testid="fund-wallet-banner" ref={setContainer as any} className={styles.fundWalletBanner}>
+    <div
+      data-testid="fund-wallet-banner"
+      ref={setContainer as React.LegacyRef<HTMLDivElement>}
+      className={styles.fundWalletBanner}
+    >
       {boundingBox && boundingBox?.width > smallScreenSizeInPx ? (
         <>{largeSizeScreenContent}</>
       ) : (

--- a/packages/staking/src/features/overview/StakeFundsBanner.tsx
+++ b/packages/staking/src/features/overview/StakeFundsBanner.tsx
@@ -16,7 +16,7 @@ export const StakeFundsBanner = ({ balance, popupView }: props): React.ReactElem
   const { walletStoreWalletUICardanoCoin } = useOutsideHandles();
   const { t } = useTranslation();
   return (
-    <div className={cn(styles.container, { [styles.popupView as any]: popupView })}>
+    <div className={cn(styles.container, { [styles.popupView as string]: popupView })}>
       {popupView ? <BgImgPopup className={styles.bg} /> : <BgImg className={styles.bg} />}
       <div className={styles.content}>
         <div className={styles.title}>{t('overview.noStaking.title')}</div>

--- a/packages/staking/src/features/staking/Navigation.tsx
+++ b/packages/staking/src/features/staking/Navigation.tsx
@@ -16,7 +16,6 @@ export const Navigation = ({ children }: NavigationProps) => {
   }));
   const { t } = useTranslation();
   const onValueChange = (value: string) => {
-    console.log(value);
     if (isValueAValidSubPage(value)) setActivePage(value);
   };
 


### PR DESCRIPTION
I noticed `main` CI is failing which turned out to be related to the recent eslint fix in CI

https://github.com/input-output-hk/lace/actions/runs/6183121545/job/16784211410

The `console.log` erro got meanwhile fixed, this PR nevertheless addresses the remaining two warnings

Moreover, workflow for `packages/staking` wasn't always executed as expected (can be seen e.g. here: https://github.com/input-output-hk/lace/pull/530), because the `staking` label, automatically added by the labeler job, wasn't present at the moment of the workflow execution, resulting in the workflow being skipped, this PR fixes that as well

## How to test

run `yarn workspace @lace/staking eslint:check` and verify that there are no errors

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2025/6184504188/index.html) for [4840f150](https://github.com/input-output-hk/lace/pull/531/commits/4840f150464539ffea755e7539fc5bfbb7652516)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->