### PR TITLE
fix(staking): fix floating point errors for Overview screen in DelegationCard

### DIFF
--- a/packages/staking/src/features/delegation-card/DelegationCard.tsx
+++ b/packages/staking/src/features/delegation-card/DelegationCard.tsx
@@ -63,7 +63,12 @@ export const DelegationCard = ({
     { nameTranslationKey: 'overview.delegationCard.label.pools', value: numberOfPools },
   ];
 
-  const totalPercentage = useMemo(() => distribution.reduce((acc, cur) => acc + cur.percentage, 0), [distribution]);
+  const totalPercentage = useMemo(() => {
+    const percentageSum = distribution.reduce((acc, cur) => acc + cur.percentage, 0);
+    // Round to avoid floating point errors in case of on-chain (float) percentages being passed to this component
+    return Math.round(percentageSum);
+  }, [distribution]);
+
   const { data, colorSet = PIE_CHART_DEFAULT_COLOR_SET } = useMemo((): {
     colorSet?: PieChartColor[];
     data: Distribution;

--- a/packages/staking/src/features/delegation-card/DelegationCard.tsx
+++ b/packages/staking/src/features/delegation-card/DelegationCard.tsx
@@ -65,6 +65,7 @@ export const DelegationCard = ({
 
   const totalPercentage = useMemo(() => {
     const percentageSum = distribution.reduce((acc, cur) => acc + cur.percentage, 0);
+    // TODO: remove after LW-8683 implemented
     // Round to avoid floating point errors in case of on-chain (float) percentages being passed to this component
     return Math.round(percentageSum);
   }, [distribution]);


### PR DESCRIPTION
discussed on standup

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2347/6403774484/index.html) for [9230cf67](https://github.com/input-output-hk/lace/pull/602/commits/9230cf67c2d1cb4a90eb7974fc3e209a3e399aca)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 0      | 0       | 0     | 32    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->