### PR TITLE
feat(staking): [LW-8929, LW-8777] apply pool search also to selected pools

### DIFF
--- a/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
@@ -23,6 +23,17 @@ const DEFAULT_SORT_OPTIONS: StakePoolSortOptions = {
 const searchDebounce = 300;
 const defaultFetchLimit = 10;
 
+// imitates apps/browser-extension-wallet/src/stores/slices/stake-pool-search-slice.ts
+const naiveSelectedPoolsSearch = (searchString: string, pools: Wallet.Cardano.StakePool[]) => {
+  const lowerCaseSearchString = searchString.toLowerCase();
+  return pools.filter(
+    (pool) =>
+      pool.metadata?.name.toLowerCase().includes(lowerCaseSearchString) ||
+      pool.metadata?.ticker.toLowerCase().includes(lowerCaseSearchString) ||
+      pool.id.toLowerCase() === lowerCaseSearchString
+  );
+};
+
 export const StakePoolsTable = ({ scrollableTargetId }: StakePoolsTableProps) => {
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState<string>('');
@@ -31,9 +42,7 @@ export const StakePoolsTable = ({ scrollableTargetId }: StakePoolsTableProps) =>
   const [sort, setSort] = useState<StakePoolSortOptions>(DEFAULT_SORT_OPTIONS);
   const [stakePools, setStakePools] = useState<Wallet.StakePoolSearchResults['pageResults']>([]);
   const [skip, setSkip] = useState<number>(0);
-  const selectedPortfolioStakePools = useDelegationPortfolioStore((store) =>
-    store.selectedPortfolio.map(({ stakePool }) => stakePool)
-  );
+  const selectedPortfolio = useDelegationPortfolioStore((store) => store.selectedPortfolio);
   const {
     walletStoreWalletUICardanoCoin: cardanoCoin,
     currentChain,
@@ -77,12 +86,19 @@ export const StakePoolsTable = ({ scrollableTargetId }: StakePoolsTableProps) =>
 
   useEffect(() => {
     // Update stake pool list and new offset position
-    setStakePools((prevPools: Wallet.StakePoolSearchResults['pageResults']) =>
-      searchSkip === 0 ? pageResults : [...prevPools, ...pageResults]
-    );
+    setStakePools((prevPools: Wallet.StakePoolSearchResults['pageResults']) => {
+      const selectedPortfolioStakePools = selectedPortfolio.map((sp) => sp.stakePool);
+      const combinedStakePools = [
+        ...(searchValue
+          ? naiveSelectedPoolsSearch(searchValue, selectedPortfolioStakePools)
+          : selectedPortfolioStakePools),
+        ...(searchSkip === 0 ? pageResults : [...prevPools, ...pageResults]),
+      ];
+      return uniqBy(combinedStakePools, (p) => p.id);
+    });
     setSkip(searchSkip);
     setIsLoadingList(false);
-  }, [pageResults, searchSkip]);
+  }, [pageResults, searchSkip, searchValue, selectedPortfolio]);
 
   const onSearch = (searchString: string) => {
     setIsSearching(true);
@@ -93,30 +109,9 @@ export const StakePoolsTable = ({ scrollableTargetId }: StakePoolsTableProps) =>
     setSearchValue(searchString);
   };
 
-  // imitates apps/browser-extension-wallet/src/stores/slices/stake-pool-search-slice.ts
-  const naiveSelectedPoolsSearch = (searchString: string, pools: Wallet.Cardano.StakePool[]) => {
-    const lowerCaseSearchString = searchString.toLowerCase();
-    return pools.filter(
-      (pool) =>
-        pool.metadata?.name.toLowerCase().includes(lowerCaseSearchString) ||
-        pool.metadata?.ticker.toLowerCase().includes(lowerCaseSearchString) ||
-        pool.id.toLowerCase() === lowerCaseSearchString
-    );
-  };
-
-  const combinedUnique = useMemo(() => {
-    const combinedStakePools = [
-      ...(searchValue
-        ? naiveSelectedPoolsSearch(searchValue, selectedPortfolioStakePools)
-        : selectedPortfolioStakePools),
-      ...stakePools,
-    ];
-    return uniqBy(combinedStakePools, (p) => p.id);
-  }, [stakePools, selectedPortfolioStakePools, searchValue]);
-
   const list = useMemo(
     () =>
-      combinedUnique.map((pool) => {
+      stakePools.map((pool) => {
         const stakePool = Wallet.util.stakePoolTransformer({ cardanoCoin, stakePool: pool });
         const logo = getRandomIcon({ id: pool.id.toString(), size: 30 });
 
@@ -127,7 +122,7 @@ export const StakePoolsTable = ({ scrollableTargetId }: StakePoolsTableProps) =>
           stakePool: pool,
         };
       }) || [],
-    [combinedUnique, cardanoCoin]
+    [stakePools, cardanoCoin]
   );
 
   return (

--- a/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
@@ -2,6 +2,7 @@ import { Wallet } from '@lace/cardano';
 import { PostHogAction, Search, getRandomIcon } from '@lace/common';
 import { Box } from '@lace/ui';
 import debounce from 'lodash/debounce';
+import intersectionBy from 'lodash/intersectionBy';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StateStatus, useOutsideHandles } from '../../outside-handles-provider';
@@ -103,9 +104,7 @@ export const StakePoolsTable = ({ scrollableTargetId }: StakePoolsTableProps) =>
        *   but this seems like the best solution for now.
        */
       ...(searchValue
-        ? selectedPortfolioStakePools.filter((pool) =>
-            stakePools.find((foundStakePool) => foundStakePool.id === pool.id)
-          )
+        ? intersectionBy(selectedPortfolioStakePools, stakePools, (p) => p.id)
         : selectedPortfolioStakePools),
       ...stakePools,
     ];

--- a/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
@@ -2,6 +2,7 @@ import { Wallet } from '@lace/cardano';
 import { PostHogAction, Search, getRandomIcon } from '@lace/common';
 import { Box } from '@lace/ui';
 import debounce from 'lodash/debounce';
+import uniqBy from 'lodash/uniqBy';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StateStatus, useOutsideHandles } from '../../outside-handles-provider';
@@ -110,10 +111,7 @@ export const StakePoolsTable = ({ scrollableTargetId }: StakePoolsTableProps) =>
         : selectedPortfolioStakePools),
       ...stakePools,
     ];
-    const combinedUniqueIds = [...new Set(combinedStakePools.map((pool) => pool.id))];
-    return combinedUniqueIds.map((id) =>
-      combinedStakePools.find((pool) => pool.id === id)
-    ) as Wallet.Cardano.StakePool[];
+    return uniqBy(combinedStakePools, (p) => p.id);
   }, [stakePools, selectedPortfolioStakePools, searchValue]);
 
   const list = useMemo(

--- a/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
@@ -93,12 +93,27 @@ export const StakePoolsTable = ({ scrollableTargetId }: StakePoolsTableProps) =>
   };
 
   const combinedUnique = useMemo(() => {
-    const combinedStakePools = [...selectedPortfolioStakePools, ...stakePools];
+    const combinedStakePools = [
+      /**
+       * If there's a search value, filter selected pools if they are in the search results.
+       * A disadvantage of this approach is that if a current pool is not yet in the search results (it's further down in results),
+       *   it will not be shown in the list. The confusing part about this is that if the user scrolls down long enough,
+       *   the pool will appear in the upper selected list.
+       * Alternative solutions include increasing the search limit / not show selected pools when searching at all,
+       *   but this seems like the best solution for now.
+       */
+      ...(searchValue
+        ? selectedPortfolioStakePools.filter((pool) =>
+            stakePools.find((foundStakePool) => foundStakePool.id === pool.id)
+          )
+        : selectedPortfolioStakePools),
+      ...stakePools,
+    ];
     const combinedUniqueIds = [...new Set(combinedStakePools.map((pool) => pool.id))];
     return combinedUniqueIds.map((id) =>
       combinedStakePools.find((pool) => pool.id === id)
     ) as Wallet.Cardano.StakePool[];
-  }, [stakePools, selectedPortfolioStakePools]);
+  }, [stakePools, selectedPortfolioStakePools, searchValue]);
 
   const list = useMemo(
     () =>


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8929, LW-8777
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Not ideal, but the best for now imho:
```
/**
 * If there's a search value, filter selected pools if they are in the search results.
 * A disadvantage of this approach is that if a current pool is not yet in the search results (it's further down in results),
 *   it will not be shown in the list. The confusing part about this is that if the user scrolls down long enough,
 *   the pool will appear in the upper selected list.
 * Alternative solutions include increasing the search limit / not show selected pools when searching at all,
 *   but this seems like the best solution for now.
 */
```

The only consistent solution IMHO would be to hide selected pools upon search, and when adding a pool, re-set the search and show all selected pools. Other solutions, such as increasing search limit from 10 to N would create problems on their own. Other solution would be to apply the same "search filters", as `stake-pools-search-slice.ts`, but that would cause duplicity and would be fragile


## Testing

Play around with selected pools & searching, see that search is applied also to selectedPools.
