### PR TITLE
ci(all): fix 'Build Staking Center' job filtering, run it always

### DIFF
--- a/.github/workflows/packages-staking.yml
+++ b/.github/workflows/packages-staking.yml
@@ -1,23 +1,22 @@
 name: packages/staking
 
 # Triggering this workflow:
-# 1. Push to main branch
+# 1. Push to main/release branch
 # 2. Pushing to Pull Request with "staking" label
 # 3. Adding "staking" label to Pull Request
 
 on:
   pull_request:
-    types: [synchronize, labeled]
   push:
     branches:
-      - main
+      - 'main'
+      - 'release/**'
 
 jobs:
   build_staking:
     name: Build Staking Center
     runs-on: ubuntu-22.04
     container: mcr.microsoft.com/playwright:v1.32.2-jammy
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'staking') || contains(github.event.pull_request.labels.*.name, 'ui-toolkit')
     steps:
       - name: Setup Build Essential
         run: apt-get update && apt-get install build-essential -y


### PR DESCRIPTION
## Proposed solution

Turns out github workflow for staking wasn't run after opening the PR because the worklow didn't have access to the labels added by the Labeler job only later. This was attempted to be fixed in #465 but turns out that the job could get scheduled and remain unexecuted which blocked the pipeline (see e.g. https://github.com/input-output-hk/lace/pull/535) 

Moreover it turns out that the `actions/labeler` job doesn't trigger the `labeled` action at all, it can be triggered only manually (or through a personal access token), see this issue: https://github.com/actions/labeler/issues/315 . So the PRs wouldn't be properly checked for the first commit where the PR wasn't labeled yet and there doesn't seem to be a reasonable solution to this, if we want to preserve the selective execution of this job for labeled PRs

Therefore, the simplest solution seems to be to just enable the staking center job for all PRs/pushes to main/release which is what we do in this PR, which shouldn't have a significant impact on the overall pipeline load/execution time as the job takes relatively little time (~5 minutes) respective to other jobs which take up to ~30 minutes

## Testing

Check that the CI passed properly


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2067/6221864241/index.html) for [342ea259](https://github.com/input-output-hk/lace/pull/544/commits/342ea2599cc01a72f00178babe873cf5e42cf0f8)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 28     | 4      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->