### PR TITLE
Fix(extension): [LW-8723] make deletion of wallet more robust

### DIFF
--- a/apps/browser-extension-wallet/src/components/ResetDataError/ResetDataError.tsx
+++ b/apps/browser-extension-wallet/src/components/ResetDataError/ResetDataError.tsx
@@ -22,14 +22,17 @@ export const ResetDataError = ({
   buttonLabel
 }: ResetDataErrorProps): React.ReactElement => {
   const { deleteWallet } = useWalletManager();
-  const { walletManagerUi } = useWalletStore();
+  const { walletManagerUi, setDeletingWallet } = useWalletStore();
   const { theme } = useTheme();
   const backgroundService = useBackgroundServiceAPIContext();
 
   const Layout = appMode === 'browser' ? WalletSetupLayout : React.Fragment;
 
   const resetData = async () => {
-    if (walletManagerUi) await deleteWallet();
+    if (walletManagerUi) {
+      setDeletingWallet(true);
+      await deleteWallet();
+    }
     window.localStorage.clear();
     window.localStorage.setItem('mode', theme.name);
     await backgroundService.resetStorage();

--- a/apps/browser-extension-wallet/src/features/unlock-wallet/components/UnlockWalletContainer.tsx
+++ b/apps/browser-extension-wallet/src/features/unlock-wallet/components/UnlockWalletContainer.tsx
@@ -19,7 +19,7 @@ export interface UnlockWalletContainerProps {
 export const UnlockWalletContainer = ({ validateMnemonic }: UnlockWalletContainerProps): React.ReactElement => {
   const analytics = useAnalyticsContext();
   const { unlockWallet, lockWallet, deleteWallet } = useWalletManager();
-  const { environmentName, setKeyAgentData } = useWalletStore();
+  const { environmentName, setKeyAgentData, setDeletingWallet } = useWalletStore();
   const backgroundService = useBackgroundServiceAPIContext();
 
   const [isVerifyingPassword, setIsVerifyingPassword] = useState(false);
@@ -75,8 +75,10 @@ export const UnlockWalletContainer = ({ validateMnemonic }: UnlockWalletContaine
   const onForgotPasswordClick = async (): Promise<void> => {
     await analytics.sendEventToPostHog(PostHogAction.UnlockWalletForgotPasswordProceedClick);
     saveValueInLocalStorage({ key: 'isForgotPasswordFlow', value: true });
+    setDeletingWallet(true);
     await deleteWallet(true);
     await backgroundService.handleOpenBrowser({ section: BrowserViewSections.FORGOT_PASSWORD });
+    setDeletingWallet(false);
   };
 
   useKeyboardShortcut(['Enter'], onUnlock);

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/userIdService.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/userIdService.ts
@@ -104,7 +104,7 @@ export class UserIdService implements UserIdServiceInterface {
     this.walletBasedUserId = undefined;
     this.userTrackingType$.next(UserTrackingType.Basic);
     this.clearSessionTimeout();
-    await this.clearStorage(['userId', 'usePersistentUserId']);
+    await this.clearStorage({ keys: ['userId', 'usePersistentUserId'] });
   }
 
   async makePersistent(): Promise<void> {

--- a/apps/browser-extension-wallet/src/lib/scripts/background/util.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/util.ts
@@ -37,18 +37,34 @@ export const getADAPriceFromBackgroundStorage = async (): Promise<BackgroundStor
 /**
  * Deletes the specified `keys` from the background storage.
  *
- * If no `keys` are passed then **ALL** of it is cleared.
+ * If no `options` are passed then **ALL** of it is cleared.
  *
- * @param keys Optional. List of keys to delete from storage
+ * @param options Optional. List of keys to either delete or remove from storage
  */
-export const clearBackgroundStorage = async (keys?: BackgroundStorageKeys[]): Promise<void> => {
-  if (!keys?.length) {
+type ClearBackgroundStorageOptions =
+  | {
+      keys: BackgroundStorageKeys[];
+      except?: never;
+    }
+  | {
+      keys?: never;
+      except: BackgroundStorageKeys[];
+    };
+export const clearBackgroundStorage = async (options?: ClearBackgroundStorageOptions): Promise<void> => {
+  if (!options) {
     await webStorage.local.remove('BACKGROUND_STORAGE');
     return;
   }
   const backgroundStorage = await getBackgroundStorage();
 
-  for (const key of keys) delete backgroundStorage?.[key];
+  for (const key in backgroundStorage) {
+    if (options.keys && options.keys.includes(key as BackgroundStorageKeys)) {
+      delete backgroundStorage[key as BackgroundStorageKeys];
+    }
+    if (options.except && options.keys.includes(key as BackgroundStorageKeys)) {
+      delete backgroundStorage[key as BackgroundStorageKeys];
+    }
+  }
   await webStorage.local.set({ BACKGROUND_STORAGE: backgroundStorage ?? {} });
 };
 

--- a/apps/browser-extension-wallet/src/lib/scripts/background/util.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/util.ts
@@ -56,12 +56,11 @@ export const clearBackgroundStorage = async (options?: ClearBackgroundStorageOpt
     return;
   }
   const backgroundStorage = await getBackgroundStorage();
-
   for (const key in backgroundStorage) {
     if (options.keys && options.keys.includes(key as BackgroundStorageKeys)) {
       delete backgroundStorage[key as BackgroundStorageKeys];
     }
-    if (options.except && options.keys.includes(key as BackgroundStorageKeys)) {
+    if (options.except && options.except.includes(key as BackgroundStorageKeys)) {
       delete backgroundStorage[key as BackgroundStorageKeys];
     }
   }

--- a/apps/browser-extension-wallet/src/lib/scripts/migrations/versions/v0_6_0.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/migrations/versions/v0_6_0.ts
@@ -129,7 +129,7 @@ export const v0_6_0: Migration = {
           removeItemFromLocalStorage('wallet_tmp');
           removeItemFromLocalStorage('keyAgentData_tmp');
           removeItemFromLocalStorage('lock_tmp');
-          await clearBackgroundStorage(['keyAgentsByChain_tmp' as BackgroundStorageKeys]);
+          await clearBackgroundStorage({ keys: ['keyAgentsByChain_tmp' as BackgroundStorageKeys] });
           throw error;
         }
       },
@@ -214,13 +214,13 @@ export const v0_6_0: Migration = {
         if (tmpBackgroundStorage?.keyAgentsByChain_tmp) {
           await setBackgroundStorage({ keyAgentsByChain: tmpBackgroundStorage.keyAgentsByChain_tmp });
         }
-        await clearBackgroundStorage(['walletName' as BackgroundStorageKeys]);
+        await clearBackgroundStorage({ keys: ['walletName' as BackgroundStorageKeys] });
         // Delete temporary storage
         removeItemFromLocalStorage('appSettings_tmp');
         removeItemFromLocalStorage('wallet_tmp');
         removeItemFromLocalStorage('keyAgentData_tmp');
         removeItemFromLocalStorage('lock_tmp');
-        await clearBackgroundStorage(['keyAgentsByChain_tmp' as BackgroundStorageKeys]);
+        await clearBackgroundStorage({ keys: ['keyAgentsByChain_tmp' as BackgroundStorageKeys] });
       },
       rollback: async () => {
         console.info(`Rollback migrated data for ${MIGRATION_VERSION} upgrade`);
@@ -229,7 +229,7 @@ export const v0_6_0: Migration = {
         if (oldWalletInfo) setItemInLocalStorage('wallet', oldWalletInfo);
         if (oldLock) setItemInLocalStorage('lock', oldLock);
         removeItemFromLocalStorage('keyAgentData');
-        await clearBackgroundStorage(['keyAgentsByChain']);
+        await clearBackgroundStorage({ keys: ['keyAgentsByChain'] });
         if (backgroundStorage?.walletName)
           await setBackgroundStorage({ walletName: backgroundStorage.walletName } as BackgroundStorage);
         // Delete any temporary storage that may have been created
@@ -237,7 +237,7 @@ export const v0_6_0: Migration = {
         removeItemFromLocalStorage('wallet_tmp');
         removeItemFromLocalStorage('keyAgentData_tmp');
         removeItemFromLocalStorage('lock_tmp');
-        await clearBackgroundStorage(['keyAgentsByChain_tmp' as BackgroundStorageKeys]);
+        await clearBackgroundStorage({ keys: ['keyAgentsByChain_tmp' as BackgroundStorageKeys] });
       }
     };
   }

--- a/apps/browser-extension-wallet/src/lib/scripts/types/background-service.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/background-service.ts
@@ -1,7 +1,8 @@
 import { BehaviorSubject, Subject } from 'rxjs';
 import { themes } from '@providers/ThemeProvider';
-import { BackgroundStorage, BackgroundStorageKeys, MigrationState } from './storage';
+import { BackgroundStorage, MigrationState } from './storage';
 import { CoinPrices } from './prices';
+import type { clearBackgroundStorage } from '../background/util';
 
 export enum BaseChannels {
   BACKGROUND_ACTIONS = 'background-actions'
@@ -60,14 +61,7 @@ export type BackgroundService = {
   handleChangeTheme: (data: ChangeThemeData) => void;
   setBackgroundStorage: (data: BackgroundStorage) => Promise<void>;
   getBackgroundStorage: () => Promise<BackgroundStorage>;
-  /**
-   * Deletes the specified `keys` from the background storage.
-   *
-   * If no `keys` are passed then **ALL** of it is cleared.
-   *
-   * @param keys Optional. List of keys to delete from storage
-   */
-  clearBackgroundStorage: (keys?: BackgroundStorageKeys[]) => Promise<void>;
+  clearBackgroundStorage: typeof clearBackgroundStorage;
   getWalletPassword: () => Uint8Array;
   setWalletPassword: (password?: Uint8Array) => void;
   resetStorage: () => Promise<void>;

--- a/apps/browser-extension-wallet/src/stores/slices/wallet-info-slice.ts
+++ b/apps/browser-extension-wallet/src/stores/slices/wallet-info-slice.ts
@@ -24,5 +24,6 @@ export const walletInfoSlice: SliceCreator<WalletInfoSlice & BlockchainProviderS
     set({ currentChain: Wallet.Cardano.ChainIds[chain], environmentName: chain });
     get().setBlockchainProvider(chain);
   },
-  getKeyAgentType: () => get()?.cardanoWallet?.keyAgent.serializableData.__typename
+  getKeyAgentType: () => get()?.cardanoWallet?.keyAgent.serializableData.__typename,
+  setDeletingWallet: (deletingWallet: boolean) => set({ deletingWallet })
 });

--- a/apps/browser-extension-wallet/src/stores/types.ts
+++ b/apps/browser-extension-wallet/src/stores/types.ts
@@ -104,6 +104,8 @@ export interface WalletInfoSlice {
   setCurrentChain: (chain: Wallet.ChainName) => void;
   environmentName?: EnvironmentTypes;
   getKeyAgentType: () => string;
+  deletingWallet?: boolean;
+  setDeletingWallet: (deletingWallet: boolean) => void;
 }
 
 export interface LockSlice {

--- a/apps/browser-extension-wallet/src/utils/local-storage.ts
+++ b/apps/browser-extension-wallet/src/utils/local-storage.ts
@@ -40,6 +40,16 @@ export const saveValueInLocalStorage = <T = ILocalStorage, K extends keyof T = k
 
 export const deleteFromLocalStorage = (key: keyof ILocalStorage): void => window.localStorage.removeItem(key);
 
+type ClearLocalStorageOptions = { except: (keyof ILocalStorage)[] };
+export const clearLocalStorage = (params?: ClearLocalStorageOptions): void => {
+  const except = params?.except || [];
+  for (const key in window.localStorage) {
+    if (!except.includes(key as keyof ILocalStorage)) {
+      window.localStorage.removeItem(key);
+    }
+  }
+};
+
 export const onStorageChangeEvent = (
   keys: (keyof ILocalStorage)[] | 'all',
   callback: StorageEventPresetAction | ((ev?: StorageEvent) => unknown),

--- a/apps/browser-extension-wallet/src/utils/mocks/store.tsx
+++ b/apps/browser-extension-wallet/src/utils/mocks/store.tsx
@@ -81,6 +81,7 @@ export const walletStoreMock = async (
     setBlockchainProvider: jest.fn(),
     addressesDiscoveryCompleted: false,
     setAddressesDiscoveryCompleted: jest.fn(),
+    setDeletingWallet: jest.fn(),
     ...customStore
   };
 };

--- a/apps/browser-extension-wallet/src/views/browser-view/components/Layout/Layout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/Layout/Layout.tsx
@@ -36,7 +36,7 @@ export const Layout = ({ children, drawerUIDefaultContent, isFullWidth }: Layout
         backgroundStorage.message?.type === MessageTypes.OPEN_BROWSER_VIEW &&
         backgroundStorage.message?.data.section === BrowserViewSections.SEND_ADVANCED
       ) {
-        await backgroundServices.clearBackgroundStorage(['message']);
+        await backgroundServices.clearBackgroundStorage({ keys: ['message'] });
         setDrawerConfig({ content: DrawerContent.SEND_TRANSACTION, options: { isAdvancedFlow: true } });
       }
     };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/__tests__/CollateralDrawer.test.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/__tests__/CollateralDrawer.test.tsx
@@ -685,7 +685,7 @@ describe('Testing CollateralDrawer component', () => {
           });
 
           await waitFor(() => {
-            expect(clearBackgroundStorageMock).toBeCalledWith(['message']);
+            expect(clearBackgroundStorageMock).toBeCalledWith({ keys: ['message'] });
             expect(mockUseRedirection).toBeCalledWith(walletRoutePaths.settings);
             expect(window.location.reload).toHaveBeenCalled();
             expect(redirectToSettingsMock.mock.invocationCallOrder[0]).toBeLessThan(
@@ -822,7 +822,7 @@ describe('Testing CollateralDrawer component', () => {
 
           setSection.mockReset();
           await waitFor(() => {
-            expect(clearBackgroundStorageMock).toBeCalledWith(['message']);
+            expect(clearBackgroundStorageMock).toBeCalledWith({ keys: ['message'] });
             expect(window.location.reload).toHaveBeenCalled();
             expect(setSection).not.toBeCalled();
             expect(redirectToActivitiesMock).not.toBeCalled();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/hardware-wallet/FooterHW.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/Collateral/hardware-wallet/FooterHW.tsx
@@ -50,7 +50,7 @@ export const FooterHW = ({ currentSection, setCurrentStep, hideDrawer }: FooterP
       backgroundStorage.message?.type === MessageTypes.OPEN_COLLATERAL_SETTINGS &&
       backgroundStorage.message?.data.section === BrowserViewSections.COLLATERAL_SETTINGS
     ) {
-      await backgroundServices.clearBackgroundStorage(['message']);
+      await backgroundServices.clearBackgroundStorage({ keys: ['message'] });
     }
 
     closeDrawer();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsWalletBase.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsWalletBase.tsx
@@ -76,7 +76,7 @@ export const SettingsWalletBase = <AdditionalDrawers extends string>({
         backgroundStorage.message?.type === MessageTypes.OPEN_COLLATERAL_SETTINGS &&
         backgroundStorage.message?.data.section === BrowserViewSections.COLLATERAL_SETTINGS
       ) {
-        await backgroundServices.clearBackgroundStorage(['message']);
+        await backgroundServices.clearBackgroundStorage({ keys: ['message'] });
         openDrawer(SettingsDrawer.collateral);
       }
     };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/__tests__/SettingsWallet.test.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/__tests__/SettingsWallet.test.tsx
@@ -321,7 +321,7 @@ describe('Testing SettingsWalletBase component', () => {
       });
 
       await waitFor(() => {
-        expect(clearBackgroundStorageMock).toBeCalledWith(['message']);
+        expect(clearBackgroundStorageMock).toBeCalledWith({ keys: ['message'] });
         expect(useSearchParamsSpy).toBeCalledWith(['activeDrawer']);
         expect(useRedirectionSpy).toBeCalledWith(walletRoutePaths.settings);
         expect(redirectToSettingsMock).toBeCalledWith({ search: { activeDrawer: SettingsDrawer.collateral } });

--- a/apps/browser-extension-wallet/src/views/browser-view/routes/index.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/routes/index.tsx
@@ -95,7 +95,8 @@ export const BrowserViewRoutes = ({ routesMap = defaultRoutes }: { routesMap?: R
     currentChain,
     setCurrentChain,
     getKeyAgentType,
-    addressesDiscoveryCompleted
+    addressesDiscoveryCompleted,
+    deletingWallet
   } = useWalletStore();
   const { loadWallet } = useWalletManager();
   const [{ chainName }] = useAppSettingsContext();
@@ -175,7 +176,7 @@ export const BrowserViewRoutes = ({ routesMap = defaultRoutes }: { routesMap?: R
     );
   }
 
-  if (!keyAgentData && !isLoadingWalletInfo) {
+  if (!keyAgentData && !isLoadingWalletInfo && !deletingWallet) {
     return (
       <Switch>
         <Route path={'/setup'} component={WalletSetup} />

--- a/packages/cardano/src/wallet/lib/cardano-wallet.ts
+++ b/packages/cardano/src/wallet/lib/cardano-wallet.ts
@@ -317,7 +317,6 @@ export const validateWalletMnemonic = async (
 export const shutdownWallet = async (walletManagerUi: WalletManagerUi): Promise<void> => {
   // Use wallet manager UI to shutdown the wallet
   await walletManagerUi.destroy();
-  // await walletManagerUi.clearStore(walletId);
 };
 
 export const switchKeyAgents = async (


### PR DESCRIPTION
# Checklist

- [ ] JIRA - LW-8723
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

There are two problems with the current implementation of wallet deletion:

1. items from local/background storage were explicitly cleaned meaning there was a chance that important items could be left out
2. zustand stores with wallet info (staking history, ...) remained untouched after deleting the wallet, meaning that if the newly loaded wallet didn't overwrite them, data of the previous wallet were shown

The solution for problem 1 was to refactor the functions to clean local/background storage to expose the option to pass a whitelist of keys to keep and delete the rest, ensuring we keep in storage only what we really want

The solution for problem 2 is forcing a full reload of the current Lace tab and to prevent the setup page from flickering a new `deletingWallet` flag has been added to the wallet store to signal that a wallet is being deleted.

Note that the other open Lace tabs already reloaded due to listening to storage changes of key agent data triggered by other documents - see docs: https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event

## Testing

Try deleting a wallet and check that the Lace tab reloads and SetupPage appears. Check that Lace behaves as expected also when wiping the wallet if user clicks "forgot password" on locked wallet.

## Screenshots

Attach screenshots here if implementation involves some UI changes
