### PR TITLE
feat(extension): add configurable extension uninstall redirect LW-8535

### DIFF
--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -65,3 +65,6 @@ ADA_HANDLE_URL_PREPROD=https://preprod.api.handle.me
 
 # Manifest.json
 LACE_EXTENSION_KEY=gafhhkghbfjjkeiendhlofajokpaflmk
+
+# Extension uninstall redirect
+LACE_EXTENSION_UNINSTALL_REDIRECT_URL=https://forms.gle/wwuZMJ3FCyU68u9H7

--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -67,4 +67,4 @@ ADA_HANDLE_URL_PREPROD=https://preprod.api.handle.me
 LACE_EXTENSION_KEY=gafhhkghbfjjkeiendhlofajokpaflmk
 
 # Extension uninstall redirect
-LACE_EXTENSION_UNINSTALL_REDIRECT_URL=https://forms.gle/wwuZMJ3FCyU68u9H7
+LACE_EXTENSION_UNINSTALL_REDIRECT_URL=https://forms.gle/XNcPfWafY8XgxkYw7

--- a/apps/browser-extension-wallet/.env.example
+++ b/apps/browser-extension-wallet/.env.example
@@ -66,6 +66,3 @@ ADA_HANDLE_URL_PREPROD=https://preprod.api.handle.me
 
 # Manifest.json
 LACE_EXTENSION_KEY=gafhhkghbfjjkeiendhlofajokpaflmk
-
-# Extension uninstall redirect
-LACE_EXTENSION_UNINSTALL_REDIRECT_URL=https://lace.io

--- a/apps/browser-extension-wallet/.env.example
+++ b/apps/browser-extension-wallet/.env.example
@@ -66,3 +66,6 @@ ADA_HANDLE_URL_PREPROD=https://preprod.api.handle.me
 
 # Manifest.json
 LACE_EXTENSION_KEY=gafhhkghbfjjkeiendhlofajokpaflmk
+
+# Extension uninstall redirect
+LACE_EXTENSION_UNINSTALL_REDIRECT_URL=https://lace.io

--- a/apps/browser-extension-wallet/src/lib/scripts/background/index.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/index.ts
@@ -3,3 +3,4 @@ import './onError';
 import './onUpdate';
 import './services';
 import './keep-alive-sw';
+import './onUninstall';

--- a/apps/browser-extension-wallet/src/lib/scripts/background/onUninstall.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/onUninstall.ts
@@ -1,0 +1,7 @@
+import { runtime } from 'webextension-polyfill';
+
+const uninstallRedirect = process.env.LACE_EXTENSION_UNINSTALL_REDIRECT_URL;
+
+if (uninstallRedirect !== undefined) {
+  runtime.setUninstallURL(uninstallRedirect);
+}


### PR DESCRIPTION
# Checklist

- [x] [JIRA ticket](https://input-output.atlassian.net/browse/LW-8535)

---

## Proposed solution

This PR adds uninstall redirect logic, which can be used to redirect users who uninstall the extension to a configurable URL to give feedback.

## Testing

1. By default nothing should happen on uninstall (because the environment flag for it is not set by default yet)
2. To enable the feature, set `LACE_EXTENSION_UNINSTALL_REDIRECT_URL=https://lace.io` in your `.env` and check that https://lace.io is opened after uninstalling the Chrome extension. 


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2279/6352714374/index.html) for [0f59ac32](https://github.com/input-output-hk/lace/pull/549/commits/0f59ac32e7c9cfe34622d8c3697ace2e1128d92e)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 2      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->