### PR TITLE
feat(extension): update copy for lock trezor device

### DIFF
--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -608,7 +608,8 @@
       "notDetectedError": {
         "title": "Failed to detect device",
         "description": "Please make sure your device is unlocked and the Cardano app is open.",
-        "agree": "Agree"
+        "agree": "Agree",
+        "trezorDescription": "Please make sure your device is unlocked."
       },
       "startOver": {
         "title": "Are you sure you want to start again?",

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/ErrorDialog.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/ErrorDialog.tsx
@@ -6,12 +6,12 @@ import { useTranslation } from 'react-i18next';
 
 const { Title, Text } = Typography;
 
-type ErrorCode = 'common' | 'notDetected';
+export type HWErrorCode = 'common' | 'notDetectedLedger' | 'notDetectedTrezor';
 
 interface ErrorDialogProps {
   visible: boolean;
   onRetry: () => void;
-  errorCode: ErrorCode;
+  errorCode: HWErrorCode;
 }
 
 export const ErrorDialog = ({ visible, onRetry, errorCode = 'common' }: ErrorDialogProps): React.ReactElement => {
@@ -23,9 +23,14 @@ export const ErrorDialog = ({ visible, onRetry, errorCode = 'common' }: ErrorDia
       description: t('browserView.onboarding.commonError.description'),
       confirm: t('browserView.onboarding.commonError.ok')
     },
-    notDetected: {
+    notDetectedLedger: {
       title: t('browserView.onboarding.notDetectedError.title'),
       description: t('browserView.onboarding.notDetectedError.description'),
+      confirm: t('browserView.onboarding.notDetectedError.agree')
+    },
+    notDetectedTrezor: {
+      title: t('browserView.onboarding.notDetectedError.title'),
+      description: t('browserView.onboarding.notDetectedError.trezorDescription'),
       confirm: t('browserView.onboarding.notDetectedError.agree')
     }
   };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -16,7 +16,7 @@ import { Switch, Route, useHistory, useLocation } from 'react-router-dom';
 import { Wallet } from '@lace/cardano';
 import { WalletSetupLayout } from '@src/views/browser-view/components/Layout';
 import { PinExtension } from './PinExtension';
-import { ErrorDialog } from './ErrorDialog';
+import { ErrorDialog, HWErrorCode } from './ErrorDialog';
 import { StartOverDialog } from '@views/browser/features/wallet-setup/components/StartOverDialog';
 import { useTranslation } from 'react-i18next';
 import {
@@ -36,7 +36,8 @@ const { WalletSetup: Events } = AnalyticsEventNames;
 const { CHAIN } = config();
 const {
   Cardano: { ChainIds },
-  AVAILABLE_WALLETS
+  AVAILABLE_WALLETS,
+  KeyManagement
 } = Wallet;
 const DEFAULT_CHAIN_ID = ChainIds[CHAIN];
 
@@ -51,8 +52,6 @@ type HardwareWalletStep = 'legal' | 'analytics' | 'connect' | 'accounts' | 'regi
 const TOTAL_ACCOUNTS = 50;
 
 const route = (path: string) => `${walletRoutePaths.setup.hardware}/${path}`;
-
-type HWErrorCode = 'common' | 'notDetected';
 
 export const HardwareWalletFlow = ({
   onCancel,
@@ -195,7 +194,9 @@ export const HardwareWalletFlow = ({
       if (error.innerError?.innerError?.message === 'The device is already open.') {
         setDeviceConnection(deviceConnection);
       } else {
-        showHardwareWalletError('notDetected');
+        showHardwareWalletError(
+          model === KeyManagement.KeyAgentType.Trezor ? 'notDetectedTrezor' : 'notDetectedLedger'
+        );
       }
     }
   };


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-8503](https://input-output.atlassian.net/browse/LW-8503)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR updates the copy of the failed to detect device drawer for Trezor user flow

## Screenshots


https://github.com/input-output-hk/lace/assets/65184652/d9003da4-3b0c-4647-a84f-0568808ce180




[LW-8503]: https://input-output.atlassian.net/browse/LW-8503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2401/6435919008/index.html) for [442b4039](https://github.com/input-output-hk/lace/pull/620/commits/442b4039d592036dd8a013952d6514f8d29bcd66)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->