### PR TITLE
fix(staking): [LW-8510] temporarily disable drift warning/rebalancing until portfolio persistence is done

### DIFF
--- a/packages/staking/src/features/drawer/StakePoolDetails.tsx
+++ b/packages/staking/src/features/drawer/StakePoolDetails.tsx
@@ -67,10 +67,7 @@ export const StakePoolDetails = ({
   } = useDelegationPortfolioStore((store) => ({
     activeDrawerStep: store.activeDrawerStep,
     activeFlow: store.activeFlow,
-    currentPortfolioDraftModified:
-      store.draftPortfolio?.some(
-        (pool) => pool.basedOnCurrentPortfolio && pool.sliderIntegerPercentage !== pool.savedIntegerPercentage
-      ) || false,
+    currentPortfolioDraftModified: store.draftPortfolio?.some((pool) => !pool.basedOnCurrentPortfolio) || false,
     currentPortfolioDrifted: isPortfolioDrifted(store.currentPortfolio),
     draftPortfolioValidity: getDraftPortfolioValidity(store),
     openPoolIsSelected: store.selectedPortfolio.some(

--- a/packages/staking/src/features/drawer/StakePoolDetails.tsx
+++ b/packages/staking/src/features/drawer/StakePoolDetails.tsx
@@ -32,6 +32,9 @@ type stakePoolDetailsProps = StakePoolDetailFooterProps & {
 type DraftPortfolioInvalidReason = 'invalid-allocation' | 'slider-zero';
 type DraftPortfolioValidity = { valid: true } | { valid: false; reason: DraftPortfolioInvalidReason };
 
+// tmp hotfix before release: disabling "rebalance" until portfolio persistence is implemented
+const TMP_PERSISTENCE_HOTFIX_DISABLE_REBALANCE = true;
+
 const getDraftPortfolioValidity = (store: DelegationPortfolioStore): DraftPortfolioValidity => {
   if (!store.draftPortfolio || store.draftPortfolio.length === 0) return { valid: true }; // throw new Error('Draft portfolio is not defined');
   const percentageSum = store.draftPortfolio.reduce((acc, pool) => acc + pool.sliderIntegerPercentage, 0);
@@ -113,7 +116,10 @@ export const StakePoolDetails = ({
         return (
           <StepPreferencesFooter
             buttonTitle={
-              activeFlow === Flow.PortfolioManagement && !currentPortfolioDraftModified && currentPortfolioDrifted
+              !TMP_PERSISTENCE_HOTFIX_DISABLE_REBALANCE &&
+              activeFlow === Flow.PortfolioManagement &&
+              !currentPortfolioDraftModified &&
+              currentPortfolioDrifted
                 ? t('drawer.preferences.rebalanceButton')
                 : t('drawer.preferences.confirmButton')
             }

--- a/packages/staking/src/features/drawer/StakePoolDetails.tsx
+++ b/packages/staking/src/features/drawer/StakePoolDetails.tsx
@@ -1,7 +1,6 @@
 import { Wallet } from '@lace/cardano';
 import { useObservable } from '@lace/common';
 import { isPortfolioDrifted } from 'features/overview/helpers';
-import { TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from 'features/store/delegationPortfolioStore/constants';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOutsideHandles } from '../outside-handles-provider';
@@ -15,6 +14,7 @@ import {
   PERCENTAGE_SCALE_MAX,
   useDelegationPortfolioStore,
 } from '../store';
+import { TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from '../store/delegationPortfolioStore/constants';
 import { StepPreferencesContent, StepPreferencesFooter } from './preferences';
 import { SignConfirmation, SignConfirmationFooter } from './SignConfirmation';
 import { StakePoolConfirmation, StakePoolConfirmationFooter } from './StakePoolConfirmation';

--- a/packages/staking/src/features/drawer/StakePoolDetails.tsx
+++ b/packages/staking/src/features/drawer/StakePoolDetails.tsx
@@ -1,6 +1,7 @@
 import { Wallet } from '@lace/cardano';
 import { useObservable } from '@lace/common';
 import { isPortfolioDrifted } from 'features/overview/helpers';
+import { TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from 'features/store/delegationPortfolioStore/constants';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOutsideHandles } from '../outside-handles-provider';
@@ -31,9 +32,6 @@ type stakePoolDetailsProps = StakePoolDetailFooterProps & {
 
 type DraftPortfolioInvalidReason = 'invalid-allocation' | 'slider-zero';
 type DraftPortfolioValidity = { valid: true } | { valid: false; reason: DraftPortfolioInvalidReason };
-
-// tmp hotfix before release: disabling "rebalance" until portfolio persistence is implemented
-const TMP_PERSISTENCE_HOTFIX_DISABLE_REBALANCE = true;
 
 const getDraftPortfolioValidity = (store: DelegationPortfolioStore): DraftPortfolioValidity => {
   if (!store.draftPortfolio || store.draftPortfolio.length === 0) return { valid: true }; // throw new Error('Draft portfolio is not defined');
@@ -113,7 +111,7 @@ export const StakePoolDetails = ({
         return (
           <StepPreferencesFooter
             buttonTitle={
-              !TMP_PERSISTENCE_HOTFIX_DISABLE_REBALANCE &&
+              !TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED &&
               activeFlow === Flow.PortfolioManagement &&
               !currentPortfolioDraftModified &&
               currentPortfolioDrifted

--- a/packages/staking/src/features/drawer/preferences/PoolDetailsCard/PoolDetailsCard.tsx
+++ b/packages/staking/src/features/drawer/preferences/PoolDetailsCard/PoolDetailsCard.tsx
@@ -1,6 +1,7 @@
 import { Box, Card, ControlButton, Flex, PieChartColor, Text } from '@lace/ui';
 import ChevronDownIcon from '@lace/ui/dist/assets/icons/chevron-down.component.svg';
 import ChevronUpIcon from '@lace/ui/dist/assets/icons/chevron-up.component.svg';
+import { TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from 'features/store/delegationPortfolioStore/constants';
 import denounce from 'lodash/debounce';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -29,6 +30,7 @@ interface PoolDetailsCardProps {
   cardanoCoinSymbol: string;
 }
 
+// eslint-disable-next-line complexity
 export const PoolDetailsCard = ({
   color,
   expanded,
@@ -58,51 +60,59 @@ export const PoolDetailsCard = ({
           <Box className={styles.poolIndicator} style={{ backgroundColor: color }} />
           <Text.SubHeading>{name}</Text.SubHeading>
         </Flex>
-        <ControlButton.Icon icon={expanded ? <ChevronUpIcon /> : <ChevronDownIcon />} onClick={onExpandButtonClick} />
+        {!TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED && (
+          <ControlButton.Icon icon={expanded ? <ChevronUpIcon /> : <ChevronDownIcon />} onClick={onExpandButtonClick} />
+        )}
       </Flex>
       {expanded && (
         <>
-          <Flex className={styles.valuesRow}>
-            <Flex pl="$32" pr="$32" flexDirection="column" className={styles.valueBox}>
-              <Box>
-                <Text.Body.Large weight="$medium" className={styles.valueLabel}>
-                  {t('drawer.preferences.poolDetails.savedRatio')}
+          {TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED && (
+            <Flex className={styles.valuesRow}>
+              <Flex pl="$32" pr="$32" flexDirection="column" className={styles.valueBox}>
+                <Box>
+                  <Text.Body.Large weight="$medium" className={styles.valueLabel}>
+                    {t('drawer.preferences.poolDetails.savedRatio')}
+                  </Text.Body.Large>
+                  {/* TODO tooltips & styles */}
+                  <InfoIcon className={styles.valueInfoIcon} />
+                </Box>
+                <Text.Body.Large weight="$semibold">
+                  {savedRatio || '-'} {savedRatio && <Text.Body.Small weight="$medium">%</Text.Body.Small>}
                 </Text.Body.Large>
-                {/* TODO tooltips & styles */}
-                <InfoIcon className={styles.valueInfoIcon} />
-              </Box>
-              <Text.Body.Large weight="$semibold">
-                {savedRatio || '-'} {savedRatio && <Text.Body.Small weight="$medium">%</Text.Body.Small>}
-              </Text.Body.Large>
-            </Flex>
-            <Flex pl="$32" pr="$32" flexDirection="column" className={styles.valueBox}>
-              <Box>
-                <Text.Body.Large weight="$medium" className={styles.valueLabel}>
-                  {t('drawer.preferences.poolDetails.actualRatio')}
+              </Flex>
+              <Flex pl="$32" pr="$32" flexDirection="column" className={styles.valueBox}>
+                <Box>
+                  <Text.Body.Large weight="$medium" className={styles.valueLabel}>
+                    {t('drawer.preferences.poolDetails.actualRatio')}
+                  </Text.Body.Large>
+                  {/* TODO tooltips & styles */}
+                  <InfoIcon className={styles.valueInfoIcon} />
+                </Box>
+                <Text.Body.Large weight="$semibold">
+                  {actualRatio || '-'} {actualRatio && <Text.Body.Small weight="$medium">%</Text.Body.Small>}
                 </Text.Body.Large>
-                {/* TODO tooltips & styles */}
-                <InfoIcon className={styles.valueInfoIcon} />
-              </Box>
-              <Text.Body.Large weight="$semibold">
-                {actualRatio || '-'} {actualRatio && <Text.Body.Small weight="$medium">%</Text.Body.Small>}
-              </Text.Body.Large>
-            </Flex>
-            <Flex pl="$32" pr="$32" flexDirection="column" className={styles.valueBox}>
-              <Box>
-                <Text.Body.Large weight="$medium" className={styles.valueLabel}>
-                  {t('drawer.preferences.poolDetails.actualStake')}
+              </Flex>
+              <Flex pl="$32" pr="$32" flexDirection="column" className={styles.valueBox}>
+                <Box>
+                  <Text.Body.Large weight="$medium" className={styles.valueLabel}>
+                    {t('drawer.preferences.poolDetails.actualStake')}
+                  </Text.Body.Large>
+                  {/* TODO tooltips & styles */}
+                  <InfoIcon className={styles.valueInfoIcon} />
+                </Box>
+                <Text.Body.Large weight="$semibold">
+                  {stakeValue} <Text.Body.Small weight="$medium">{cardanoCoinSymbol}</Text.Body.Small>
                 </Text.Body.Large>
-                {/* TODO tooltips & styles */}
-                <InfoIcon className={styles.valueInfoIcon} />
-              </Box>
-              <Text.Body.Large weight="$semibold">
-                {stakeValue} <Text.Body.Small weight="$medium">{cardanoCoinSymbol}</Text.Body.Small>
-              </Text.Body.Large>
+              </Flex>
             </Flex>
-          </Flex>
+          )}
           <Flex gap="$28" p="$32" pt="$20" flexDirection="column" alignItems="center">
             <Flex justifyContent="space-between" alignItems="center" w="$fill">
-              <Text.Body.Large>Edit saved ratio</Text.Body.Large>
+              {!TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED ? (
+                <Text.Body.Large>Edit saved ratio</Text.Body.Large>
+              ) : (
+                <Box w="$120" />
+              )}
               <Flex alignItems="center" gap="$12">
                 <Text.Body.Large>Ratio</Text.Body.Large>
                 <input type="number" max={PERCENTAGE_SCALE_MAX} min={localValue === 0 ? 0 : 1} value={localValue} />

--- a/packages/staking/src/features/drawer/preferences/PoolDetailsCard/PoolDetailsCard.tsx
+++ b/packages/staking/src/features/drawer/preferences/PoolDetailsCard/PoolDetailsCard.tsx
@@ -5,6 +5,7 @@ import denounce from 'lodash/debounce';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import InfoIcon from '../../../../assets/icons/info-icon.svg';
+import { Tooltip } from '../../../overview/StakingInfoCard/StatsTooltip';
 // import { PERCENTAGE_SCALE_MAX } from '../../store';
 import { DelegationRatioSlider } from '../DelegationRatioSlider';
 import * as styles from './PoolDetailsCard.css';
@@ -115,12 +116,17 @@ export const PoolDetailsCard = ({
               value={localValue}
               onValueChange={setLocalValue}
             />
-            <ControlButton.Outlined
-              label="Remove pool from portfolio"
-              icon={<TrashIcon />}
-              w="$fill"
-              onClick={onRemove}
-            />
+            <Tooltip content={onRemove ? undefined : t('drawer.preferences.pickMorePools')}>
+              <div>
+                <ControlButton.Outlined
+                  label="Remove pool from portfolio"
+                  icon={<TrashIcon />}
+                  w="$fill"
+                  onClick={onRemove}
+                  disabled={!onRemove}
+                />
+              </div>
+            </Tooltip>
           </Flex>
         </>
       )}

--- a/packages/staking/src/features/drawer/preferences/PoolDetailsCard/PoolDetailsCard.tsx
+++ b/packages/staking/src/features/drawer/preferences/PoolDetailsCard/PoolDetailsCard.tsx
@@ -1,13 +1,13 @@
 import { Box, Card, ControlButton, Flex, PieChartColor, Text } from '@lace/ui';
 import ChevronDownIcon from '@lace/ui/dist/assets/icons/chevron-down.component.svg';
 import ChevronUpIcon from '@lace/ui/dist/assets/icons/chevron-up.component.svg';
-import { TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from 'features/store/delegationPortfolioStore/constants';
 import denounce from 'lodash/debounce';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import InfoIcon from '../../../../assets/icons/info-icon.svg';
 import { Tooltip } from '../../../overview/StakingInfoCard/StatsTooltip';
 // import { PERCENTAGE_SCALE_MAX } from '../../store';
+import { TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from '../../../store/delegationPortfolioStore/constants';
 import { DelegationRatioSlider } from '../DelegationRatioSlider';
 import * as styles from './PoolDetailsCard.css';
 import TrashIcon from './trash.svg';
@@ -66,7 +66,7 @@ export const PoolDetailsCard = ({
       </Flex>
       {expanded && (
         <>
-          {TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED && (
+          {!TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED && (
             <Flex className={styles.valuesRow}>
               <Flex pl="$32" pr="$32" flexDirection="column" className={styles.valueBox}>
                 <Box>

--- a/packages/staking/src/features/overview/helpers/isPortfolioDrifted.ts
+++ b/packages/staking/src/features/overview/helpers/isPortfolioDrifted.ts
@@ -6,6 +6,8 @@ import type { CurrentPortfolioStakePool } from '../../store';
 import { PERCENTAGE_SCALE_MAX } from '../../store';
 
 const PORTFOLIO_DRIFT_PERCENTAGE_THRESHOLD = 15;
+// tmp hotfix before release: disabling portfolio drift, until portfolio persistence is implemented
+const TMP_PERSISTENCE_HOTFIX_DISABLE_PORTFOLIO_DRIFT = true;
 
 const getPortfolioTotalPercentageDrift = (portfolio: CurrentPortfolioStakePool[]): number => {
   const totalValue = Wallet.BigIntMath.sum(portfolio.map(({ value }) => value));
@@ -22,6 +24,8 @@ const getPortfolioTotalPercentageDrift = (portfolio: CurrentPortfolioStakePool[]
 
 // TODO: move this file to store. It gets imported also outside the overview feature so the store seems better place.
 export const isPortfolioDrifted = (currentPortfolio: CurrentPortfolioStakePool[]) => {
+  if (TMP_PERSISTENCE_HOTFIX_DISABLE_PORTFOLIO_DRIFT) return false;
+
   const drift = getPortfolioTotalPercentageDrift(currentPortfolio);
   return drift >= PORTFOLIO_DRIFT_PERCENTAGE_THRESHOLD;
 };

--- a/packages/staking/src/features/overview/helpers/isPortfolioDrifted.ts
+++ b/packages/staking/src/features/overview/helpers/isPortfolioDrifted.ts
@@ -1,13 +1,12 @@
 /* eslint-disable no-magic-numbers */
 import { Wallet } from '@lace/cardano';
 import BigNumber from 'bignumber.js';
+import { TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from 'features/store/delegationPortfolioStore/constants';
 import sum from 'lodash/sum';
 import type { CurrentPortfolioStakePool } from '../../store';
 import { PERCENTAGE_SCALE_MAX } from '../../store';
 
 const PORTFOLIO_DRIFT_PERCENTAGE_THRESHOLD = 15;
-// tmp hotfix before release: disabling portfolio drift, until portfolio persistence is implemented
-const TMP_PERSISTENCE_HOTFIX_DISABLE_PORTFOLIO_DRIFT = true;
 
 const getPortfolioTotalPercentageDrift = (portfolio: CurrentPortfolioStakePool[]): number => {
   const totalValue = Wallet.BigIntMath.sum(portfolio.map(({ value }) => value));
@@ -24,7 +23,7 @@ const getPortfolioTotalPercentageDrift = (portfolio: CurrentPortfolioStakePool[]
 
 // TODO: move this file to store. It gets imported also outside the overview feature so the store seems better place.
 export const isPortfolioDrifted = (currentPortfolio: CurrentPortfolioStakePool[]) => {
-  if (TMP_PERSISTENCE_HOTFIX_DISABLE_PORTFOLIO_DRIFT) return false;
+  if (TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED) return false;
 
   const drift = getPortfolioTotalPercentageDrift(currentPortfolio);
   return drift >= PORTFOLIO_DRIFT_PERCENTAGE_THRESHOLD;

--- a/packages/staking/src/features/overview/helpers/isPortfolioDrifted.ts
+++ b/packages/staking/src/features/overview/helpers/isPortfolioDrifted.ts
@@ -1,10 +1,10 @@
 /* eslint-disable no-magic-numbers */
 import { Wallet } from '@lace/cardano';
 import BigNumber from 'bignumber.js';
-import { TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from 'features/store/delegationPortfolioStore/constants';
 import sum from 'lodash/sum';
 import type { CurrentPortfolioStakePool } from '../../store';
 import { PERCENTAGE_SCALE_MAX } from '../../store';
+import { TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from '../../store/delegationPortfolioStore/constants';
 
 const PORTFOLIO_DRIFT_PERCENTAGE_THRESHOLD = 15;
 

--- a/packages/staking/src/features/store/delegationPortfolioStore/constants.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/constants.ts
@@ -5,6 +5,10 @@ export const MAX_POOLS_COUNT = 5;
 export const LAST_STABLE_EPOCH = 2;
 export const PERCENTAGE_SCALE_MAX = 100; // 0-100
 
+// tmp hotfix before release: disabling several features depending on portfolio persistence
+// which is not implemented yet
+export const TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED = true;
+
 export const CARDANO_COIN_SYMBOL: Record<Wallet.Cardano.NetworkId, AdaSymbol> = {
   [Wallet.Cardano.NetworkId.Mainnet]: 'ADA',
   [Wallet.Cardano.NetworkId.Testnet]: 'tADA',

--- a/packages/staking/src/features/store/delegationPortfolioStore/selectors.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/selectors.ts
@@ -1,7 +1,6 @@
 import { Wallet } from '@lace/cardano';
-import { isPortfolioDrifted } from '../../overview/helpers';
 import { mapStakePoolToDisplayData } from './mapStakePoolToDisplayData';
-import { DrawerManagementStep, Flow } from './stateMachine';
+import { Flow } from './stateMachine';
 import { DelegationPortfolioStore, StakePoolDetails } from './types';
 
 export const isDrawerVisible = ({ activeFlow }: DelegationPortfolioStore) =>
@@ -18,12 +17,3 @@ export const stakePoolDetailsSelector = ({
 
 export const isPoolSelectedSelector = (poolHexId: Wallet.Cardano.PoolIdHex) => (store: DelegationPortfolioStore) =>
   !!store.selectedPortfolio?.find((pool) => pool.id === poolHexId);
-
-export const shouldRebalancePortfolio = (store: DelegationPortfolioStore): boolean =>
-  store.activeFlow === Flow.Overview &&
-  store.activeDrawerStep === DrawerManagementStep.Preferences &&
-  isPortfolioDrifted(store.currentPortfolio) &&
-  // check if sliders unchanged
-  !!store.draftPortfolio?.every(
-    (pool) => pool.basedOnCurrentPortfolio && pool.sliderIntegerPercentage === pool.savedIntegerPercentage
-  );

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/atomicStateMutators.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/atomicStateMutators.ts
@@ -105,8 +105,10 @@ export const atomicStateMutators = {
     state: State;
   }) => {
     if (!state.draftPortfolio) throw new Error(missingDraftPortfolioErrorMessage);
-    state.draftPortfolio = state.draftPortfolio.map((pool) =>
-      pool.id === id ? { ...pool, sliderIntegerPercentage: newSliderPercentage } : pool
+    state.draftPortfolio = ejectDraftFromCurrentPortfolio(
+      state.draftPortfolio.map((pool) =>
+        pool.id === id ? { ...pool, sliderIntegerPercentage: newSliderPercentage } : pool
+      )
     );
   },
 };


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8510
- [x] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Until the upcoming release the staking portfolio likely won't be persisted, yet we want to introduce the new "slider" UI for pools which is however incompatible with drift warning/"rebalance" CTA button. Therefore this PR introduces two `TMP_PERSISTENCE_HOTFIX_*` flags that disable these functionalities with minimum changes

## Testing

* Open staking management drawer and check that "Confirm" button appears as soon as a slider is altered
* check that no drift warning is visible even if the portfolio is drifted (can be achieved e.g. by sending all or most available funds to the "receive" address

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2282/6352951793/index.html) for [971ad05e](https://github.com/input-output-hk/lace/pull/588/commits/971ad05e1c78e2a86b33aa47cae7ec53d711b4cf)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->