### PR TITLE
fix(staking): LW-8378 reduce amount of decimals shown in StakingInfoCard

### DIFF
--- a/packages/staking/src/features/overview/staking-info-card/StakingInfoCard.tsx
+++ b/packages/staking/src/features/overview/staking-info-card/StakingInfoCard.tsx
@@ -23,9 +23,13 @@ export const formatLocaleNumber = (value: string, decimalPlaces: number = DEFAUL
     groupSize: 3,
   });
 
-const formatNumericValue = (val: number | string, suffix: number | string): React.ReactElement => (
+const formatNumericValue = (
+  val: number | string,
+  suffix: number | string,
+  decimalPlaces: number = DEFAULT_DECIMALS
+): React.ReactElement => (
   <>
-    {val ? formatLocaleNumber(String(val)) : '-'}
+    {val ? formatLocaleNumber(String(val), decimalPlaces) : '-'}
     {val !== undefined && <span className={styles.suffix}>{suffix}</span>}
   </>
 );
@@ -108,19 +112,19 @@ export const StakingInfoCard = ({
         <div className={cn(styles.col, styles.justifyContentSpaceAround)}>
           <Stats
             text={t('overview.stakingInfoCard.ros')}
-            value={apy && formatNumericValue(apy, '%')}
+            value={apy && formatNumericValue(apy, '%', 1)}
             popupView
             dataTestid="stats-apy"
           />
           <Stats
             text={t('overview.stakingInfoCard.fee')}
-            value={fee && formatNumericValue(fee, cardanoCoinSymbol)}
+            value={fee && formatNumericValue(fee, cardanoCoinSymbol, 0)}
             popupView
             dataTestid="stats-fee"
           />
           <Stats
             text={t('overview.stakingInfoCard.margin')}
-            value={formatNumericValue(margin, '%')}
+            value={formatNumericValue(margin, '%', 1)}
             popupView
             dataTestid="stats-margin"
           />


### PR DESCRIPTION
hotfixes edge-case with overflowing amounts for larger values

# Checklist

- [x] JIRA - LW-8378
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

The overflowing issue found should really concern only edge-cases with very high fees/margin which seems an unlikely combination for any "serious" pool. The main issue is that the margin ADA amount may in theory be unbounded and as of now there aren't designs to handle that. A possible solution could be showing the amount in a compact format (e.g. 10k ADA), accompanied with a tooltip but this seems to be too much effort considering the unlikelyhood of this scenario in practice.

Another alternative solution proposed in the task description was to remove one of the breakpoints (the smallest one, presumably), but that would result in the staking info section not being aligned with the header which is not ideal either and would impact all users, so I decided not to pursue that solution in this PR

So in the end, this PR just aligns the amount of decimals shown with the figma designs which naturally makes the ROS/Fee/Margin cell more compact and is actually barely enough to squeeze the abnormal pool data into the cell without overflowing

## Testing

Try delegating to a pool with high fees and margin, e.g. `ATADA Austria - PreView Pool` and check that its data is properly shown in the overview as the window gets horizonatlly narrowed, especially below 668px (`breakpoint-minimum`)

## Screenshots

Before:
![Screenshot 2023-09-22 at 15 46 03](https://github.com/input-output-hk/lace/assets/4980147/44dba16a-ebf9-4cf4-b31c-92f739444430)

After:
![Screenshot 2023-09-22 at 16 04 19](https://github.com/input-output-hk/lace/assets/4980147/4a108c92-b2e8-43c7-994a-9fa3dc28ea4d)


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2163/6275362506/index.html) for [d7b8edae](https://github.com/input-output-hk/lace/pull/562/commits/d7b8edaeac98989016a19f1934503179a41273f8)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->