### PR TITLE
fix/LW-8337 - Collateral settings wrong password message

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useCollateral.ts
+++ b/apps/browser-extension-wallet/src/hooks/useCollateral.ts
@@ -96,8 +96,8 @@ export const useCollateral = (): UseCollateralReturn => {
           error: error.message
         });
         setTxBuilder(undefined);
-        throw error;
       }
+      throw error;
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/send/CollateralFooterSend.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/send/CollateralFooterSend.tsx
@@ -56,13 +56,12 @@ export const CollateralFooterSend = ({
         return await backgroundServices?.handleOpenBrowser({ section: BrowserViewSections.COLLATERAL_SETTINGS });
       await submitTx();
       if (isInMemory) onClose();
-    } catch (error) {
+    } catch {
       if (!isInMemory) {
         setCurrentStep({ currentSection: Sections.FAIL_TX });
       } else {
         setIsPasswordValid(false);
       }
-      console.error(error);
     }
 
     return true;

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/send/CollateralStepSend.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/send/CollateralStepSend.tsx
@@ -36,7 +36,7 @@ export const CollateralStepSend = ({
   hasEnoughAda
 }: CollateralStepSendProps): JSX.Element => {
   const { t } = useTranslation();
-  const handleChange: inputProps['onChange'] = ({ target: { value } }) => {
+  const handlePasswordChange: inputProps['onChange'] = ({ target: { value } }) => {
     setIsPasswordValid(true);
     return setPassword(value);
   };
@@ -63,7 +63,7 @@ export const CollateralStepSend = ({
             <div data-testid="collateral-password" className={styles.passwordContainerCollateral}>
               <Spin spinning={false}>
                 <Password
-                  onChange={handleChange}
+                  onChange={handlePasswordChange}
                   value={password}
                   error={isPasswordValid === false}
                   errorMessage={t('browserView.transaction.send.error.invalidPassword')}


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8337

---

## Proposed solution

`submitCollateralTx` in `useCollateral` hook was not throwing when an error, like invalid password, occurred and it was not a hardware wallet


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2493/6484142187/index.html) for [17a20515](https://github.com/input-output-hk/lace/pull/577/commits/17a205159ba2a84444cb702e57cd573d87727102)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 0      | 0       | 0     | 32    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->