### PR TITLE
test(extension): add de-authorization step in dapp tc

### DIFF
--- a/packages/e2e-tests/src/features/e2e/SendTransactionDappE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/SendTransactionDappE2E.feature
@@ -32,8 +32,9 @@ Feature: Send Transactions from Dapp - E2E
     And I click on a transaction: 1
     Then The Tx details are displayed as "package.core.activityDetails.received" for ADA with value: 3.00 and wallet: "WalletSendSimpleTransactionE2E" address
 
-  @LW-6797 @Testnet @wip
+  @LW-6797 @Testnet
   Scenario: Send Token from DApp E2E
+    And I de-authorize all DApps in extended mode
     And I save token: "LaceCoin2" balance
     And I open and authorize test DApp with "Only once" setting
     And I click "Send Token" button in test DApp


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2808/6729620124/index.html) for [9835accb](https://github.com/input-output-hk/lace/pull/694/commits/9835accb4b54f80d4e3b640c4273beba2d4f6a19)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 1      | 0       | 0     | 31    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->