### PR TITLE
chore: main branch with 1.6.1 manifest and release note

### DIFF
--- a/apps/browser-extension-wallet/manifest.json
+++ b/apps/browser-extension-wallet/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Lace",
   "description": "One fast, accessible, and secure platform for digital assets, DApps, NFTs, and DeFi.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "manifest_version": 3,
   "key": "$LACE_EXTENSION_KEY",
   "icons": {

--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lace/browser-extension-wallet",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A fully capable wallet packaged as browser extensions for Chrome, Firefox, and Edge",
   "homepage": "https://github.com/input-output-hk/lace/blob/master/apps/browser-extension-wallet/README.md",
   "bugs": {

--- a/apps/browser-extension-wallet/src/release-notes/1_6_1.tsx
+++ b/apps/browser-extension-wallet/src/release-notes/1_6_1.tsx
@@ -1,0 +1,13 @@
+/* eslint-disable camelcase */
+import React from 'react';
+
+const ReleaseNote_1_6_1 = (): React.ReactElement => (
+  <>
+    <p>Introducing Lace 1.6.1 This hotfix version solves the following:</p>
+    <ul style={{ listStyleType: 'disc', margin: 0 }}>
+      <li>Fixed a minor data fetch issue</li>
+    </ul>
+  </>
+);
+
+export default ReleaseNote_1_6_1;


### PR DESCRIPTION
Cherry picked manifest update + release note to merge to `main`

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2810/6730612421/index.html) for [179a57ef](https://github.com/input-output-hk/lace/pull/695/commits/179a57ef039c9b4335159fb5969700af5eea7a06)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 1      | 0       | 0     | 31    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->