### PR TITLE
fix(common): lw-7416-make drawer navigation title visible

### DIFF
--- a/packages/common/src/ui/components/Drawer/DrawerNavigation.module.scss
+++ b/packages/common/src/ui/components/Drawer/DrawerNavigation.module.scss
@@ -13,6 +13,7 @@
   :global(.ant-btn-icon-only) {
     height: size_unit(5);
     width: size_unit(5);
+    z-index: 1;
   }
   @media (max-width: $breakpoint-popup) {
     border-bottom: none;

--- a/packages/common/src/ui/components/Drawer/DrawerNavigation.module.scss
+++ b/packages/common/src/ui/components/Drawer/DrawerNavigation.module.scss
@@ -32,7 +32,6 @@
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: -1;
   @media (max-width: $breakpoint-popup) {
     display: none;
   }


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-7416]
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Remove z-index of -1 from drawer navigation title

## Screenshots

### Before

<img width="664" alt="Screenshot 2023-09-29 at 14 19 41" src="https://github.com/input-output-hk/lace/assets/48496855/548662d1-6fb4-457a-8a7b-b4cf0bf91679">

### After

<img width="670" alt="Screenshot 2023-09-29 at 14 18 49" src="https://github.com/input-output-hk/lace/assets/48496855/a040bccd-e114-4261-a393-00995d531069">



[LW-7416]: https://input-output.atlassian.net/browse/LW-7416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2441/6468455769/index.html) for [139a0a4a](https://github.com/input-output-hk/lace/pull/586/commits/139a0a4ab9881e0399f28c8262f184b3b8903cca)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 27     | 5      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->