### PR TITLE
fix(extension): remove extra close your keys section event

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/GeneralSettingsDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/GeneralSettingsDrawer.tsx
@@ -36,7 +36,6 @@ export const GeneralSettingsDrawer = ({
   const handleClose = () => {
     onClose();
     setIsPublicKeyQRVisible(false);
-    sendAnalyticsEvent(PostHogAction.SettingsYourKeysShowPublicKeyXClick);
   };
 
   useKeyboardShortcut(['Escape'], () => visible && handleGoBackDrawer());


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<[LW-8769](https://input-output.atlassian.net/browse/LW-8769)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR removes an extra `settings | your keys | show public key | x | click`


[LW-8769]: https://input-output.atlassian.net/browse/LW-8769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2470/6473526573/index.html) for [eb86b2c6](https://github.com/input-output-hk/lace/pull/633/commits/eb86b2c683c2a70bf74c22568f8bc1efb8c2e378)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->