### PR TITLE
refactor(staking): [LW-7837] encapsulate staking notifications within StakingNotificationBanners

### DIFF
--- a/packages/staking/src/features/overview/Overview.tsx
+++ b/packages/staking/src/features/overview/Overview.tsx
@@ -75,7 +75,8 @@ export const Overview = () => {
   if (currentPortfolio.length === 0)
     return (
       <>
-        {stakingNotifications.length > 0 ? (
+        {/* defensive check - no other notification than pendingFirstDelegation should be possible here at the moment of writing this comment */}
+        {stakingNotifications.includes('pendingFirstDelegation') ? (
           <StakingNotificationBanners notifications={stakingNotifications} onClickableBannerClick={onManageClick} />
         ) : (
           <Flex flexDirection="column" gap="$32">
@@ -100,10 +101,10 @@ export const Overview = () => {
           status={currentPortfolio.length === 1 ? 'simple-delegation' : 'multi-delegation'}
         />
       </Box>
-      {stakingNotifications && (
-        <Box mb="$40">
+      {stakingNotifications.length > 0 && (
+        <Flex mb="$40" flexDirection="column">
           <StakingNotificationBanners notifications={stakingNotifications} onClickableBannerClick={onManageClick} />
-        </Box>
+        </Flex>
       )}
       <Flex justifyContent="space-between" mb="$16">
         <Text.SubHeading>{t('overview.yourPoolsSection.heading')}</Text.SubHeading>

--- a/packages/staking/src/features/overview/OverviewPopup.tsx
+++ b/packages/staking/src/features/overview/OverviewPopup.tsx
@@ -85,18 +85,10 @@ export const OverviewPopup = () => {
 
   return (
     <>
-      {stakingNotifications.includes('portfolioDrifted') && (
-        <Box mb="$32">
-          <StakingNotificationBanners notifications={['portfolioDrifted']} onClickableBannerClick={expandStakingView} />
-        </Box>
-      )}
-      {stakingNotifications.includes('poolRetiredOrSaturated') && (
-        <Box mb="$32">
-          <StakingNotificationBanners
-            notifications={['poolRetiredOrSaturated']}
-            onClickableBannerClick={expandStakingView}
-          />
-        </Box>
+      {stakingNotifications.length > 0 && (
+        <Flex mb="$32" flexDirection="column">
+          <StakingNotificationBanners notifications={stakingNotifications} onClickableBannerClick={expandStakingView} />
+        </Flex>
       )}
       <Box mb="$32">
         <DelegationCard

--- a/packages/staking/src/features/overview/StakingNotificationBanner/StakingNotificationBanner.css.ts
+++ b/packages/staking/src/features/overview/StakingNotificationBanner/StakingNotificationBanner.css.ts
@@ -8,3 +8,7 @@ export const bannerInfoIcon = style({
 export const bannerBellIcon = style({
   color: theme.colors.$bannerBellIconColor,
 });
+
+export const bannerContainer = style({
+  width: '100%',
+});

--- a/packages/staking/src/features/overview/StakingNotificationBanner/StakingNotificationBanners.tsx
+++ b/packages/staking/src/features/overview/StakingNotificationBanner/StakingNotificationBanners.tsx
@@ -1,4 +1,5 @@
 import { Banner } from '@lace/common';
+import { Box } from '@lace/ui';
 import ExclamationIcon from '@lace/ui/dist/assets/icons/warning-icon-triangle.component.svg';
 import { useTranslation } from 'react-i18next';
 import BellIcon from '../../../assets/icons/bell-icon.component.svg';
@@ -52,7 +53,7 @@ export const StakingNotificationBanners = ({
       <Banner
         popupView={popupView}
         withIcon
-        customIcon={<BellIcon className={styles.bannerInfoIcon} />}
+        customIcon={<BellIcon className={styles.bannerBellIcon} />}
         message={t('overview.banners.portfolioDrifted.title')}
         description={t('overview.banners.portfolioDrifted.message')}
         onBannerClick={onClickableBannerClick}
@@ -63,7 +64,9 @@ export const StakingNotificationBanners = ({
   return (
     <>
       {notifications.map((notification, index) => (
-        <div key={index}>{notificationComponents[notification]}</div>
+        <Box key={index} className={styles.bannerContainer}>
+          {notificationComponents[notification]}
+        </Box>
       ))}
     </>
   );

--- a/packages/staking/src/features/overview/StakingNotificationBanner/getCurrentStakingNotifications.ts
+++ b/packages/staking/src/features/overview/StakingNotificationBanner/getCurrentStakingNotifications.ts
@@ -13,21 +13,13 @@ export const getCurrentStakingNotifications = ({
   currentPortfolio,
 }: GetCurrentStakingNotificationParams): StakingNotificationType[] => {
   const pendingDelegationTransaction = hasPendingDelegationTransaction(walletActivities);
-  const notifications: StakingNotificationType[] = [];
 
   if (pendingDelegationTransaction) {
-    currentPortfolio.length === 0
-      ? notifications.push('pendingFirstDelegation')
-      : notifications.push('pendingPoolMigration');
+    return currentPortfolio.length === 0 ? ['pendingFirstDelegation'] : ['pendingPoolMigration'];
   }
 
-  if (isPortfolioDrifted(currentPortfolio)) {
-    notifications.push('portfolioDrifted');
-  }
-
-  if (hasSaturatedOrRetiredPools(currentPortfolio)) {
-    notifications.push('poolRetiredOrSaturated');
-  }
-
-  return notifications;
+  return [
+    isPortfolioDrifted(currentPortfolio) ? 'portfolioDrifted' : undefined,
+    hasSaturatedOrRetiredPools(currentPortfolio) ? 'poolRetiredOrSaturated' : undefined,
+  ].filter(Boolean) as StakingNotificationType[];
 };


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7837
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

followup of #659 which aims to simplify the logic around managing staking notification banners

## Testing

Hardcode different notification combinations in `getCurrentStakingNotifications()` helper and check that they look OK

## Screenshots

before:
![Screenshot 2023-10-27 at 11 57 28](https://github.com/input-output-hk/lace/assets/4980147/c212c155-0494-4e2e-a443-040c37a02d33)
![Screenshot 2023-10-27 at 11 57 44](https://github.com/input-output-hk/lace/assets/4980147/a7f1bc20-04e6-483c-94f9-efce59a91bf2)


after:
![Screenshot 2023-10-27 at 12 36 04](https://github.com/input-output-hk/lace/assets/4980147/5b711dff-1fe3-44a0-b9fc-6298d6f045c4)
![Screenshot 2023-10-27 at 12 36 42](https://github.com/input-output-hk/lace/assets/4980147/304c3d4c-a419-430d-9135-7a4310773283)

Note that in popup view I dropped the gap between notifications if there are multiple as I found that to look better, let me know if looks better to you too


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2736/6665676710/index.html) for [5f9d662e](https://github.com/input-output-hk/lace/pull/675/commits/5f9d662ee6e184f3db16364e067ee15589becac9)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->