### PR TITLE
test(extension): test maintenance, add retry for authorization window…

### DIFF
--- a/packages/e2e-tests/src/assert/drawerSendExtendedAssert.ts
+++ b/packages/e2e-tests/src/assert/drawerSendExtendedAssert.ts
@@ -295,7 +295,10 @@ class DrawerSendExtendedAssert {
   }
 
   async assertReviewTransactionButtonIsEnabled(shouldBeEnabled: boolean) {
-    await new TransactionNewPage().reviewTransactionButton.waitForClickable({ reverse: !shouldBeEnabled });
+    await new TransactionNewPage().reviewTransactionButton.waitForClickable({
+      reverse: !shouldBeEnabled,
+      timeout: 10_000
+    });
   }
 
   async assertReviewTransactionButtonIsDisplayed(shouldBeDisplayed: boolean) {

--- a/packages/e2e-tests/src/assert/tokensPageAssert.ts
+++ b/packages/e2e-tests/src/assert/tokensPageAssert.ts
@@ -152,7 +152,7 @@ class TokensPageAssert {
         (await TokensPage.getTokenBalanceAsFloatByName(tokenName)) === expectedValueRounded - 0.01 ||
         (await TokensPage.getTokenBalanceAsFloatByName(tokenName)) === expectedValueRounded,
       {
-        timeout: 50_000,
+        timeout: 120_000,
         interval: 3000,
         timeoutMsg: `failed while waiting for ${tokenName} value update`
       }

--- a/packages/e2e-tests/src/features/analytics/AnalyticsSettingsPopup.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsSettingsPopup.feature
@@ -3,6 +3,7 @@ Feature: Analytics - Settings - Popup View
 
   Background:
     Given Lace is ready for test
+    And I de-authorize all DApps in popup mode
 
   @LW-8560
   Scenario: Analytics - Popup view - Settings - Network events - Switch network

--- a/packages/e2e-tests/src/features/e2e/SendTransactionDappE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/SendTransactionDappE2E.feature
@@ -32,7 +32,7 @@ Feature: Send Transactions from Dapp - E2E
     And I click on a transaction: 1
     Then The Tx details are displayed as "package.core.transactionDetailBrowser.received" for ADA with value: 3.00 and wallet: "WalletSendSimpleTransactionE2E" address
 
-  @LW-6797 @Testnet
+  @LW-6797 @Testnet @wip
   Scenario: Send Token from DApp E2E
     And I save token: "LaceCoin2" balance
     And I open and authorize test DApp with "Only once" setting

--- a/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
@@ -32,6 +32,12 @@ class DAppConnectorPageObject {
     await browser.switchWindow(this.DAPP_CONNECTOR_WINDOW_HANDLE);
   }
 
+  async closeDappConnectorWindowHandle() {
+    await browser.switchWindow(this.DAPP_CONNECTOR_WINDOW_HANDLE);
+    await browser.closeWindow();
+    await this.switchToTestDAppWindow();
+  }
+
   async switchToTestDAppWindow() {
     await browser.switchWindow(this.TEST_DAPP_NAME);
   }

--- a/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
@@ -11,6 +11,7 @@ import RemoveDAppModal from '../elements/dappConnector/removeDAppModal';
 import testContext from '../utils/testContext';
 import ConfirmTransactionPage from '../elements/dappConnector/confirmTransactionPage';
 import NoWalletModal from '../elements/dappConnector/noWalletModal';
+import DAppConnectorAssert, { ExpectedDAppDetails } from '../assert/dAppConnectorAssert';
 
 class DAppConnectorPageObject {
   TEST_DAPP_URL = this.getTestDAppUrl();
@@ -96,6 +97,15 @@ class DAppConnectorPageObject {
     let feeValue = await ConfirmTransactionPage.transactionAmountFee.getText();
     feeValue = feeValue.replace(' ADA', '').replace('Fee: ', '');
     await testContext.save('feeValueDAppTx', feeValue);
+  }
+
+  async switchToDappConnectorPopupAndAuthorize(testDAppDetails: ExpectedDAppDetails, mode: 'Always' | 'Only once') {
+    await this.waitAndSwitchToDAppConnectorWindow(3);
+    await DAppConnectorAssert.assertSeeAuthorizeDAppPage(testDAppDetails);
+    await this.clickButtonInDAppAuthorizationWindow('Authorize');
+    await this.clickButtonInDAppAuthorizationModal(mode);
+    await this.switchToTestDAppWindow();
+    await DAppConnectorAssert.waitUntilBalanceNotEmpty();
   }
 }
 

--- a/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
+++ b/packages/e2e-tests/src/pageobject/dAppConnectorPageObject.ts
@@ -12,6 +12,8 @@ import testContext from '../utils/testContext';
 import ConfirmTransactionPage from '../elements/dappConnector/confirmTransactionPage';
 import NoWalletModal from '../elements/dappConnector/noWalletModal';
 import DAppConnectorAssert, { ExpectedDAppDetails } from '../assert/dAppConnectorAssert';
+import { Logger } from '../support/logger';
+import TestDAppPage from '../elements/dappConnector/testDAppPage';
 
 class DAppConnectorPageObject {
   TEST_DAPP_URL = this.getTestDAppUrl();
@@ -106,6 +108,21 @@ class DAppConnectorPageObject {
     await this.clickButtonInDAppAuthorizationModal(mode);
     await this.switchToTestDAppWindow();
     await DAppConnectorAssert.waitUntilBalanceNotEmpty();
+  }
+  async switchToDappConnectorPopupAndAuthorizeWithRetry(
+    testDAppDetails: ExpectedDAppDetails,
+    mode: 'Always' | 'Only once'
+  ) {
+    try {
+      await this.switchToDappConnectorPopupAndAuthorize(testDAppDetails, mode);
+    } catch {
+      Logger.log('Failed to authorize Dapp. Retry will be executed');
+      if ((await browser.getWindowHandles()).length === 3) {
+        await this.closeDappConnectorWindowHandle();
+      }
+      await TestDAppPage.refreshButton.click();
+      await this.switchToDappConnectorPopupAndAuthorize(testDAppDetails, mode);
+    }
   }
 }
 

--- a/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
+++ b/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
@@ -171,16 +171,7 @@ Then(/^I see test DApp on the Authorized DApps list$/, async () => {
 
 When(/^I open and authorize test DApp with "(Always|Only once)" setting$/, async (mode: 'Always' | 'Only once') => {
   await DAppConnectorPageObject.openTestDApp();
-  try {
-    await DAppConnectorPageObject.switchToDappConnectorPopupAndAuthorize(testDAppDetails, mode);
-  } catch {
-    Logger.log('Failed to authorize Dapp. Retry will be executed');
-    if ((await browser.getWindowHandles()).length === 3) {
-      await DAppConnectorPageObject.closeDappConnectorWindowHandle();
-    }
-    await TestDAppPage.refreshButton.click();
-    await DAppConnectorPageObject.switchToDappConnectorPopupAndAuthorize(testDAppDetails, mode);
-  }
+  await DAppConnectorPageObject.switchToDappConnectorPopupAndAuthorizeWithRetry(testDAppDetails, mode);
 });
 
 Then(/^I de-authorize all DApps in (extended|popup) mode$/, async (mode: 'extended' | 'popup') => {

--- a/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
+++ b/packages/e2e-tests/src/steps/dAppConnectorSteps.ts
@@ -171,24 +171,15 @@ Then(/^I see test DApp on the Authorized DApps list$/, async () => {
 
 When(/^I open and authorize test DApp with "(Always|Only once)" setting$/, async (mode: 'Always' | 'Only once') => {
   await DAppConnectorPageObject.openTestDApp();
-  const switchToDappConnectorPopupAndAuthorize = async () => {
-    await DAppConnectorPageObject.waitAndSwitchToDAppConnectorWindow(3);
-    await DAppConnectorAssert.assertSeeAuthorizeDAppPage(testDAppDetails);
-    await DAppConnectorPageObject.clickButtonInDAppAuthorizationWindow('Authorize');
-    await DAppConnectorPageObject.clickButtonInDAppAuthorizationModal(mode);
-    await DAppConnectorPageObject.switchToTestDAppWindow();
-    await DAppConnectorAssert.waitUntilBalanceNotEmpty();
-  };
-
   try {
-    await switchToDappConnectorPopupAndAuthorize();
+    await DAppConnectorPageObject.switchToDappConnectorPopupAndAuthorize(testDAppDetails, mode);
   } catch {
     Logger.log('Failed to authorize Dapp. Retry will be executed');
     if ((await browser.getWindowHandles()).length === 3) {
       await DAppConnectorPageObject.closeDappConnectorWindowHandle();
     }
     await TestDAppPage.refreshButton.click();
-    await switchToDappConnectorPopupAndAuthorize();
+    await DAppConnectorPageObject.switchToDappConnectorPopupAndAuthorize(testDAppDetails, mode);
   }
 });
 


### PR DESCRIPTION
… in dapp


<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2779/6695245375/index.html) for [4abe6501](https://github.com/input-output-hk/lace/pull/685/commits/4abe6501eb3e2b3ba0791feeb1cfd68c7fc7b1cf)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 31     | 1      | 0       | 0     | 32    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->