### PR TITLE
fix(all): [LW-8912] fix missing pending txs in activity & stuck infinite scroll on bigger resolutions

### DIFF
--- a/apps/browser-extension-wallet/manifest.json
+++ b/apps/browser-extension-wallet/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Lace",
   "description": "One fast, accessible, and secure platform for digital assets, DApps, NFTs, and DeFi.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "manifest_version": 3,
   "key": "$LACE_EXTENSION_KEY",
   "icons": {

--- a/apps/browser-extension-wallet/src/stores/slices/wallet-activities-slice.ts
+++ b/apps/browser-extension-wallet/src/stores/slices/wallet-activities-slice.ts
@@ -308,8 +308,8 @@ const getWalletActivitiesObservable = async ({
     map(async (allTransactions) =>
       (await allTransactions).sort((firstTx, secondTx) => {
         // ensure pending txs are always first
-        if (firstTx.status === ActivityStatus.PENDING && secondTx.status !== ActivityStatus.PENDING) return 1;
-        if (secondTx.status === ActivityStatus.PENDING && firstTx.status !== ActivityStatus.PENDING) return -1;
+        if (firstTx.status === ActivityStatus.PENDING && secondTx.status !== ActivityStatus.PENDING) return -1;
+        if (secondTx.status === ActivityStatus.PENDING && firstTx.status !== ActivityStatus.PENDING) return 1;
         // otherwise sort by date
         return secondTx.date.getTime() - firstTx.date.getTime();
       })

--- a/packages/core/src/ui/components/Activity/GroupedAssetActivityList.tsx
+++ b/packages/core/src/ui/components/Activity/GroupedAssetActivityList.tsx
@@ -26,21 +26,29 @@ export const GroupedAssetActivityList = ({
   withTitle,
   isDrawerView
 }: GroupedAssetActivityListProps): React.ReactElement => {
-  const TAKE = 5;
+  // workaround for bug in react-infinite-scroll-component
+  // related to not loading more elements if the height of the container is less than the height of the window
+  // https://github.com/ankeetmaini/react-infinite-scroll-component/issues/380
+  // windowHeight state needed to ensure that page size remains the same if window is resized
+  const [initialWindowHeight] = useState(window.innerHeight);
+  const ESTIMATED_ITEM_HEIGHT = 100;
+  // eslint-disable-next-line no-magic-numbers
+  const pageSize = Math.max(5, Math.floor(initialWindowHeight / ESTIMATED_ITEM_HEIGHT));
+
   const FAKE_LOAD_TIMEOUT = 1000;
   const [skip, setSkip] = useState(0);
-  const [paginatedLists, setPaginatedLists] = useState(take(lists, skip + TAKE));
+  const [paginatedLists, setPaginatedLists] = useState(take(lists, skip + pageSize));
 
   const loadMoreData = () => {
     setTimeout(() => {
-      setSkip(skip + TAKE);
+      setSkip(skip + pageSize);
     }, FAKE_LOAD_TIMEOUT);
   };
 
   useEffect(() => {
     if (lists.length === 0) return;
-    setPaginatedLists(take(lists, skip + TAKE));
-  }, [skip, lists]);
+    setPaginatedLists(take(lists, skip + pageSize));
+  }, [skip, lists, pageSize]);
 
   return (
     <InfiniteScroll


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8912
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This PR fixes two independent bugs:
1. pending txs were incorrectly placed at the bottom of the activity list, resulted in their perceived "disappearance" from activity
2. while fixing bug 1 I noticed that the activity list remained "stuck" at loading on my screen which appears to be a result of a long-standing bug in the infinite scroll library (https://github.com/ankeetmaini/react-infinite-scroll-component/issues/380) . A proper fix would probably involve patching the infinite scroll lib or replacing it with a completely different lib. For now I at least documented the bug with a comment and made a workaround to load enough elements to overflow the screen.

## Testing

1. test fix for bug 1 try making a delegation, check that it appears at the top of the "Activity" tab while pending
2. for bug 2, check that upon initially opening the tab, the activities don't remain stuck in loading state

## Screenshots

bug 2: Activity -> stuck loading, especially on full screen, fixed in this PR:

![Screenshot 2023-11-02 at 12 39 38](https://github.com/input-output-hk/lace/assets/4980147/a0905d46-a603-46b7-b1aa-df7e5272f0ac)