### PR TITLE
fix(staking): [LW-8714] handle percentages from sdk delegation distribution not adding up to 100%

### DIFF
--- a/packages/staking/src/features/staking/Setup/Setup.tsx
+++ b/packages/staking/src/features/staking/Setup/Setup.tsx
@@ -18,7 +18,7 @@ type SetupProps = Omit<SetupBaseProps, 'loading'> &
     view: 'popup' | 'expanded';
   };
 
-// hotfix: percentages from the cardano-js-sdk because for some
+// hotfix: percentages from the cardano-js-sdk due to some
 // not yet understood reason may not always add up to 100
 // hence we are patching them here.
 // Once LW-8703 is done, this patch can be removed

--- a/packages/staking/src/features/staking/Setup/Setup.tsx
+++ b/packages/staking/src/features/staking/Setup/Setup.tsx
@@ -1,8 +1,4 @@
-import { BigIntMath } from '@cardano-sdk/util';
-import { DelegatedStake } from '@cardano-sdk/wallet';
-import { Wallet } from '@lace/cardano';
 import { useObservable } from '@lace/common';
-import BigNumber from 'bignumber.js';
 import { useEffect } from 'react';
 import { initI18n } from '../../i18n';
 import '../reset.css';
@@ -18,21 +14,6 @@ type SetupProps = Omit<SetupBaseProps, 'loading'> &
     view: 'popup' | 'expanded';
   };
 
-// hotfix: percentages from the cardano-js-sdk due to some
-// not yet understood reason may not always add up to 100
-// hence we are patching them here.
-// Once LW-8703 is done, this patch can be removed
-const patchPercentages = (delegationDistribution: DelegatedStake[]): DelegatedStake[] => {
-  const totalPortfolioStake = BigIntMath.sum(delegationDistribution.map(({ stake }) => stake));
-
-  return delegationDistribution.map((delegation) => ({
-    ...delegation,
-    percentage: new BigNumber(delegation.stake.toString())
-      .div(totalPortfolioStake.toString())
-      .toNumber() as Wallet.Percent,
-  }));
-};
-
 export const Setup = ({ children, currentChain, view, ...rest }: SetupProps) => {
   const { balancesBalance, walletStoreInMemoryWallet } = useOutsideHandles();
   const portfolioMutators = useDelegationPortfolioStore((s) => s.mutators);
@@ -45,7 +26,7 @@ export const Setup = ({ children, currentChain, view, ...rest }: SetupProps) => 
     portfolioMutators.setCardanoCoinSymbol(currentChain);
     portfolioMutators.setCurrentPortfolio({
       currentEpoch,
-      delegationDistribution: patchPercentages([...delegationDistribution.values()]),
+      delegationDistribution: [...delegationDistribution.values()],
       delegationRewardsHistory,
     });
     portfolioMutators.setView(view);

--- a/packages/staking/src/features/staking/Setup/Setup.tsx
+++ b/packages/staking/src/features/staking/Setup/Setup.tsx
@@ -18,11 +18,11 @@ type SetupProps = Omit<SetupBaseProps, 'loading'> &
     view: 'popup' | 'expanded';
   };
 
-// hotfix: percentage from the cardano-js-sdk because for some
-// not yet understood reason it may not always add up to 100
+// hotfix: percentages from the cardano-js-sdk because for some
+// not yet understood reason may not always add up to 100
 // hence we are patching them here.
 // Once LW-8703 is done, this patch can be removed
-const patchDelegationDistributionPercentages = (delegationDistribution: DelegatedStake[]): DelegatedStake[] => {
+const patchPercentages = (delegationDistribution: DelegatedStake[]): DelegatedStake[] => {
   const totalPortfolioStake = BigIntMath.sum(delegationDistribution.map(({ stake }) => stake));
 
   return delegationDistribution.map((delegation) => ({
@@ -45,7 +45,7 @@ export const Setup = ({ children, currentChain, view, ...rest }: SetupProps) => 
     portfolioMutators.setCardanoCoinSymbol(currentChain);
     portfolioMutators.setCurrentPortfolio({
       currentEpoch,
-      delegationDistribution: patchDelegationDistributionPercentages([...delegationDistribution.values()]),
+      delegationDistribution: patchPercentages([...delegationDistribution.values()]),
       delegationRewardsHistory,
     });
     portfolioMutators.setView(view);

--- a/packages/staking/src/features/staking/Setup/Setup.tsx
+++ b/packages/staking/src/features/staking/Setup/Setup.tsx
@@ -23,7 +23,7 @@ type SetupProps = Omit<SetupBaseProps, 'loading'> &
 // hence we are patching them here.
 // Once LW-8703 is done, this patch can be removed
 const patchDelegationDistributionPercentages = (delegationDistribution: DelegatedStake[]): DelegatedStake[] => {
-  const totalPortfolioStake = BigIntMath.sum(delegationDistribution.map(({ stake: s }) => s));
+  const totalPortfolioStake = BigIntMath.sum(delegationDistribution.map(({ stake }) => stake));
 
   return delegationDistribution.map((delegation) => ({
     ...delegation,

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/normalizePercentages.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/normalizePercentages.ts
@@ -7,10 +7,13 @@ import { PERCENTAGE_SCALE_MAX } from '../constants';
 export const normalizePercentages = <K extends string, T extends { [key in K]: number }>(items: T[], key: K) => {
   const currentSum = items.reduce((acc, item) => acc + item[key], 0);
   const epsilon = 0.1;
-  if (Math.abs(currentSum - PERCENTAGE_SCALE_MAX) > epsilon)
-    throw new Error(`Percentages must sum to ${PERCENTAGE_SCALE_MAX}`);
 
   const itemsWithRoundedNumbers: T[] = items.map((item) => ({ ...item, [key]: Math.round(item[key]) }));
+  if (Math.abs(currentSum - PERCENTAGE_SCALE_MAX) > epsilon) {
+    console.error(`Percentages must add up to ${PERCENTAGE_SCALE_MAX}, instead they add up to ${currentSum}`);
+    // fall back to naive rounding
+    return itemsWithRoundedNumbers;
+  }
 
   // Calculate the adjustment needed to make the sum exactly equal to 100 (PERCENTAGE_SCALE_MAX)
   const adjustment = PERCENTAGE_SCALE_MAX - itemsWithRoundedNumbers.reduce((acc, item) => acc + item[key], 0);


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8714
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Apparently sdk percentages not always add up to 100% which turned out to be caused by one of the wallet stake addresses not delegating anywhere. To prevent any such inconsistencies from causing a catastrophic failure (uncaught exception), this PR relaxes the `normalizePercentages` helper to fall back to naive rounding if the percentages happen to not add up to 100%

See screenshots to understand how this change manifests in UI

## Testing

Test impacted portfolio, check that management drawer/staking overview is properly shown

## Screenshots

Screenshot of the bug
![CleanShot 2023-10-04 at 17 02 30@2x](https://github.com/input-output-hk/lace/assets/4980147/67219cfc-8cee-41bb-b0fd-ccd2acadbc71)

After implementing this patch this is how the overview/management drawer look like:

![Screenshot 2023-10-05 at 09 06 30](https://github.com/input-output-hk/lace/assets/4980147/9269abb9-e366-4d62-8c82-a3b2a880675e)
![Screenshot 2023-10-05 at 09 06 35](https://github.com/input-output-hk/lace/assets/4980147/64223800-ff8a-4fdb-a57c-9eeca516832f)



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2363/6411235092/index.html) for [f8367d30](https://github.com/input-output-hk/lace/pull/609/commits/f8367d30bbdbbd336f52a0f63185c83ea6ea8fc6)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 2      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->