### PR TITLE
fix(extension): reset user id service values

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
@@ -56,5 +56,6 @@ export const userIdServiceProperties: RemoteApiProperties<UserIdServiceInterface
   getAliasProperties: RemoteApiPropertyType.MethodReturningPromise,
   getRandomizedUserId: RemoteApiPropertyType.MethodReturningPromise,
   getUserId: RemoteApiPropertyType.MethodReturningPromise,
-  userTrackingType$: RemoteApiPropertyType.HotObservable
+  userTrackingType$: RemoteApiPropertyType.HotObservable,
+  resetToDefaultValues: RemoteApiPropertyType.MethodReturningPromise
 };

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/userIdService.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/userIdService.ts
@@ -13,6 +13,7 @@ import randomBytes from 'randombytes';
 import { userIdServiceProperties } from '../config';
 import { getChainNameByNetworkMagic } from '@src/utils/get-chain-name-by-network-magic';
 import { UserTrackingType } from '@providers/AnalyticsProvider/analyticsTracker';
+import isUndefined from 'lodash/isUndefined';
 
 // eslint-disable-next-line no-magic-numbers
 export const SESSION_LENGTH = Number(process.env.SESSION_LENGTH_IN_SECONDS || 1800) * 1000;
@@ -87,6 +88,14 @@ export class UserIdService implements UserIdServiceInterface {
     const id = await this.getWalletBasedUserId(networkMagic);
     const alias = await this.getRandomizedUserId();
     return { alias, id };
+  }
+
+  async resetToDefaultValues(): Promise<void> {
+    const { usePersistentUserId, userId } = await this.getStorage();
+    if (isUndefined(usePersistentUserId) && isUndefined(userId)) {
+      await this.clearId();
+      this.userIdRestored = false;
+    }
   }
 
   async clearId(): Promise<void> {

--- a/apps/browser-extension-wallet/src/lib/scripts/types/userIdService.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/userIdService.ts
@@ -11,5 +11,6 @@ export interface UserIdService {
   makePersistent(): Promise<void>;
   makeTemporary(): Promise<void>;
   extendLifespan(): Promise<void>;
+  resetToDefaultValues(): Promise<void>;
   userTrackingType$: BehaviorSubject<UserTrackingType>;
 }

--- a/apps/browser-extension-wallet/src/utils/mocks/test-helpers.tsx
+++ b/apps/browser-extension-wallet/src/utils/mocks/test-helpers.tsx
@@ -623,6 +623,7 @@ export const userIdServiceMock: Record<keyof UserIdService, jest.Mock> = {
   getRandomizedUserId: jest.fn(),
   getUserId: jest.fn(),
   getAliasProperties: jest.fn(),
+  resetToDefaultValues: jest.fn(),
   userTrackingType$: new Subject() as any
 };
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
@@ -20,6 +20,8 @@ import { Portal } from './Portal';
 import { SendOnboardingAnalyticsEvent, SetupType } from '../types';
 import styles from './WalletSetup.module.scss';
 import { WalletSetupWizard } from './WalletSetupWizard';
+import { getUserIdService } from '@providers/AnalyticsProvider/getUserIdService';
+const userIdService = getUserIdService();
 
 const { WalletSetup: Events } = AnalyticsEventNames;
 
@@ -80,6 +82,14 @@ export const WalletSetup = ({ initialStep = WalletSetupSteps.Legal }: WalletSetu
       document.removeEventListener('keydown', handleEnterKeyPress);
     };
   }, []);
+
+  const clearUserIdService = useCallback(async () => {
+    await userIdService.resetToDefaultValues();
+  }, []);
+  // reset values in user ID service if the background storage and local storage are manually removed
+  useEffect(() => {
+    clearUserIdService();
+  }, [clearUserIdService]);
 
   const clearWallet = useCallback(() => {
     deleteFromLocalStorage('wallet');


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2646/6613776362/index.html) for [cd4fd480](https://github.com/input-output-hk/lace/pull/656/commits/cd4fd48037ee5345cf1aa8d8b4eec30bfc377d7c)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->