### PR TITLE
Implement events for user dropdown menu

### DIFF
--- a/apps/browser-extension-wallet/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/apps/browser-extension-wallet/src/components/DropdownMenu/DropdownMenu.tsx
@@ -9,21 +9,35 @@ import ChevronSmall from '../../assets/icons/chevron-down-small.component.svg';
 import styles from './DropdownMenu.module.scss';
 import { useWalletStore } from '@src/stores';
 import { UserAvatar } from '../MainMenu/DropdownMenuOverlay/components';
+import { useAnalyticsContext } from '@providers';
+import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 
 export interface DropdownMenuProps {
   isPopup?: boolean;
 }
 
 export const DropdownMenu = ({ isPopup }: DropdownMenuProps): React.ReactElement => {
+  const analytics = useAnalyticsContext();
   const { walletInfo } = useWalletStore();
   const [open, setOpen] = useState(false);
   const Chevron = isPopup ? ChevronSmall : ChevronNormal;
 
+  const sendAnalyticsEvent = (event: PostHogAction) => {
+    analytics.sendEventToPostHog(event);
+  };
+
+  const handleDropdownState = (openDropdown: boolean) => {
+    setOpen(openDropdown);
+    if (openDropdown) {
+      sendAnalyticsEvent(PostHogAction.UserWalletProfileIconClick);
+    }
+  };
+
   return (
     <Dropdown
       destroyPopupOnHide
-      onVisibleChange={setOpen}
-      overlay={<DropdownMenuOverlay isPopup={isPopup} />}
+      onVisibleChange={handleDropdownState}
+      overlay={<DropdownMenuOverlay isPopup={isPopup} sendAnalyticsEvent={sendAnalyticsEvent} />}
       placement="bottomRight"
       trigger={['click']}
     >

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/DropdownMenuOverlay.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/DropdownMenuOverlay.tsx
@@ -13,20 +13,28 @@ import {
 import styles from './DropdownMenuOverlay.module.scss';
 import { NetworkInfo } from './components/NetworkInfo';
 import { Sections } from './types';
+import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 
 interface Props extends MenuProps {
   isPopup?: boolean;
   lockWalletButton?: ReactNode;
   topSection?: ReactNode;
+  sendAnalyticsEvent?: (event: PostHogAction) => void;
 }
 
 export const DropdownMenuOverlay: VFC<Props> = ({
   isPopup,
   lockWalletButton = <LockWallet />,
   topSection = <UserInfo />,
+  sendAnalyticsEvent,
   ...props
 }): React.ReactElement => {
   const [currentSection, setCurrentSection] = useState<Sections>(Sections.Main);
+
+  const handleNetworkChoise = () => {
+    setCurrentSection(Sections.NetworkInfo);
+    sendAnalyticsEvent(PostHogAction.UserWalletProfileNetworkClick);
+  };
 
   return (
     <Menu {...props} className={styles.menuOverlay} data-testid="header-menu">
@@ -38,7 +46,7 @@ export const DropdownMenuOverlay: VFC<Props> = ({
             <SettingsLink />
             <Separator />
             <ThemeSwitcher isPopup={isPopup} />
-            <NetworkChoise onClick={() => setCurrentSection(Sections.NetworkInfo)} />
+            <NetworkChoise onClick={handleNetworkChoise} />
             {lockWalletButton && (
               <>
                 <Separator /> {lockWalletButton}

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/AddressBookLink.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/AddressBookLink.tsx
@@ -8,7 +8,8 @@ import { useAnalyticsContext } from '@providers';
 import {
   MatomoEventActions,
   MatomoEventCategories,
-  AnalyticsEventNames
+  AnalyticsEventNames,
+  PostHogAction
 } from '@providers/AnalyticsProvider/analyticsTracker';
 
 export const AddressBookLink = ({ isPopup }: { isPopup: boolean }): React.ReactElement => {
@@ -23,6 +24,7 @@ export const AddressBookLink = ({ isPopup }: { isPopup: boolean }): React.ReactE
         ? AnalyticsEventNames.AddressBook.VIEW_ADDRESSES_POPUP
         : AnalyticsEventNames.AddressBook.VIEW_ADDRESSES_BROWSER
     });
+    analytics.sendEventToPostHog(PostHogAction.UserWalletProfileAddressBookClick);
   };
 
   return (

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/LockWallet.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/LockWallet.tsx
@@ -4,14 +4,27 @@ import { useWalletStore } from '@src/stores';
 import { Menu } from 'antd';
 import { useTranslation } from 'react-i18next';
 import styles from '../DropdownMenuOverlay.module.scss';
+import { useAnalyticsContext } from '@providers';
+import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 
 export const LockWallet = (): React.ReactElement => {
   const { t } = useTranslation();
   const { lockWallet } = useWalletManager();
   const { walletLock } = useWalletStore();
+  const analytics = useAnalyticsContext();
+
+  const handleLockWallet = () => {
+    analytics.sendEventToPostHog(PostHogAction.UserWalletProfileLockWalletClick);
+    lockWallet();
+  };
 
   return (
-    <Menu.Item data-testid="header-menu-lock" onClick={lockWallet} className={styles.menuItem} disabled={!walletLock}>
+    <Menu.Item
+      data-testid="header-menu-lock"
+      onClick={handleLockWallet}
+      className={styles.menuItem}
+      disabled={!walletLock}
+    >
       {t('browserView.topNavigationBar.links.lockWallet')}
     </Menu.Item>
   );

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/NetworkInfo.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/NetworkInfo.tsx
@@ -25,7 +25,7 @@ export const NetworkInfo = ({ onBack }: NetworkChoiseProps): React.ReactElement 
         </div>
       </div>
       <div className={styles.content} data-testid="user-dropdown-network-choice">
-        <NetworkChoice />
+        <NetworkChoice section="wallet-profile" />
       </div>
     </div>
   );

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/SettingsLink.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/SettingsLink.tsx
@@ -4,12 +4,19 @@ import { Menu } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import styles from '../DropdownMenuOverlay.module.scss';
+import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
+import { useAnalyticsContext } from '@providers';
 
 export const SettingsLink = (): React.ReactElement => {
   const { t } = useTranslation();
+  const analytics = useAnalyticsContext();
+
+  const handleOnLinkClick = () => {
+    analytics.sendEventToPostHog(PostHogAction.UserWalletProfileSettingsClick);
+  };
 
   return (
-    <Link to={walletRoutePaths.settings}>
+    <Link to={walletRoutePaths.settings} onClick={handleOnLinkClick}>
       <Menu.Item data-testid="header-menu-settings" className={styles.menuItem}>
         <a>{t('browserView.topNavigationBar.links.settings')}</a>
       </Menu.Item>

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/ThemeSwitcher.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/ThemeSwitcher.tsx
@@ -7,6 +7,8 @@ import { useTheme } from '@providers/ThemeProvider/context';
 import SunIcon from '../../../../assets/icons/sun.component.svg';
 import MoonIcon from '../../../../assets/icons/moon.component.svg';
 import { useBackgroundServiceAPIContext } from '@providers/BackgroundServiceAPI';
+import { useAnalyticsContext } from '@providers';
+import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 
 const modeTranslate: Record<string, string> = {
   light: 'browserView.sideMenu.mode.light',
@@ -20,6 +22,7 @@ interface Props {
 export const ThemeSwitch = ({ isPopup }: Props): React.ReactElement => {
   const { theme, setTheme } = useTheme();
   const backgroundServices = useBackgroundServiceAPIContext();
+  const analytics = useAnalyticsContext();
 
   const handleCurrentTheme = () => {
     const pickedTheme = theme.name === 'light' ? 'dark' : 'light';
@@ -28,6 +31,11 @@ export const ThemeSwitch = ({ isPopup }: Props): React.ReactElement => {
     if (isPopup) {
       backgroundServices.handleChangeTheme({ theme: pickedTheme });
     }
+    analytics.sendEventToPostHog(
+      pickedTheme === 'light'
+        ? PostHogAction.UserWalletProfileLightModeClick
+        : PostHogAction.UserWalletProfileDarkModeClick
+    );
   };
 
   return (

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/UserInfo.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/UserInfo.tsx
@@ -9,6 +9,8 @@ import { toast, addEllipsis } from '@lace/common';
 import { WalletStatusContainer } from '@components/WalletStatus';
 import { UserAvatar } from './UserAvatar';
 import { useGetHandles } from '@hooks';
+import { useAnalyticsContext } from '@providers';
+import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 
 const ADRESS_FIRST_PART_LENGTH = 10;
 const ADRESS_LAST_PART_LENGTH = 5;
@@ -28,11 +30,17 @@ interface UserInfoProps {
 export const UserInfo = ({ avatarVisible = true }: UserInfoProps): React.ReactElement => {
   const { t } = useTranslation();
   const { walletInfo } = useWalletStore();
+  const analytics = useAnalyticsContext();
   const walletAddress = walletInfo.addresses[0].address.toString();
   const shortenedWalletAddress = addEllipsis(walletAddress, ADRESS_FIRST_PART_LENGTH, ADRESS_LAST_PART_LENGTH);
   const walletName = addEllipsis(walletInfo.name.toString(), WALLET_NAME_MAX_LENGTH, 0);
   const [handle] = useGetHandles();
   const handleName = handle?.nftMetadata?.name;
+
+  const handleOnAddressCopy = () => {
+    toast.notify({ duration: TOAST_DEFAULT_DURATION, text: t('general.clipboard.copiedToClipboard') });
+    analytics.sendEventToPostHog(PostHogAction.UserWalletProfileWalletAddressClick);
+  };
 
   return (
     <Menu.ItemGroup className={classnames(styles.menuItem, styles.borderBottom)} data-testid="header-menu-user-info">
@@ -47,12 +55,7 @@ export const UserInfo = ({ avatarVisible = true }: UserInfoProps): React.ReactEl
               </span>
             }
           >
-            <div
-              className={styles.userInfo}
-              onClick={() =>
-                toast.notify({ duration: TOAST_DEFAULT_DURATION, text: t('general.clipboard.copiedToClipboard') })
-              }
-            >
+            <div className={styles.userInfo} onClick={handleOnAddressCopy}>
               {avatarVisible && <UserAvatar walletName={walletName} />}
               <div className={styles.userMeta} data-testid="header-menu-user-details">
                 <p className={styles.walletName} data-testid="header-menu-wallet-name">

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -126,7 +126,19 @@ export enum PostHogAction {
   SettingsCollateralClick = 'settings | collateral | click',
   SettingsCollateralConfirmClick = 'settings | collateral | confirm | click',
   SettingsCollateralReclaimCollateralClick = 'settings | collateral | reclaim collateral | click',
-  SettingsCollateralXClick = 'settings | collateral | x | click'
+  SettingsCollateralXClick = 'settings | collateral | x | click',
+  // User
+  UserWalletProfileIconClick = 'user/wallet profile | profile icon | click',
+  UserWalletProfileWalletAddressClick = 'user/wallet profile | wallet address | click',
+  UserWalletProfileAddressBookClick = 'user/wallet profile | address book | click',
+  UserWalletProfileSettingsClick = 'user/wallet profile | settings | click',
+  UserWalletProfileLightModeClick = 'user/wallet profile | light mode | click',
+  UserWalletProfileDarkModeClick = 'user/wallet profile | dark mode | click',
+  UserWalletProfileNetworkClick = 'user/wallet profile | network | click',
+  UserWalletProfileNetworkPreviewClick = 'user/wallet profile | network | preview | click',
+  UserWalletProfileNetworkPreprodClick = 'user/wallet profile | network | preprod | click',
+  UserWalletProfileNetworkMainnetClick = 'user/wallet profile | network | mainnet | click',
+  UserWalletProfileLockWalletClick = 'user/wallet profile | lock wallet | click'
 }
 
 export enum EnhancedAnalyticsOptInStatus {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/NetworkChoiceDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/NetworkChoiceDrawer.tsx
@@ -37,7 +37,7 @@ export const NetworkChoiceDrawer = ({
       <div className={popupView ? styles.popupContainer : undefined}>
         <Text className={styles.drawerDescription}>{t('browserView.settings.wallet.network.drawerDescription')}</Text>
         <div className={styles.radios}>
-          <NetworkChoice />
+          <NetworkChoice section="settings" />
         </div>
       </div>
     </Drawer>


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-8371](https://input-output.atlassian.net/browse/LW-8371)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR implements events for the user dropdown menu on the top navigation bar

Event list:
- user/wallet profile | profile icon | click
- user/wallet profile | wallet address | click
- user/wallet profile | address book | click
- user/wallet profile | settings | click
- user/wallet profile | light mode | click
- user/wallet profile | dark mode | click
- user/wallet profile | network | click
- user/wallet profile | network | preview | click
- user/wallet profile | network | preprod | click
- user/wallet profile | network | mainnet | click
- user/wallet profile | lock wallet | click





[LW-8371]: https://input-output.atlassian.net/browse/LW-8371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2146/6264739753/index.html) for [3901e49d](https://github.com/input-output-hk/lace/pull/560/commits/3901e49d7992b1b48f39b4edfa0f97987a039a45)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->