### PR TITLE
test(extension): e2e - LW-8524 add tests for automatic collateral setup

### DIFF
--- a/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
+++ b/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
@@ -75,28 +75,30 @@ class DAppConnectorAssert {
     await CollateralDAppPage.modalDescription.waitForDisplayed();
     const currentDAppUrl = new URL(expectedDappDetails.url);
 
-    await expect(await CollateralDAppPage.modalDescription.getText()).to.equal(
-      (await t('dapp.collateral.request'))
-        .replace('{{symbol}}', 'tADA')
-        .replace('{{symbol}}', 'tADA')
-        .replace('{{dapp}}', `${currentDAppUrl.protocol}//${currentDAppUrl.host}`)
-        .replace('{{requestedAmount}}', '5.00')
-        .replace('{{lockableAmount}}', '9.83')
+    const valuePlaceholder = 'valuePlaceholder';
+    const currentModalText = (await CollateralDAppPage.modalDescription.getText()).replaceAll(
+      /(\d+(?:\.\d*)?|\.\d+)/g,
+      valuePlaceholder
     );
+    const expectedModalText = (await t('dapp.collateral.request'))
+      .replaceAll('{{symbol}}', 'tADA')
+      .replace('{{dapp}}', `${currentDAppUrl.protocol}//${currentDAppUrl.host}`)
+      .replace('{{requestedAmount}}', valuePlaceholder)
+      .replace('{{lockableAmount}}', valuePlaceholder);
+
+    expect(currentModalText).to.equal(expectedModalText);
 
     await CollateralDAppPage.banner.container.waitForDisplayed();
     await CollateralDAppPage.banner.icon.waitForDisplayed();
     await CollateralDAppPage.banner.description.waitForDisplayed();
-    await expect(await CollateralDAppPage.banner.description.getText()).to.equal(
-      await t('dapp.collateral.amountSeparated')
-    );
+    expect(await CollateralDAppPage.banner.description.getText()).to.equal(await t('dapp.collateral.amountSeparated'));
 
     await CollateralDAppPage.acceptButton.waitForDisplayed();
-    await expect(await CollateralDAppPage.acceptButton.getText()).to.equal(
+    expect(await CollateralDAppPage.acceptButton.getText()).to.equal(
       await t('browserView.settings.wallet.collateral.confirm')
     );
     await CollateralDAppPage.cancelButton.waitForDisplayed();
-    await expect(await CollateralDAppPage.cancelButton.getText()).to.equal(await t('general.button.cancel'));
+    expect(await CollateralDAppPage.cancelButton.getText()).to.equal(await t('general.button.cancel'));
   }
 
   async assertSeeAuthorizePagePermissions() {

--- a/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
+++ b/packages/e2e-tests/src/assert/dAppConnectorAssert.ts
@@ -6,6 +6,7 @@ import AuthorizeDAppModal from '../elements/dappConnector/authorizeDAppModal';
 import ExampleDAppPage from '../elements/dappConnector/testDAppPage';
 import ConfirmTransactionPage from '../elements/dappConnector/confirmTransactionPage';
 import CommonDappPageElements from '../elements/dappConnector/commonDappPageElements';
+import CollateralDAppPage from '../elements/dappConnector/collateralDAppPage';
 import SignTransactionPage from '../elements/dappConnector/signTransactionPage';
 import DAppTransactionAllDonePage from '../elements/dappConnector/dAppTransactionAllDonePage';
 import { Logger } from '../support/logger';
@@ -65,6 +66,37 @@ class DAppConnectorAssert {
     await expect(await AuthorizeDAppPage.authorizeButton.getText()).to.equal(await t('dapp.connect.btn.accept'));
     await AuthorizeDAppPage.cancelButton.waitForDisplayed();
     await expect(await AuthorizeDAppPage.cancelButton.getText()).to.equal(await t('dapp.connect.btn.cancel'));
+  }
+
+  async assertSeeCollateralDAppPage(expectedDappDetails: ExpectedDAppDetails) {
+    await this.assertSeeHeader();
+    await this.assertSeeTitleAndDappDetails('dapp.collateral.set.header', expectedDappDetails);
+
+    await CollateralDAppPage.modalDescription.waitForDisplayed();
+    const currentDAppUrl = new URL(expectedDappDetails.url);
+
+    await expect(await CollateralDAppPage.modalDescription.getText()).to.equal(
+      (await t('dapp.collateral.request'))
+        .replace('{{symbol}}', 'tADA')
+        .replace('{{symbol}}', 'tADA')
+        .replace('{{dapp}}', `${currentDAppUrl.protocol}//${currentDAppUrl.host}`)
+        .replace('{{requestedAmount}}', '5.00')
+        .replace('{{lockableAmount}}', '9.83')
+    );
+
+    await CollateralDAppPage.banner.container.waitForDisplayed();
+    await CollateralDAppPage.banner.icon.waitForDisplayed();
+    await CollateralDAppPage.banner.description.waitForDisplayed();
+    await expect(await CollateralDAppPage.banner.description.getText()).to.equal(
+      await t('dapp.collateral.amountSeparated')
+    );
+
+    await CollateralDAppPage.acceptButton.waitForDisplayed();
+    await expect(await CollateralDAppPage.acceptButton.getText()).to.equal(
+      await t('browserView.settings.wallet.collateral.confirm')
+    );
+    await CollateralDAppPage.cancelButton.waitForDisplayed();
+    await expect(await CollateralDAppPage.cancelButton.getText()).to.equal(await t('general.button.cancel'));
   }
 
   async assertSeeAuthorizePagePermissions() {

--- a/packages/e2e-tests/src/elements/dappConnector/collateralDAppPage.ts
+++ b/packages/e2e-tests/src/elements/dappConnector/collateralDAppPage.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-undef */
+import Banner from '../banner';
+import { ChainablePromiseElement } from 'webdriverio';
+import CommonDappPageElements from './commonDappPageElements';
+
+class CollateralDAppPage extends CommonDappPageElements {
+  private MODAL_DESCRIPTION = '[data-testid="collateral-modal-description"]';
+  private ACCEPT_BUTTON = '[data-testid="collateral-set-accept"]';
+  private CANCEL_BUTTON = '[data-testid="collateral-set-cancel"]';
+
+  get banner(): typeof Banner {
+    return Banner;
+  }
+
+  get modalDescription(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.MODAL_DESCRIPTION);
+  }
+
+  get acceptButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.ACCEPT_BUTTON);
+  }
+
+  get cancelButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.CANCEL_BUTTON);
+  }
+
+  async clickAcceptButton() {
+    await this.acceptButton.waitForClickable();
+    await this.acceptButton.click();
+  }
+
+  async clickCancelButton() {
+    await this.cancelButton.waitForClickable();
+    await this.cancelButton.click();
+  }
+}
+
+export default new CollateralDAppPage();

--- a/packages/e2e-tests/src/elements/dappConnector/testDAppPage.ts
+++ b/packages/e2e-tests/src/elements/dappConnector/testDAppPage.ts
@@ -24,6 +24,7 @@ class TestDAppPage {
   private SEND_TOKEN_ASSET_NAME = '[data-testid="send-token-asset-name-hex"]';
   private SEND_ADA_RUN_BUTTON = '[data-testid="send-ada-run-button"]';
   private SEND_TOKEN_RUN_BUTTON = '[data-testid="send-token-run-button"]';
+  private SET_COLLATERAL_BUTTON = '[data-testid="collateral-run-button"]';
 
   get walletItem(): ChainablePromiseElement<WebdriverIO.Element> {
     return $(this.WALLET_ITEM);
@@ -115,6 +116,10 @@ class TestDAppPage {
 
   get sendTokenRunButton(): ChainablePromiseElement<WebdriverIO.Element> {
     return $(this.SEND_TOKEN_RUN_BUTTON);
+  }
+
+  get setCollateralButton(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $(this.SET_COLLATERAL_BUTTON);
   }
 }
 

--- a/packages/e2e-tests/src/features/CollateralExtended.feature
+++ b/packages/e2e-tests/src/features/CollateralExtended.feature
@@ -3,6 +3,7 @@ Feature: Collateral - extended view
 
   Background:
     Given Wallet is synced
+    And I reclaim collateral (if active) in extended mode
 
   @LW-5520
   Scenario: Extended View - Settings - Add/Reclaim Collateral

--- a/packages/e2e-tests/src/features/CollateralPopup.feature
+++ b/packages/e2e-tests/src/features/CollateralPopup.feature
@@ -3,6 +3,7 @@ Feature: Collateral - popup view
 
   Background:
     Given Wallet is synced
+    And I reclaim collateral (if active) in popup mode
 
   @LW-5523
   Scenario: Popup View - Settings -  Add/Reclaim Collateral

--- a/packages/e2e-tests/src/features/DAppConnector.feature
+++ b/packages/e2e-tests/src/features/DAppConnector.feature
@@ -4,6 +4,7 @@ Feature: DAppConnector - Common
   Background:
     Given Wallet is synced
     And I de-authorize all DApps in extended mode
+    And I reclaim collateral (if active) in extended mode
 
   @LW-3760 @Testnet @Mainnet
   Scenario: Extended View - Limited wallet information when wallet is not connected
@@ -31,11 +32,12 @@ Feature: DAppConnector - Common
 
   @LW-4062 @LW-3753 @Testnet @Mainnet
   Scenario: Authorize app functions as expected when the user chooses 'Only once'
-    Given I save token: "Cardano" balance
+    Given I am on Tokens extended page
+    And I save token: "Cardano" balance
     When I open test DApp
     And I see DApp authorization window
     And I click "Authorize" button in DApp authorization window
-    And I click "Only once" button in DApp authorization modal
+    And I click "Only once" button in DApp authorization window
     Then I see Lace wallet info in DApp when connected
     And I switch to window with Lace
     And I close all remaining tabs except current one
@@ -47,7 +49,7 @@ Feature: DAppConnector - Common
     When I open test DApp
     And I see DApp authorization window
     And I click "Authorize" button in DApp authorization window
-    And I click "Always" button in DApp authorization modal
+    And I click "Always" button in DApp authorization window
     And I switch to window with Lace
     And I save token: "Cardano" balance
     And I close all remaining tabs except current one
@@ -115,7 +117,12 @@ Feature: DAppConnector - Common
     When I open test DApp
     Then I see DApp authorization window in <theme> mode
     And I click "Authorize" button in DApp authorization window
-    And I click "Only once" button in DApp authorization modal
+    And I click "Only once" button in DApp authorization window
+    When I click "Set Collateral" "Run" button in test DApp
+    Then I see DApp collateral window in <theme> mode
+    When I click "Confirm" button in DApp collateral window
+    Then I see DApp connector "All done" page in <theme> mode
+    And I click "Close" button on DApp "All done" page
     When I click "Send ADA" "Run" button in test DApp
     Then I see DApp connector "Confirm transaction" page in <theme> mode
     Examples:
@@ -130,11 +137,16 @@ Feature: DAppConnector - Common
     When I open test DApp
     Then I see DApp authorization window in light mode
     And I click "Authorize" button in DApp authorization window
-    And I click "Only once" button in DApp authorization modal
+    And I click "Only once" button in DApp authorization window
     And I switch to window with Lace
     And I close all remaining tabs except current one
     And I set theme switcher to dark mode
-    And I open test DApp
+    And I open and authorize test DApp with "Only once" setting
+    When I click "Set Collateral" "Run" button in test DApp
+    Then I see DApp collateral window in dark mode
+    And I click "Confirm" button in DApp collateral window
+    Then I see DApp connector "All done" page in dark mode
+    And I click "Close" button on DApp "All done" page
     When I click "Send ADA" "Run" button in test DApp
     Then I see DApp connector "Confirm transaction" page in dark mode
 
@@ -169,3 +181,33 @@ Feature: DAppConnector - Common
     And I close all remaining tabs except current one
     When I open test DApp
     Then I see DApp authorization window
+
+    @LW-8403
+    Scenario: Automatically trigger collateral setup - happy path
+      Given I am on Settings extended page
+      And I see collateral as: "Inactive" in settings
+      And I click on "Collateral" setting
+      And all elements of Inactive collateral drawer are displayed
+      And I open and authorize test DApp with "Only once" setting
+      When I click "Set Collateral" "Run" button in test DApp
+      Then I see DApp collateral window
+      When I click "Confirm" button in DApp collateral window
+      And I see DApp connector "All done" page
+      And I click "Close" button on DApp "All done" page
+      And I don't see DApp window
+      And I switch to window with Lace
+      Then all elements of Active collateral drawer are displayed
+      When I click "Reclaim collateral" button on collateral drawer
+      And I switch to window with DApp
+      And I click "Set Collateral" "Run" button in test DApp
+      Then I see DApp collateral window
+
+  @LW-8404
+  Scenario: Automatically trigger collateral setup - click cancel on Collateral modal
+    Given I open and authorize test DApp with "Only once" setting
+    And I click "Set Collateral" "Run" button in test DApp
+    And I see DApp collateral window
+    When I click "Cancel" button in DApp collateral window
+    Then I don't see DApp window
+    And I click "Set Collateral" "Run" button in test DApp
+    And I see DApp collateral window

--- a/packages/e2e-tests/src/features/DAppConnector.feature
+++ b/packages/e2e-tests/src/features/DAppConnector.feature
@@ -51,6 +51,7 @@ Feature: DAppConnector - Common
     And I click "Authorize" button in DApp authorization window
     And I click "Always" button in DApp authorization window
     And I switch to window with Lace
+    And I am on Tokens extended page
     And I save token: "Cardano" balance
     And I close all remaining tabs except current one
     And I open test DApp

--- a/packages/e2e-tests/src/features/DAppConnectorExtended.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorExtended.feature
@@ -36,7 +36,7 @@ Feature: DAppConnector - Extended view
     And I click on "Authorized DApps" setting
     And I see test DApp on the Authorized DApps list
     When I de-authorize test DApp in extended mode
-    Then I see DApp removal confirmation modal
+    Then I see DApp removal confirmation window
     When I click "Back" button in DApp removal confirmation modal
     Then I see test DApp on the Authorized DApps list
     When I open test DApp

--- a/packages/e2e-tests/src/features/DAppConnectorExtended.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorExtended.feature
@@ -51,7 +51,7 @@ Feature: DAppConnector - Extended view
     And I click on "Authorized DApps" setting
     And I see test DApp on the Authorized DApps list
     When I de-authorize test DApp in extended mode
-    Then I see DApp removal confirmation modal
+    Then I see DApp removal confirmation window
     When I click "Disconnect DApp" button in DApp removal confirmation modal
     Then I see "Authorized DApps" section empty state in extended mode
     When I open test DApp

--- a/packages/e2e-tests/src/features/DAppConnectorPopup.feature
+++ b/packages/e2e-tests/src/features/DAppConnectorPopup.feature
@@ -36,7 +36,7 @@ Feature: DAppConnector - Popup view
     And I click on "Authorized DApps" setting
     And I see test DApp on the Authorized DApps list
     When I de-authorize test DApp in popup mode
-    Then I see DApp removal confirmation modal
+    Then I see DApp removal confirmation window
     When I click "Back" button in DApp removal confirmation modal
     Then I see test DApp on the Authorized DApps list
     When I open test DApp
@@ -51,7 +51,7 @@ Feature: DAppConnector - Popup view
     And I click on "Authorized DApps" setting
     And I see test DApp on the Authorized DApps list
     When I de-authorize test DApp in popup mode
-    Then I see DApp removal confirmation modal
+    Then I see DApp removal confirmation window
     When I click "Disconnect DApp" button in DApp removal confirmation modal
     Then I see "Authorized DApps" section empty state in popup mode
     When I open test DApp

--- a/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
@@ -28,6 +28,7 @@ class DAppConnectorPageObject {
 
   async waitAndSwitchToDAppConnectorWindow(expectedNumberOfHandles: number) {
     await waitUntilExpectedNumberOfHandles(expectedNumberOfHandles);
+    await browser.pause(1000);
     await browser.switchWindow(this.DAPP_CONNECTOR_WINDOW_HANDLE);
   }
 

--- a/packages/e2e-tests/src/steps/settingsSteps.ts
+++ b/packages/e2e-tests/src/steps/settingsSteps.ts
@@ -26,6 +26,9 @@ import CollateralDrawer from '../elements/settings/CollateralDrawer';
 import HelpDrawer from '../elements/settings/HelpDrawer';
 import ModalAssert from '../assert/modalAssert';
 import menuHeaderPageObject from '../pageobject/menuHeaderPageObject';
+import SettingsPage from '../elements/settings/SettingsPage';
+import extendedView from '../page/extendedView';
+import popupView from '../page/popupView';
 
 Given(
   /^I click on "(About|Your keys|Network|Authorized DApps|Show recovery phrase|Passphrase verification|FAQs|Help|Terms and conditions|Privacy policy|Cookie policy|Collateral)" setting$/,
@@ -287,4 +290,13 @@ When(/^I fill (correct|incorrect) password and confirm collateral$/, async (type
 When(/^I click "Reclaim collateral" button on collateral drawer$/, async () => {
   await CollateralDrawer.collateralButton.waitForClickable();
   await CollateralDrawer.collateralButton.click();
+});
+
+When(/^I reclaim collateral \(if active\) in (extended|popup) mode$/, async (mode: 'extended' | 'popup') => {
+  mode === 'extended' ? await extendedView.visitSettings() : await popupView.visitSettings();
+  if ((await SettingsPage.collateralLink.addon.getText()) === 'Active') {
+    await settingsExtendedPageObject.clickSettingsItem('Collateral');
+    await CollateralDrawer.collateralButton.waitForClickable();
+    await CollateralDrawer.collateralButton.click();
+  }
 });

--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -14,7 +14,7 @@
       "@wdio/devtools-service",
       "wdio-intercept-service"
     ],
-    "lib": ["es2015", "dom"],
+    "lib": ["es2021", "dom"],
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "rootDir": "../../"


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2308/6381127797/index.html) for [e43561a8](https://github.com/input-output-hk/lace/pull/585/commits/e43561a820eb0964df26461c507f96e989fd6b0e)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 2      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->