### PR TITLE
test(extension): maintenance 23 oct

### DIFF
--- a/packages/core/src/ui/components/WalletSetup/WalletSetupMnemonicIntroStep.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupMnemonicIntroStep.tsx
@@ -45,6 +45,7 @@ export const WalletSetupMnemonicIntroStep = ({
           src={videoSrc}
           title="YouTube video player"
           allow="accelerometer; fullscreen; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          data-testid="mnemonic-intro-yt-video-frame"
         />
       </div>
     </WalletSetupStepLayout>

--- a/packages/e2e-tests/src/assert/onboarding/onboardingMnemonicInfoPageAssert.ts
+++ b/packages/e2e-tests/src/assert/onboarding/onboardingMnemonicInfoPageAssert.ts
@@ -11,7 +11,7 @@ class OnboardingMnemonicInfoPageAssert extends OnboardingCommonAssert {
     )}`;
     await this.assertSeeStepSubtitle(expectedStepSubtitle);
     await this.assertSeeMnemonicInfoPageContentLink();
-    await MnemonicInfoPage.mnemonicImage.waitForDisplayed();
+    await MnemonicInfoPage.mnemonicVideoFrame.waitForDisplayed();
     await this.assertSeeBackButton();
     await this.assertSeeNextButton();
     await this.assertSeeLegalLinks();

--- a/packages/e2e-tests/src/assert/onboarding/onboardingWalletNamePageAssert.ts
+++ b/packages/e2e-tests/src/assert/onboarding/onboardingWalletNamePageAssert.ts
@@ -17,9 +17,9 @@ class OnboardingWalletNamePageAssert extends OnboardingCommonAssert {
   }
 
   async assertSeeWalletNamePage() {
+    await this.assertSeeWalletNameInput();
     await this.assertSeeStepTitle(await t('core.walletSetupRegisterStep.title'));
     await this.assertSeeStepSubtitle(await t('core.walletSetupRegisterStep.description'));
-    await this.assertSeeWalletNameInput();
 
     await this.assertSeeBackButton();
     await this.assertSeeNextButton();

--- a/packages/e2e-tests/src/elements/onboarding/mnemonicInfoPage.ts
+++ b/packages/e2e-tests/src/elements/onboarding/mnemonicInfoPage.ts
@@ -2,14 +2,14 @@ import CommonOnboardingElements from './commonOnboardingElements';
 
 class MnemonicInfoPage extends CommonOnboardingElements {
   private HERE_LINK = '[data-testid="faq-secret-passphrase-url"]';
-  private MNEMONIC_IMAGE = '[data-testid="mnemonic-intro-image"]';
+  private MNEMONIC_VIDEO_FRAME = '[data-testid="mnemonic-intro-yt-video-frame"]';
 
   get hereLink() {
     return $(this.HERE_LINK);
   }
 
-  get mnemonicImage() {
-    return $(this.MNEMONIC_IMAGE);
+  get mnemonicVideoFrame() {
+    return $(this.MNEMONIC_VIDEO_FRAME);
   }
 }
 

--- a/packages/e2e-tests/src/features/analytics/AnalyticsOnboardingEvents.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsOnboardingEvents.feature
@@ -51,7 +51,7 @@ Feature: Analytics - Posthog - Onboarding - Extended View
     And I validate latest analytics multiple events:
       | onboarding \| restore wallet \| all done \| go to my wallet \| click |
       | $create_alias                                                        |
-    And I validate that alias event has assigned same user id "baa84325a43e5db53c514045ce474263" in posthog
+    And I validate that alias event has assigned same user id "5b3ca1f1f7a14aad1e79f46213e2777d" in posthog
     And I validate that 9 analytics event(s) have been sent
 
   @LW-7365


### PR DESCRIPTION
Fixes for onboarding test automation (mnemonic page) / Fix distinc id anaytlics tc

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2648/6614199712/index.html) for [a172ae7a](https://github.com/input-output-hk/lace/pull/657/commits/a172ae7ad18d4a2955939998f275f229b65a2efb)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 29     | 3      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->