### PR TITLE
chore(extension): disable production mode tracking

### DIFF
--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -43,7 +43,8 @@ TERMS_OF_USE_URL=https://www.lace.io/lace-terms-of-use.pdf
 # events tracking
 MATOMO_API_ENDPOINT=https://matomo.cw.iog.io/matomo.php
 PUBLIC_POSTHOG_HOST=https://eu.posthog.com
-PRODUCTION_MODE_TRACKING=true
+# set this variable to true only in release packages. By having this set to false, we ensure that we will not be using Post Hog production projects tokens in development stage
+PRODUCTION_MODE_TRACKING=false
 
 # Cardano Services
 CARDANO_SERVICES_URL_MAINNET=https://backend.live-mainnet.eks.lw.iog.io

--- a/apps/browser-extension-wallet/.env.example
+++ b/apps/browser-extension-wallet/.env.example
@@ -43,6 +43,7 @@ TERMS_OF_USE_URL=https://www.lace.io/lace-terms-of-use.pdf
 # events tracking
 MATOMO_API_ENDPOINT=https://matomo.cw.iog.io/matomo.php
 PUBLIC_POSTHOG_HOST=https://eu.posthog.com
+# set this variable to true only in release packages. By having this set to false, we ensure that we will not be using Post Hog production projects tokens in development stage
 PRODUCTION_MODE_TRACKING=false
 SESSION_LENGTH_IN_SECONDS=60
 


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR disable the Post Hog production tracking in development stage, right now we have it set to true and we are using the production project tokens, so, we might be polluting the production project with incorrect events


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2026/6184611747/index.html) for [780f3130](https://github.com/input-output-hk/lace/pull/532/commits/780f31308df21f9bbb8825cabd7dff0b97b77c1b)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->