### PR TITLE
[LW-8998] Add missing tracking points around dApp connector submission in Lace

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/DappTransactionFail.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/DappTransactionFail.tsx
@@ -1,12 +1,27 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@lace/common';
+import { Button, PostHogAction } from '@lace/common';
 import Fail from '../../../assets/icons/exclamation-circle.svg';
 import styles from './Layout.module.scss';
 import { Image } from 'antd';
+import { useAnalyticsContext } from '@providers';
+import { TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
 
 export const DappTransactionFail = (): React.ReactElement => {
   const { t } = useTranslation();
+  const analytics = useAnalyticsContext();
+  const onClose = async () => {
+    await analytics?.sendEventToPostHog(PostHogAction.SendSomethingWentWrongCancelClick, {
+      [TX_CREATION_TYPE_KEY]: TxCreationType.External
+    });
+    window.close();
+  };
+
+  useEffect(() => {
+    analytics?.sendEventToPostHog(PostHogAction.SendSomethingWentWrongView, {
+      [TX_CREATION_TYPE_KEY]: TxCreationType.External
+    });
+  }, [analytics]);
 
   return (
     <div data-testid="dapp-sign-tx-fail" className={styles.noWalletContainer}>
@@ -16,7 +31,7 @@ export const DappTransactionFail = (): React.ReactElement => {
         <div className={styles.description}>{t('dapp.sign.failure.description')}</div>
       </div>
       <div className={styles.footer}>
-        <Button onClick={() => window.close()} color="secondary" className={styles.footerBtn}>
+        <Button onClick={onClose} color="secondary" className={styles.footerBtn}>
           {t('general.button.cancel')}
         </Button>
       </div>

--- a/apps/browser-extension-wallet/src/features/dapp/components/DappTransactionSuccess.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/DappTransactionSuccess.tsx
@@ -1,12 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@lace/common';
+import { Button, PostHogAction } from '@lace/common';
 import { Image } from 'antd';
 import Success from '../../../assets/icons/success-staking.svg';
 import styles from './Layout.module.scss';
+import { useAnalyticsContext } from '@providers';
+import { TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
 
 export const DappTransactionSuccess = (): React.ReactElement => {
+  const analytics = useAnalyticsContext();
   const { t } = useTranslation();
+
+  const onClose = async () => {
+    await analytics?.sendEventToPostHog(PostHogAction.SendAllDoneCloseClick, {
+      [TX_CREATION_TYPE_KEY]: TxCreationType.External
+    });
+    window.close();
+  };
+
+  useEffect(() => {
+    analytics?.sendEventToPostHog(PostHogAction.SendAllDoneView, {
+      [TX_CREATION_TYPE_KEY]: TxCreationType.External
+    });
+  }, [analytics]);
 
   return (
     <div data-testid="dapp-sign-tx-success" className={styles.noWalletContainer}>
@@ -20,11 +36,7 @@ export const DappTransactionSuccess = (): React.ReactElement => {
         </div>
       </div>
       <div className={styles.footer}>
-        <Button
-          data-testid="dapp-sign-tx-success-close-button"
-          className={styles.footerBtn}
-          onClick={() => window.close()}
-        >
+        <Button data-testid="dapp-sign-tx-success-close-button" className={styles.footerBtn} onClick={onClose}>
           {t('general.button.close')}
         </Button>
       </div>

--- a/apps/browser-extension-wallet/src/features/dapp/components/__tests__/ConfirmTransaction.test.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/__tests__/ConfirmTransaction.test.tsx
@@ -13,7 +13,7 @@ import { ConfirmTransaction } from '../ConfirmTransaction';
 import '@testing-library/jest-dom';
 import { I18nextProvider } from 'react-i18next';
 import { StoreProvider } from '@src/stores';
-import { AppSettingsProvider, DatabaseProvider, ViewFlowProvider } from '@src/providers';
+import { AnalyticsProvider, AppSettingsProvider, DatabaseProvider, ViewFlowProvider } from '@src/providers';
 import { APP_MODE_BROWSER } from '@src/utils/constants';
 import i18n from '@lib/i18n';
 import { BehaviorSubject } from 'rxjs';
@@ -70,9 +70,11 @@ const getWrapper =
       <AppSettingsProvider>
         <DatabaseProvider>
           <StoreProvider appMode={APP_MODE_BROWSER}>
-            <I18nextProvider i18n={i18n}>
-              <ViewFlowProvider viewStates={sendViewsFlowState}>{children}</ViewFlowProvider>
-            </I18nextProvider>
+            <AnalyticsProvider analyticsDisabled>
+              <I18nextProvider i18n={i18n}>
+                <ViewFlowProvider viewStates={sendViewsFlowState}>{children}</ViewFlowProvider>
+              </I18nextProvider>
+            </AnalyticsProvider>
           </StoreProvider>
         </DatabaseProvider>
       </AppSettingsProvider>

--- a/apps/browser-extension-wallet/src/features/dapp/components/__tests__/ConfirmTransaction.test.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/__tests__/ConfirmTransaction.test.tsx
@@ -13,12 +13,21 @@ import { ConfirmTransaction } from '../ConfirmTransaction';
 import '@testing-library/jest-dom';
 import { I18nextProvider } from 'react-i18next';
 import { StoreProvider } from '@src/stores';
-import { AnalyticsProvider, AppSettingsProvider, DatabaseProvider, ViewFlowProvider } from '@src/providers';
+import {
+  AnalyticsProvider,
+  AppSettingsProvider,
+  BackgroundServiceAPIProvider,
+  BackgroundServiceAPIProviderProps,
+  DatabaseProvider,
+  ViewFlowProvider
+} from '@src/providers';
 import { APP_MODE_BROWSER } from '@src/utils/constants';
 import i18n from '@lib/i18n';
 import { BehaviorSubject } from 'rxjs';
 import { act } from 'react-dom/test-utils';
 import { sendViewsFlowState } from '../../config';
+import { PostHogClientProvider } from '@providers/PostHogClientProvider';
+import { postHogClientMocks } from '@src/utils/mocks/test-helpers';
 
 const assetInfo$ = new BehaviorSubject(new Map());
 const available$ = new BehaviorSubject([]);
@@ -63,21 +72,30 @@ const testIds = {
   dappTransactionConfirm: 'dapp-transaction-confirm'
 };
 
+const backgroundService = {
+  getBackgroundStorage: jest.fn(),
+  setBackgroundStorage: jest.fn()
+} as unknown as BackgroundServiceAPIProviderProps['value'];
+
 const getWrapper =
   () =>
   ({ children }: { children: React.ReactNode }) =>
     (
-      <AppSettingsProvider>
-        <DatabaseProvider>
-          <StoreProvider appMode={APP_MODE_BROWSER}>
-            <AnalyticsProvider analyticsDisabled>
-              <I18nextProvider i18n={i18n}>
-                <ViewFlowProvider viewStates={sendViewsFlowState}>{children}</ViewFlowProvider>
-              </I18nextProvider>
-            </AnalyticsProvider>
-          </StoreProvider>
-        </DatabaseProvider>
-      </AppSettingsProvider>
+      <BackgroundServiceAPIProvider value={backgroundService}>
+        <AppSettingsProvider>
+          <DatabaseProvider>
+            <StoreProvider appMode={APP_MODE_BROWSER}>
+              <PostHogClientProvider postHogCustomClient={postHogClientMocks as any}>
+                <AnalyticsProvider analyticsDisabled>
+                  <I18nextProvider i18n={i18n}>
+                    <ViewFlowProvider viewStates={sendViewsFlowState}>{children}</ViewFlowProvider>
+                  </I18nextProvider>
+                </AnalyticsProvider>
+              </PostHogClientProvider>
+            </StoreProvider>
+          </DatabaseProvider>
+        </AppSettingsProvider>
+      </BackgroundServiceAPIProvider>
     );
 
 describe('Testing ConfirmTransaction component', () => {

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/types.ts
@@ -54,6 +54,13 @@ export enum TxRecipientType {
   RegularAddress = 'regular address'
 }
 
+export const TX_CREATION_TYPE_KEY = 'tx_creation_type';
+
+export enum TxCreationType {
+  Internal = 'internal',
+  External = 'external'
+}
+
 export type OnboardingFlows = 'create' | 'restore' | 'hw' | 'forgot_password';
 export type PostHogActionsKeys =
   | 'SETUP_OPTION_CLICK'

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -30,7 +30,9 @@ import {
   MatomoEventActions,
   MatomoEventCategories,
   AnalyticsEventNames,
-  PostHogAction
+  PostHogAction,
+  TxCreationType,
+  TX_CREATION_TYPE_KEY
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { buttonIds } from '@hooks/useEnterKeyPress';
 import { AssetPickerFooter } from './AssetPickerFooter';
@@ -105,7 +107,10 @@ export const Footer = withAddressBookContext(
     const isSummaryStep = currentSection.currentSection === Sections.SUMMARY;
 
     const sendEventToPostHog = (evtAction: PostHogAction) =>
-      analytics.sendEventToPostHog(evtAction, { trigger_point: triggerPoint });
+      analytics.sendEventToPostHog(evtAction, {
+        trigger_point: triggerPoint,
+        [TX_CREATION_TYPE_KEY]: TxCreationType.Internal
+      });
 
     const sendAnalytics = useCallback(() => {
       switch (currentSection.currentSection) {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/HeaderView.tsx
@@ -33,7 +33,9 @@ import {
   MatomoEventActions,
   MatomoEventCategories,
   AnalyticsEventNames,
-  PostHogAction
+  PostHogAction,
+  TX_CREATION_TYPE_KEY,
+  TxCreationType
 } from '@providers/AnalyticsProvider/analyticsTracker';
 
 import { useWalletStore } from '@src/stores';
@@ -182,9 +184,15 @@ export const HeaderNavigation = ({ isPopupView }: HeaderNavigationProps): React.
 
   const onCrossIconClick = () => {
     if (section.currentSection === Sections.SUCCESS_TX) {
-      analytics.sendEventToPostHog(PostHogAction.SendAllDoneXClick, { trigger_point: triggerPoint });
+      analytics.sendEventToPostHog(PostHogAction.SendAllDoneXClick, {
+        trigger_point: triggerPoint,
+        [TX_CREATION_TYPE_KEY]: TxCreationType.Internal
+      });
     } else if (section.currentSection === Sections.FAIL_TX) {
-      analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongXClick, { trigger_point: triggerPoint });
+      analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongXClick, {
+        trigger_point: triggerPoint,
+        [TX_CREATION_TYPE_KEY]: TxCreationType.Internal
+      });
     }
     onClose();
   };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ResultMessage } from '@components/ResultMessage';
 import { useAnalyticsContext } from '@providers';
-import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
+import { PostHogAction, TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
 import styles from './TransactionSuccessView.module.scss';
 import { useAnalyticsSendFlowTriggerPoint } from '../store';
 
@@ -12,8 +12,11 @@ export const TransactionFail = (): React.ReactElement => {
   const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
 
   useEffect(() => {
-    // eslint-disable-next-line camelcase
-    analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongView, { trigger_point: triggerPoint });
+    analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongView, {
+      // eslint-disable-next-line camelcase
+      trigger_point: triggerPoint,
+      [TX_CREATION_TYPE_KEY]: TxCreationType.Internal
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.tsx
@@ -3,7 +3,12 @@ import uniq from 'lodash/uniq';
 import { ResultMessage } from '@components/ResultMessage';
 import { TransactionHashBox } from '@components/TransactionHashBox';
 import { useAnalyticsContext } from '@providers';
-import { PostHogAction, TxRecipientType } from '@providers/AnalyticsProvider/analyticsTracker';
+import {
+  PostHogAction,
+  TX_CREATION_TYPE_KEY,
+  TxCreationType,
+  TxRecipientType
+} from '@providers/AnalyticsProvider/analyticsTracker';
 import {
   useBuiltTxState,
   useAnalyticsSendFlowTriggerPoint,
@@ -75,7 +80,8 @@ export const TransactionSuccessView = ({ footerSlot }: { footerSlot?: React.Reac
         // eslint-disable-next-line camelcase
         recipient_type: recipientTypesUnique,
         // eslint-disable-next-line camelcase
-        recipient_source: recipientSourceUnique
+        recipient_source: recipientSourceUnique,
+        [TX_CREATION_TYPE_KEY]: TxCreationType.Internal
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
# Checklist

- [x] JIRA - https://input-output.atlassian.net/browse/LW-8998

---

## Proposed solution

Added new property to posthog events to differentiate between normal and dapp transactions.

```
export enum TxCreationType {
  Internal = 'internal',
  External = 'external'
}
```

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- smokeTests -->
**smokeTests**: ❌ [test report](https://lace-qa:8PP5wBaDV6UoXj@dq4ajm5i5q7bz.cloudfront.net/linux/chrome/2837/6749131473/index.html) for [a45ea30a](https://github.com/input-output-hk/lace/pull/701/commits/a45ea30ab17551e4d2816d53723e1898921be43b)
|       | passed | failed | skipped | flaky | total | result |
|-------|--------|--------|---------|-------|-------|--------|
| Total | 30     | 1      | 0       | 0     | 31    | ❌     |
<!-- smokeTests -->

<!-- jobs -->
<!-- allurestop -->