### PR TITLE
chore(extension): bump version to 1.6 and add new release notes

### DIFF
--- a/apps/browser-extension-wallet/manifest.json
+++ b/apps/browser-extension-wallet/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Lace",
   "description": "One fast, accessible, and secure platform for digital assets, DApps, NFTs, and DeFi.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "manifest_version": 3,
   "key": "$LACE_EXTENSION_KEY",
   "icons": {

--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lace/browser-extension-wallet",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A fully capable wallet packaged as browser extensions for Chrome, Firefox, and Edge",
   "homepage": "https://github.com/input-output-hk/lace/blob/master/apps/browser-extension-wallet/README.md",
   "bugs": {

--- a/apps/browser-extension-wallet/src/release-notes/1_6_0.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_6_0.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+import React from 'react';
+
+const ReleaseNote_1_6_0 = (): React.ReactElement => (
+  <>
+    <p>Introducing Lace 1.5.0 This version supports the following features:</p>
+    <ul style={{ listStyleType: 'disc', margin: 0 }}>
+      <li />
+    </ul>
+    <p>
+      Check out the details in the{' '}
+      <a href="https://www.lace.io/blog/lace-1-6-release" target="_blank">
+        blog
+      </a>
+    </p>
+  </>
+);
+
+export default ReleaseNote_1_6_0;

--- a/apps/browser-extension-wallet/src/release-notes/1_6_0.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_6_0.tsx
@@ -3,9 +3,12 @@ import React from 'react';
 
 const ReleaseNote_1_6_0 = (): React.ReactElement => (
   <>
-    <p>Introducing Lace 1.5.0 This version supports the following features:</p>
+    <p>Introducing Lace 1.6.0 This version supports the following features:</p>
     <ul style={{ listStyleType: 'disc', margin: 0 }}>
-      <li />
+      <li>Feature: Multi-staking custom ratios</li>
+      <li>Feature: Multi-staking UX Improvements</li>
+      <li>Feature: Recovery Phrase improvements</li>
+      <li>Bug fixes</li>
     </ul>
     <p>
       Check out the details in the{' '}


### PR DESCRIPTION
Bump version to 1.6 and add new release notes

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2440/6468415640/index.html) for [45188c9b](https://github.com/input-output-hk/lace/pull/628/commits/45188c9b90cb1b37bb9f2769f1559db4e8d8f7c0)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 27     | 5      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->