### PR TITLE
feat(extension): add warning banner for trezor transaction

### DIFF
--- a/apps/browser-extension-wallet/src/assets/icons/exclamation-triangle-red.component.svg
+++ b/apps/browser-extension-wallet/src/assets/icons/exclamation-triangle-red.component.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="72" viewBox="0 0 24 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 34V36M12 40H12.01M5.07183 44H18.9282C20.4678 44 21.4301 42.3333 20.6603 41L13.7321 29C12.9623 27.6667 11.0378 27.6667 10.268 29L3.33978 41C2.56998 42.3333 3.53223 44 5.07183 44Z" stroke="#FF5470" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -226,7 +226,9 @@
     "sendMultipleOutputsAtTheSameTime": "Send multiple outputs at the same time and add metadata. This means you can send multiple assets to different addresses in one transaction",
     "theAmountYoullBeChargedToProcessYourTransaction": "The amount you'll be charged to process your transaction",
     "connectYourLedger": "Connect your Ledger device directly to your computer. Unlock the device and open the Cardano app. Then click confirm.",
-    "toSendAnNFTOrNativeToken": "To send an NFT or a native token, a small amount of ADA has to be sent with it to facilitate the operation"
+    "connectYourTrezor": "Just connect your device to your computer. Unlock the device and click 'confirm' to continue",
+    "toSendAnNFTOrNativeToken": "To send an NFT or a native token, a small amount of ADA has to be sent with it to facilitate the operation",
+    "trezorDoesNotDupportDecimals": "Trezor does not support decimals for Cardano tokens, so your device's software may show incorrect amounts (3 token units as 3,000,000, for example) when sending these tokens."
   },
   "staking": {
     "sectionTitle": "Staking",

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionSummary.module.scss
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionSummary.module.scss
@@ -5,3 +5,7 @@
   margin-bottom: size_unit(2);
   color: var(--text-color-secondary) !important;
 }
+
+.banner {
+  margin-bottom: 25px;
+}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionSummary.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionSummary.tsx
@@ -19,7 +19,8 @@ import {
   AnalyticsEventNames
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { getTokenAmountInFiat, parseFiat } from '@src/utils/assets-transformers';
-import { useObservable } from '@lace/common';
+import { useObservable, Banner } from '@lace/common';
+import ExclamationIcon from '../../../../../assets/icons/exclamation-triangle-red.component.svg';
 
 const { Text } = Typography;
 
@@ -113,6 +114,8 @@ export const SendTransactionSummary = withAddressBookContext(
       () => getKeyAgentType() === Wallet.KeyManagement.KeyAgentType.InMemory,
       [getKeyAgentType]
     );
+    const isTrezor = useMemo(() => getKeyAgentType() === Wallet.KeyManagement.KeyAgentType.Trezor, [getKeyAgentType]);
+
     const { list: addressList } = useAddressBookContext();
     const analytics = useAnalyticsContext();
     const { fiatCurrency } = useCurrencyStore();
@@ -165,7 +168,19 @@ export const SendTransactionSummary = withAddressBookContext(
             })
           }
         />
-        {!isInMemory && !isPopupView && <Text className={styles.connectLedgerText}>{t('send.connectYourLedger')}</Text>}
+        {!isInMemory && !isPopupView && (
+          <Text className={styles.connectLedgerText}>
+            {isTrezor ? t('send.connectYourTrezor') : t('send.connectYourLedger')}
+          </Text>
+        )}
+        {isTrezor && (
+          <Banner
+            className={styles.banner}
+            message={t('send.trezorDoesNotDupportDecimals')}
+            withIcon
+            customIcon={<ExclamationIcon style={{ height: '72px' }} />}
+          />
+        )}
       </>
     );
   }


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-8502](https://input-output.atlassian.net/browse/LW-8502)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution
This PR implements an information message about Trezor not supporting token decimals on Transaction summary screen, this message will be visible only with Trezor HW.

## Screenshots

<img width="615" alt="Screenshot 2023-10-05 at 16 13 48" src="https://github.com/input-output-hk/lace/assets/65184652/bf582c0f-30f3-446f-8161-eb2e2c955143">


[LW-8502]: https://input-output.atlassian.net/browse/LW-8502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2377/6423564692/index.html) for [75a90f88](https://github.com/input-output-hk/lace/pull/613/commits/75a90f8829d9451d0627d96b41f92a1353931609)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->