### PR TITLE
refactor(extension): add posthog api tokens as env variables

### DIFF
--- a/.github/shared/build/action.yml
+++ b/.github/shared/build/action.yml
@@ -4,6 +4,22 @@ inputs:
   LACE_EXTENSION_KEY:
     description: 'Public extended manifest key'
     required: true
+  POSTHOG_PRODUCTION_TOKEN_MAINNET:
+    description: 'Post hog production mainnet token'
+    required: false
+    default: ''
+  POSTHOG_PRODUCTION_TOKEN_PREPROD:
+    description: 'Post hog production preprod token'
+    required: false
+    default: ''
+  POSTHOG_PRODUCTION_TOKEN_PREVIEW:
+    description: 'Post hog production preview token'
+    required: false
+    default: ''
+  PRODUCTION_MODE_TRACKING:
+    description: 'Enable analytics tracking in production'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -26,4 +42,8 @@ runs:
       shell: bash
       env:
         LACE_EXTENSION_KEY: ${{ inputs.LACE_EXTENSION_KEY }}
+        POSTHOG_PRODUCTION_TOKEN_MAINNET: ${{ inputs.POSTHOG_PRODUCTION_TOKEN_MAINNET }}
+        POSTHOG_PRODUCTION_TOKEN_PREPROD: ${{ inputs.POSTHOG_PRODUCTION_TOKEN_PREPROD }}
+        POSTHOG_PRODUCTION_TOKEN_PREVIEW: ${{ inputs.POSTHOG_PRODUCTION_TOKEN_PREVIEW }}
+        PRODUCTION_MODE_TRACKING: ${{ inputs.PRODUCTION_MODE_TRACKING }}
       run: yarn browser build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
         uses: ./.github/shared/build
         with:
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY  }}
+          POSTHOG_PRODUCTION_TOKEN_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_MAINNET || '' }}
+          POSTHOG_PRODUCTION_TOKEN_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREPROD || '' }}
+          POSTHOG_PRODUCTION_TOKEN_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREVIEW || '' }}
+          PRODUCTION_MODE_TRACKING: ${{ startsWith(github.ref, 'refs/heads/release') && 'true' || 'false' }}
       - name: Check for linter issues
         run: yarn lint
       - name: Run unit tests, generate test coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         shell: bash
         env:
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY  }}
+          POSTHOG_PRODUCTION_TOKEN_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_MAINNET || '' }}
+          POSTHOG_PRODUCTION_TOKEN_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREPROD || '' }}
+          POSTHOG_PRODUCTION_TOKEN_PREVIEW: ${{  startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREVIEW || '' }}
+          PRODUCTION_MODE_TRACKING: ${{  startsWith(github.ref, 'refs/heads/release') && 'true' || 'false' }}
         run: |
           eval "set -x ; $(cat apps/browser-extension-wallet/.env.* | grep ^USE_ | sed -r 's/false/true/' | sort --unique | sed -r 's/^/export /' | tr '\n' ';') set +x"
           yarn browser build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY  }}
           POSTHOG_PRODUCTION_TOKEN_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_MAINNET || '' }}
           POSTHOG_PRODUCTION_TOKEN_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREPROD || '' }}
-          POSTHOG_PRODUCTION_TOKEN_PREVIEW: ${{  startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREVIEW || '' }}
-          PRODUCTION_MODE_TRACKING: ${{  startsWith(github.ref, 'refs/heads/release') && 'true' || 'false' }}
+          POSTHOG_PRODUCTION_TOKEN_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREVIEW || '' }}
+          PRODUCTION_MODE_TRACKING: ${{ startsWith(github.ref, 'refs/heads/release') && 'true' || 'false' }}
         run: |
           eval "set -x ; $(cat apps/browser-extension-wallet/.env.* | grep ^USE_ | sed -r 's/false/true/' | sort --unique | sed -r 's/^/export /' | tr '\n' ';') set +x"
           yarn browser build

--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -49,6 +49,11 @@ POSTHOG_EXCLUDED_EVENTS=
 # set this variable to true only in release packages. By having this set to false, we ensure that we will not be using Post Hog production projects tokens in development stage
 PRODUCTION_MODE_TRACKING=false
 
+# Post Hog
+POSTHOG_DEV_TOKEN_MAINNET=phc_gH96Lx5lEVXTTWEyytSdTFPDk3Xsxwi4BqG88mKObd1
+POSTHOG_DEV_TOKEN_PREPROD=phc_Xlmldm6EYSfQVgB9Uxm3b2xC1noDlgFFXpF9AJ6SMfJ
+POSTHOG_DEV_TOKEN_PREVIEW=phc_e8SaOOWpXpNE59TnpLumeUjWm4iv024AWjhQqU406jr
+
 # Cardano Services
 CARDANO_SERVICES_URL_MAINNET=https://backend.live-mainnet.eks.lw.iog.io
 CARDANO_SERVICES_URL_PREPROD=https://backend.live-preprod.eks.lw.iog.io

--- a/apps/browser-extension-wallet/.env.example
+++ b/apps/browser-extension-wallet/.env.example
@@ -49,6 +49,13 @@ PRODUCTION_MODE_TRACKING=false
 SESSION_LENGTH_IN_SECONDS=60
 POSTHOG_EXCLUDED_EVENTS=
 
+POSTHOG_PRODUCTION_TOKEN_MAINNET=production-mainnet-token
+POSTHOG_PRODUCTION_TOKEN_PREPROD=production-preprod-token
+POSTHOG_PRODUCTION_TOKEN_PREVIEW=production-preview-token
+POSTHOG_DEV_TOKEN_MAINNET=dev-mainnet-token
+POSTHOG_DEV_TOKEN_PREPROD=dev-preprod-token
+POSTHOG_DEV_TOKEN_PREVIEW=dev-preview-token
+
 # Cardano Services
 CARDANO_SERVICES_URL_MAINNET=https://backend.live-mainnet.eks.lw.iog.io
 CARDANO_SERVICES_URL_PREPROD=https://backend.live-preprod.eks.lw.iog.io

--- a/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/PostHogClient.ts
@@ -42,12 +42,14 @@ export class PostHogClient {
     private publicPostHogHost: string = PUBLIC_POSTHOG_HOST
   ) {
     if (!this.publicPostHogHost) throw new Error('PUBLIC_POSTHOG_HOST url has not been provided');
+    const token = this.getApiToken(this.chain);
+    if (!token) throw new Error('posthog token has not been provided');
     this.hasPostHogInitialized$ = new BehaviorSubject(false);
 
     this.userIdService
       .getUserId(chain.networkMagic)
       .then((id) => {
-        posthog.init(this.getApiToken(this.chain), {
+        posthog.init(token, {
           request_batching: false,
           api_host: this.publicPostHogHost,
           autocapture: false,

--- a/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/config.ts
+++ b/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/config.ts
@@ -7,15 +7,15 @@ export const PRODUCTION_TRACKING_MODE_ENABLED = process.env.PRODUCTION_MODE_TRAC
 export const POSTHOG_EXCLUDED_EVENTS = process.env.POSTHOG_EXCLUDED_EVENTS ?? '';
 
 export const DEV_NETWORK_ID_TO_POSTHOG_TOKEN_MAP: Record<Wallet.Cardano.NetworkMagic, string> = {
-  [Wallet.Cardano.NetworkMagics.Mainnet]: 'phc_gH96Lx5lEVXTTWEyytSdTFPDk3Xsxwi4BqG88mKObd1',
-  [Wallet.Cardano.NetworkMagics.Preprod]: 'phc_Xlmldm6EYSfQVgB9Uxm3b2xC1noDlgFFXpF9AJ6SMfJ',
-  [Wallet.Cardano.NetworkMagics.Preview]: 'phc_e8SaOOWpXpNE59TnpLumeUjWm4iv024AWjhQqU406jr'
+  [Wallet.Cardano.NetworkMagics.Mainnet]: process.env.POSTHOG_DEV_TOKEN_MAINNET,
+  [Wallet.Cardano.NetworkMagics.Preprod]: process.env.POSTHOG_DEV_TOKEN_PREPROD,
+  [Wallet.Cardano.NetworkMagics.Preview]: process.env.POSTHOG_DEV_TOKEN_PREVIEW
 };
 
 export const PRODUCTION_NETWORK_ID_TO_POSTHOG_TOKEN_MAP: Record<Wallet.Cardano.NetworkMagic, string> = {
-  [Wallet.Cardano.NetworkMagics.Mainnet]: 'phc_dCx1iT3Ud5tGIRwGqEvpeddFmPcKDGxBzk6rPP58RFE',
-  [Wallet.Cardano.NetworkMagics.Preprod]: 'phc_5sVVmLJ5x6IuipMBZwjudVk5bQcfcBSMjgEOe5gTOh0',
-  [Wallet.Cardano.NetworkMagics.Preview]: 'phc_p7GeKELpQtkValRMvzUXX38TPGhKQYItO7aBRYJfvhW'
+  [Wallet.Cardano.NetworkMagics.Mainnet]: process.env.POSTHOG_PRODUCTION_TOKEN_MAINNET,
+  [Wallet.Cardano.NetworkMagics.Preprod]: process.env.POSTHOG_PRODUCTION_TOKEN_PREPROD,
+  [Wallet.Cardano.NetworkMagics.Preview]: process.env.POSTHOG_PRODUCTION_TOKEN_PREVIEW
 };
 
 export const DEV_NETWORK_ID_TO_POSTHOG_PROJECT_ID_MAP: Record<Wallet.Cardano.NetworkMagic, number> = {

--- a/apps/browser-extension-wallet/test/__mocks__/set-env-vars.js
+++ b/apps/browser-extension-wallet/test/__mocks__/set-env-vars.js
@@ -11,3 +11,4 @@ process.env.USE_POSTHOG_ANALYTICS = 'true';
 process.env.USE_POSTHOG_ANALYTICS_FOR_OPTED_OUT = 'false';
 process.env.USE_MATOMO_ANALYTICS_FOR_OPTED_OUT = 'false';
 process.env.PUBLIC_POSTHOG_HOST = 'https://eu.posthog.com';
+process.env.POSTHOG_DEV_TOKEN_PREPROD = 'test-token';


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-8508](https://input-output.atlassian.net/browse/LW-8508)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR moves the Post Hog api tokens to .env file



[LW-8508]: https://input-output.atlassian.net/browse/LW-8508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2548/6508610469/index.html) for [18eb81bc](https://github.com/input-output-hk/lace/pull/631/commits/18eb81bcc5955e5e5f1a595120ec984838fe3dad)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 0      | 0       | 0     | 32    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->