### PR TITLE
Disable e2e test because of a bug

### DIFF
--- a/packages/e2e-tests/src/features/e2e/MultidelegationSwitchingPoolsExtendedE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/MultidelegationSwitchingPoolsExtendedE2E.feature
@@ -6,7 +6,8 @@ Feature: Staking Page - Switching pools - Extended Browser View - E2E
     And I disable showing Multidelegation beta banner
     And I navigate to Staking extended page
 
-  @LW-7819 @Testnet
+  @LW-7819 @Testnet @Pending
+#    bug LW-8777
   Scenario Outline: Extended View - Multidelegation - Delegate to multiple pools E2E
     When I click Overview tab
     And I wait until delegation info card shows staking to "<pools_before>" pool(s)


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Disabling test LW-7819 because new bug [LW-8777](https://input-output.atlassian.net/browse/LW-8777)

[LW-8777]: https://input-output.atlassian.net/browse/LW-8777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2480/6481708292/index.html) for [bb8a8eff](https://github.com/input-output-hk/lace/pull/636/commits/bb8a8effdbf4a3ad62c9c12f91b813ec8360582d)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 0      | 0       | 0     | 32    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->