### PR TITLE
feat(staking): lw-7931-add confirmation modal to pool management drawer

### DIFF
--- a/packages/staking/src/features/drawer/StakePoolConfirmation.tsx
+++ b/packages/staking/src/features/drawer/StakePoolConfirmation.tsx
@@ -9,6 +9,7 @@ import cn from 'classnames';
 import isNil from 'lodash/isNil';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PoolsManagementModal, PoolsManagementModalType } from '../modals';
 import { Balance, CurrencyInfo, useOutsideHandles } from '../outside-handles-provider';
 import { DraftPortfolioStakePool, StakingError, useDelegationPortfolioStore, useStakingStore } from '../store';
 import ArrowDown from './arrow-down.svg';
@@ -50,6 +51,11 @@ const ItemStatRenderer = ({ img, text, subText }: statRendererProps) => (
     </div>
   </div>
 );
+
+const validateIsPoolsChanged = (currentPortfolioIds: string[], draftPortfolioIds: string[]) => {
+  const samePools = currentPortfolioIds.filter((id) => draftPortfolioIds.includes(id));
+  return samePools.length !== draftPortfolioIds.length;
+};
 
 interface StakePoolConfirmationBodyProps {
   balance?: Balance;
@@ -321,10 +327,13 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
   } = useOutsideHandles();
   const { isBuildingTx, stakingError } = useStakingStore();
   const [isConfirmingTx, setIsConfirmingTx] = useState(false);
-  const { /* currentPortfolio,*/ portfolioMutators } = useDelegationPortfolioStore((store) => ({
+  const { currentPortfolio, portfolioMutators, draftPortfolio } = useDelegationPortfolioStore((store) => ({
     currentPortfolio: store.currentPortfolio,
+    draftPortfolio: store.draftPortfolio,
     portfolioMutators: store.mutators,
   }));
+  const [openPoolsManagementConfirmationModal, setOpenPoolsManagementConfirmationModal] =
+    useState<PoolsManagementModalType | null>(null);
 
   const keyAgentType = getKeyAgentType();
   const isInMemory = useMemo(() => keyAgentType === Wallet.KeyManagement.KeyAgentType.InMemory, [keyAgentType]);
@@ -338,6 +347,19 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
 
   const handleConfirmation = useCallback(async () => {
     setIsConfirmingTx(false);
+
+    const isPoolsReduced = draftPortfolio && currentPortfolio.length > draftPortfolio?.length;
+
+    const currentPortfolioIds = currentPortfolio.map((pool) => pool.id);
+    const draftPortfolioIds = draftPortfolio?.map((pool) => pool.id) || [];
+
+    const isPoolsChanged = validateIsPoolsChanged(currentPortfolioIds, draftPortfolioIds);
+
+    if (isPoolsReduced && isPoolsChanged)
+      return setOpenPoolsManagementConfirmationModal(PoolsManagementModalType.ADJUSTMENT);
+
+    if (isPoolsReduced) return setOpenPoolsManagementConfirmationModal(PoolsManagementModalType.REDUCTION);
+
     // HW-WALLET (FIX LATER):
     // if (!isInMemory) {
     //   setIsConfirmingTx(true);
@@ -351,8 +373,8 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
     //     setIsConfirmingTx(false);
     //   }
     // }
-    portfolioMutators.executeCommand({ type: 'DrawerContinue' });
-  }, [portfolioMutators]);
+    return portfolioMutators.executeCommand({ type: 'DrawerContinue' });
+  }, [currentPortfolio, draftPortfolio, portfolioMutators]);
 
   const confirmLabel = useMemo(() => {
     if (!isInMemory) {
@@ -365,17 +387,25 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
   }, [isConfirmingTx, isInMemory, keyAgentType, popupView, t]);
 
   return (
-    <div className={styles.actions}>
-      <Button
-        data-testid="stake-pool-confirmation-btn"
-        disabled={isBuildingTx || !!stakingError}
-        loading={isConfirmingTx || isBuildingTx}
-        onClick={handleConfirmation}
-        className={styles.confirmBtn}
-        size="large"
-      >
-        {confirmLabel}
-      </Button>
-    </div>
+    <>
+      <div className={styles.actions}>
+        <Button
+          data-testid="stake-pool-confirmation-btn"
+          disabled={isBuildingTx || !!stakingError}
+          loading={isConfirmingTx || isBuildingTx}
+          onClick={handleConfirmation}
+          className={styles.confirmBtn}
+          size="large"
+        >
+          {confirmLabel}
+        </Button>
+      </div>
+      <PoolsManagementModal
+        type={openPoolsManagementConfirmationModal}
+        visible={!!openPoolsManagementConfirmationModal}
+        onConfirm={() => portfolioMutators.executeCommand({ type: 'DrawerContinue' })}
+        onCancel={() => setOpenPoolsManagementConfirmationModal(null)}
+      />
+    </>
   );
 };

--- a/packages/staking/src/features/i18n/translations/en.ts
+++ b/packages/staking/src/features/i18n/translations/en.ts
@@ -90,6 +90,13 @@ export const en: Translations = {
   'modals.changingPreferences.description':
     "That's totally fine! Just please note that you'll continue receiving rewards from your former pool(s) for two epochs. After that, you'll start to receiving rewards from your new pool(s).",
   'modals.changingPreferences.title': 'Changing staking preferences?',
+  'modals.poolsManagement.buttons.cancel': 'Cancel',
+  'modals.poolsManagement.buttons.confirm': 'Fine by me',
+  'modals.poolsManagement.description.adjustment':
+    "Reducing pool numbers needs a stake key de-registration, triggering the return of the initial ADA deposit and possibly losing any undistributed rewards. When changing pools, you'll get rewards from the former pool for two epochs, then start receiving them from the new pool.",
+  'modals.poolsManagement.description.reduction':
+    'Reducing your pool count requires stake key de-registration, which returns the initial ADA deposit and may cause the loss of undistributed rewards in the calculation epoch phase.',
+  'modals.poolsManagement.title': 'Switching Pool?',
   'overview.banners.pendingFirstDelegation.message':
     'You will see your staking portfolio here once the transaction has been validated',
   'overview.banners.pendingFirstDelegation.title': 'Your staking transaction has been submitted',

--- a/packages/staking/src/features/i18n/types.ts
+++ b/packages/staking/src/features/i18n/types.ts
@@ -152,6 +152,17 @@ type KeysStructure = {
       description: '';
       button: '';
     };
+    poolsManagement: {
+      title: '';
+      buttons: {
+        cancel: '';
+        confirm: '';
+      };
+      description: {
+        reduction: '';
+        adjustment: '';
+      };
+    };
   };
   overview: {
     delegationCard: {

--- a/packages/staking/src/features/modals/PoolsManagementModal.tsx
+++ b/packages/staking/src/features/modals/PoolsManagementModal.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+import { StakingModal } from './StakingModal';
+
+export enum PoolsManagementModalType {
+  ADJUSTMENT = 'adjustment',
+  REDUCTION = 'reduction',
+}
+
+interface PoolsManagementModalProps {
+  visible: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  type: PoolsManagementModalType | null;
+}
+
+export const PoolsManagementModal = ({ visible, onConfirm, onCancel, type }: PoolsManagementModalProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <StakingModal
+      title={t('modals.poolsManagement.title')}
+      visible={visible}
+      description={
+        type === PoolsManagementModalType.ADJUSTMENT
+          ? t('modals.poolsManagement.description.adjustment')
+          : t('modals.poolsManagement.description.reduction')
+      }
+      actions={[
+        {
+          body: t('modals.poolsManagement.buttons.cancel'),
+          color: 'secondary',
+          dataTestId: 'switch-pools-modal-cancel',
+          onClick: () => onCancel(),
+        },
+        {
+          body: t('modals.poolsManagement.buttons.confirm'),
+          dataTestId: 'switch-pools-modal-confirm',
+          onClick: () => onConfirm(),
+        },
+      ]}
+      focusTriggerAfterClose={false}
+    />
+  );
+};

--- a/packages/staking/src/features/modals/index.ts
+++ b/packages/staking/src/features/modals/index.ts
@@ -1,2 +1,3 @@
 export { ChangingPreferencesModal } from './ChangingPreferencesModal';
 export { MultidelegationBetaModal } from './MultidelegationBetaModal';
+export { PoolsManagementModal, PoolsManagementModalType } from './PoolsManagementModal';


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7931
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

This PR adds a confirmation modal when reducing or adjust pools

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

<img width="706" alt="Screenshot 2023-10-18 at 00 05 18" src="https://github.com/input-output-hk/lace/assets/48496855/fd2d237b-c13e-4a2b-a770-592a1c269812">

<img width="704" alt="Screenshot 2023-10-18 at 00 06 51" src="https://github.com/input-output-hk/lace/assets/48496855/561212d0-c80e-4ee5-bd47-475b167c2638">



<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2677/6632862459/index.html) for [8c604029](https://github.com/input-output-hk/lace/pull/652/commits/8c604029eb38e2ce12e7250e3872386029b364c2)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->