### PR TITLE
fix(staking): lw-8573 make staking modal buttons responsive

### DIFF
--- a/packages/staking/src/features/modals/StakingModal.module.scss
+++ b/packages/staking/src/features/modals/StakingModal.module.scss
@@ -48,6 +48,10 @@
   display: flex;
   gap: size_unit(2);
   justify-content: space-between;
+
+  @media screen and (max-width: $breakpoint-popup) {
+    flex-direction: column;
+  }
 }
 
 .modal.popupView {


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8573
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Use media query on the popup screen.

#### Limitations
- The management and stake pool details drawer distorts on viewport <= 360px because of [this](https://github.com/input-output-hk/lace/blob/85c590bf0cec2633c6eb7918e057aadcc6d04b3f/packages/ui/src/design-tokens/sx.css.ts#L7). When that line is removed everything works.  I don't know if there is value in resolving this since our minimum supported screen size on extended view is 668px.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots


### Before

![eba1bfcb-cb0f-4dcf-be6a-aab008bb3977](https://github.com/input-output-hk/lace/assets/48496855/bddd91b6-3c51-4b6d-a350-a7bcf5966034)

### After

<img width="563" alt="Screenshot 2023-10-12 at 18 32 45" src="https://github.com/input-output-hk/lace/assets/48496855/414843f3-eb8b-4031-9361-90559b93b426">



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2523/6499035384/index.html) for [ab00ddcd](https://github.com/input-output-hk/lace/pull/644/commits/ab00ddcdef1ac6973019ef5e104f4db3c3f1d3b8)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 0      | 0       | 0     | 32    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->