### PR TITLE
fix(extension): [LW-8498] send input field alignment

### DIFF
--- a/packages/common/src/ui/components/Search/Search.module.scss
+++ b/packages/common/src/ui/components/Search/Search.module.scss
@@ -33,7 +33,7 @@ $button_size: 52px;
 
 
   @media (max-width: $breakpoint-popup) {
-    padding: 0 size_unit(0.75) 0 size_unit(2.5) !important;
+    padding: 0 size_unit(0.75) 0 size_unit(0.75) !important;
   }
 
   :global {


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<LW-8498>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Minor CSS issue.

## Testing

Go to send screen in popup mode. All input placeholders should be vertically aligned.

## Screenshots

![image](https://github.com/input-output-hk/lace/assets/27725122/2c346db5-76a5-4ba0-af37-9933556b401d)



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ✅ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2576/6547494451/index.html) for [3e400a52](https://github.com/input-output-hk/lace/pull/649/commits/3e400a5241bd64c22d3f59a5f13d69bd885b5bef)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 32     | 0      | 0       | 0     | 32    | ✅     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->