### PR TITLE
feat(staking: [LW-8510] init draft sliders to on chain percentages

### DIFF
--- a/packages/staking/src/features/drawer/preferences/PoolDetailsCard/PoolDetailsCard.tsx
+++ b/packages/staking/src/features/drawer/preferences/PoolDetailsCard/PoolDetailsCard.tsx
@@ -56,7 +56,8 @@ export const PoolDetailsCard = ({
       return;
     }
     onSliderChange(localValue);
-  }, [onSliderChange, localValue]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localValue]);
 
   return (
     <Card.Outlined className={styles.root}>

--- a/packages/staking/src/features/drawer/preferences/StepPreferencesContent.tsx
+++ b/packages/staking/src/features/drawer/preferences/StepPreferencesContent.tsx
@@ -118,11 +118,10 @@ export const StepPreferencesContent = () => {
               onExpandButtonClick={() => void 0}
               onPercentageChange={(value) => {
                 console.info(value);
-                // TODO: infinite loop :( need to fix useEffect in PoolDetailsCard
-                // portfolioMutators.executeCommand({
-                //   data: { id, newSliderPercentage: value },
-                //   type: 'UpdateStakePercentage',
-                // })
+                portfolioMutators.executeCommand({
+                  data: { id, newSliderPercentage: value },
+                  type: 'UpdateStakePercentage',
+                });
               }}
             />
           )

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/processExpandedViewCases.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/processExpandedViewCases.ts
@@ -1,4 +1,4 @@
-import { PERCENTAGE_SCALE_MAX } from '../constants';
+import { PERCENTAGE_SCALE_MAX, TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED } from '../constants';
 import { atomicStateMutators } from './atomicStateMutators';
 import {
   BrowsePoolsCommand,
@@ -26,6 +26,7 @@ import {
   UpdateStakePercentage,
 } from './commands';
 import { mapStakePoolToPortfolioPool } from './mapStakePoolToPortfolioPool';
+import { normalizePercentages } from './normalizePercentages';
 import { cases, handler } from './stateTreeUtilities';
 import {
   CurrentPortfolioStakePool,
@@ -37,11 +38,20 @@ import {
 } from './types';
 
 export const currentPortfolioToDraft = (pools: CurrentPortfolioStakePool[]): DraftPortfolioStakePool[] =>
-  pools.map((cp) => ({
-    ...cp,
-    basedOnCurrentPortfolio: true,
-    sliderIntegerPercentage: cp.savedIntegerPercentage,
-  }));
+  TMP_HOTFIX_PORTFOLIO_STORE_NOT_PERSISTED
+    ? normalizePercentages(
+        pools.map((cp) => ({
+          ...cp,
+          basedOnCurrentPortfolio: true,
+          sliderIntegerPercentage: cp.onChainPercentage,
+        })),
+        'sliderIntegerPercentage'
+      )
+    : pools.map((cp) => ({
+        ...cp,
+        basedOnCurrentPortfolio: true,
+        sliderIntegerPercentage: cp.savedIntegerPercentage,
+      }));
 
 export const processExpandedViewCases: Handler = (params) =>
   cases<ExpandedViewFlow>(


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8510
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

As agreed offline, let's initialize the slider values to on-chain current portfolio percentages if managing existing portfolio

## Testing

Try managing existing portfolio and verify that the initial state of the slider matches on-chain percentages

## Screenshots

Attach screenshots here if implementation involves some UI changes


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2290/6354759147/index.html) for [1d0f47cd](https://github.com/input-output-hk/lace/pull/590/commits/1d0f47cdf2feb3b95ab786408da635ac342c7cd0)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 2      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->