### PR TITLE
fix(extension): remove insufficient balance check from dapp popup

### DIFF
--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
@@ -3,8 +3,6 @@ import { Ellipsis, ErrorPane } from '@lace/common';
 import { DappInfo, DappInfoProps } from '../DappInfo';
 import styles from './DappTransaction.module.scss';
 import { TranslationsFor } from '@ui/utils/types';
-import { ReactComponent as WarningIcon } from '../../assets/icons/warning-icon.component.svg';
-import Icon from '@ant-design/icons';
 
 type TransactionDetails = {
   fee: string;
@@ -27,27 +25,17 @@ export interface DappTransactionProps {
   dappInfo: Omit<DappInfoProps, 'className'>;
   /** Optional error message */
   errorMessage?: string;
-  translations: TranslationsFor<
-    'transaction' | 'amount' | 'recipient' | 'fee' | 'insufficientFunds' | 'adaFollowingNumericValue'
-  >;
-  hasInsufficientFunds: boolean;
+  translations: TranslationsFor<'transaction' | 'amount' | 'recipient' | 'fee' | 'adaFollowingNumericValue'>;
 }
 
 export const DappTransaction = ({
   transaction: { type, outputs, fee },
   dappInfo,
   errorMessage,
-  translations,
-  hasInsufficientFunds
+  translations
 }: DappTransactionProps): React.ReactElement => (
   <div>
     <DappInfo {...dappInfo} className={styles.dappInfo} />
-    {hasInsufficientFunds && (
-      <div className={styles.warningAlert}>
-        <Icon component={WarningIcon} />
-        <p>{translations.insufficientFunds}</p>
-      </div>
-    )}
     {errorMessage && <ErrorPane error={errorMessage} className={styles.error} />}
     <div data-testid="dapp-transaction-container" className={styles.details}>
       <div className={styles.header}>


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-8590](https://input-output.atlassian.net/browse/LW-8590)

---

## Proposed solution

Lace performs and incorrect, and redundant check on the wallet balances when verifying DApp transactions.
Remove this check as it’s the responsibility of the DApp to not over-spend. In future we can hook into wallet signing to look for errors and present these in a different flow.

## Testing

When creating a transaction via a DApp that tries to use more than the balance available. Assert that no warning is shown in Lace, and the transaction can be signed which will later be rejected by the node if submitted.


[LW-8590]: https://input-output.atlassian.net/browse/LW-8590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2218/6322725099/index.html) for [11d6adf6](https://github.com/input-output-hk/lace/pull/570/commits/11d6adf65527edad1abce3b1b651e75b51750605)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->