### PR TITLE
fix(all): [LW-8723] make order of delete operations 1:1 match original code

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -302,13 +302,18 @@ export const useWalletManager = (): UseWalletManager => {
   const deleteWallet = useCallback(
     async (isForgotPasswordFlow = false): Promise<void> => {
       await Wallet.shutdownWallet(walletManagerUi);
-      setKeyAgentData();
-      resetWalletLock();
-      setCardanoWallet();
-
+      deleteFromLocalStorage('appSettings');
+      deleteFromLocalStorage('showDappBetaModal');
+      deleteFromLocalStorage('lastStaking');
+      deleteFromLocalStorage('userInfo');
+      deleteFromLocalStorage('keyAgentData');
       await backgroundService.clearBackgroundStorage({
         except: ['fiatPrices', 'userId', 'usePersistentUserId', 'experimentsConfiguration']
       });
+      setKeyAgentData();
+      resetWalletLock();
+      setCardanoWallet();
+      setCurrentChain(CHAIN);
 
       const commonLocalStorageKeysToKeep: (keyof ILocalStorage)[] = [
         'currency',
@@ -318,8 +323,6 @@ export const useWalletManager = (): UseWalletManager => {
         'isForgotPasswordFlow',
         'multidelegationFirstVisit'
       ];
-
-      setCurrentChain(CHAIN);
 
       if (isForgotPasswordFlow) {
         const additionalKeysToKeep: (keyof ILocalStorage)[] = ['wallet', ENHANCED_ANALYTICS_OPT_IN_STATUS_LS_KEY];


### PR DESCRIPTION
# Checklist

- [x] JIRA -LW-8723
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Fix ensuring the order of operations within the `deleteWallet()` matches the original one before #674 as it apparently has impact in case of automation tests which started crashing

## Testing

Check that automation tests pass. Try also manually removing a wallet and restoring a new one and check that it still works as intended. Check that no additional leftovers are in local/background storage

## Screenshots

Attach screenshots here if implementation involves some UI changes
