### PR TITLE
feat(extension): [LW-7417] track manual re-sync and hd wallet discovery

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 import {
   AnalyticsEventNames,
   EnhancedAnalyticsOptInStatus,
+  PostHogAction,
   postHogOnboardingActions
 } from '@providers/AnalyticsProvider/analyticsTracker';
 import { config } from '@src/config';
@@ -174,6 +175,14 @@ export const HardwareWalletFlow = ({
       setDoesUserAllowAnalytics(
         isAnalyticsAccepted ? EnhancedAnalyticsOptInStatus.OptedIn : EnhancedAnalyticsOptInStatus.OptedOut
       );
+      const addressDiscoverySubscriber = wallet.asyncKeyAgent.knownAddresses$.subscribe((addresses) => {
+        if (addresses.length === 0) return;
+        const hdWalletDiscovered = addresses.some((addr) => addr.index > 0);
+        if (hdWalletDiscovered) {
+          analytics.sendEventToPostHog(PostHogAction.OnboardingRestoreHdWallet);
+        }
+        addressDiscoverySubscriber.unsubscribe();
+      });
       await analytics.setOptedInForEnhancedAnalytics(
         isAnalyticsAccepted ? EnhancedAnalyticsOptInStatus.OptedIn : EnhancedAnalyticsOptInStatus.OptedOut
       );

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -23,6 +23,7 @@ import { WarningModal } from '@src/views/browser-view/components/WarningModal';
 import {
   AnalyticsEventNames,
   EnhancedAnalyticsOptInStatus,
+  PostHogAction,
   postHogOnboardingActions,
   UserTrackingType
 } from '@providers/AnalyticsProvider/analyticsTracker';
@@ -290,6 +291,15 @@ export const WalletSetupWizard = ({
       await analytics.setOptedInForEnhancedAnalytics(
         isAnalyticsAccepted ? EnhancedAnalyticsOptInStatus.OptedIn : EnhancedAnalyticsOptInStatus.OptedOut
       );
+      const addressDiscoverySubscriber = wallet.wallet.asyncKeyAgent.knownAddresses$.subscribe((addresses) => {
+        if (addresses.length === 0) return;
+        const hdWalletDiscovered = addresses.some((addr) => addr.index > 0);
+        if (setupType === SetupType.RESTORE && hdWalletDiscovered) {
+          analytics.sendEventToPostHog(PostHogAction.OnboardingRestoreHdWallet);
+        }
+        addressDiscoverySubscriber.unsubscribe();
+      });
+
       if (setupType === SetupType.FORGOT_PASSWORD) {
         deleteFromLocalStorage('isForgotPasswordFlow');
         goToMyWallet(wallet);

--- a/packages/common/src/analytics/types.ts
+++ b/packages/common/src/analytics/types.ts
@@ -23,6 +23,7 @@ export enum PostHogAction {
   OnboardingRestoreEnterPassphrase09NextClick = 'onboarding | restore wallet | enter passphrase #09 | next | click',
   OnboardingRestoreEnterPassphrase17NextClick = 'onboarding | restore wallet | enter passphrase #17 | next | click',
   OnboardingRestoreWalletNamePasswordNextClick = 'onboarding | restore wallet | wallet name & password | next | click',
+  OnboardingRestoreHdWallet = 'onboarding | restore wallet | hd wallet',
   // Create new wallet
   OnboardingCreateDoneGoToWallet = 'onboarding | new wallet | all done | go to my wallet | click',
   OnboardingCreateAnalyticsAgreeClick = 'onboarding | new wallet | analytics | agree | click',
@@ -159,6 +160,8 @@ export enum PostHogAction {
   SettingsAnalyticsAgreeClick = 'settings | analytics | agree | click',
   SettingsAnalyticsSkipClick = 'settings | analytics | skip | click',
   SettingsFaqsClick = 'settings | faqs | click',
+  SettingsWalletHdWalletSyncSyncClick = 'settings | wallet | hd wallet sync | sync | click',
+  SettingsWalletHdWalletSyncSyncNewAddresses = 'settings | wallet | hd wallet sync | sync | new addresses',
   // Recieve section
   ReceiveClick = 'receive | receive | click',
   ReceiveCopyAddressIconClick = 'receive | receive | copy address icon | click',


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-7417
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Track three new events:
1. user triggered manual hd wallet re-sync from settings (click on "Sync" button)
2. the manual re-sync triggered above resulted in the discovery of new (hd wallet) addresses 
3. when user in the onboarding flow recovers a wallet/connects hw wallet and a hd wallet is discovered (i.e. at least one address with index > 0)

Note that, as noted in the task description, we are looking for hd addresses, i.e. addresses with index > 0, not the addresses with staking index > 0 used for multidelegation

## Testing

Enable posthog in env and check that the events outlined above are fired. The easiest way to create an hd wallet and add new hd addresses I know of is to use https://preprod.adalite.io, log in with the Lace mnemonic there and send funds to any of the addresses shown in the "Receive" tab

Test Onboarding:
1. If onboarding non-hd wallet, no posthog event is logged
2. If onboarding hd wallet, the posthog event added in this PR is logged at the moment of the first load of the wallet

Test on-demand sync:
1. for non-hd wallet just the "click" event should be logged to posthog
2. for hd wallet no event should be logged if all addresses already discovered
3. for hd wallet, if a new address is used (e.g. with Adalite) and on-demand sync is triggered, an event should be logged to posthog

## Screenshots

Attach screenshots here if implementation involves some UI changes
