### PR TITLE
fix(staking): [LW-8912] fix delegations with stake key (de)registrations being omitted from activity

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/helpers/common-tx-transformer.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/helpers/common-tx-transformer.ts
@@ -70,7 +70,12 @@ const splitDelegationTx = (tx: TransformedActivity): TransformedTransactionActiv
     ];
   }
 
-  return [];
+  return [
+    {
+      ...tx,
+      type: 'delegation'
+    }
+  ];
 };
 
 const transformTransactionStatus = (status: Wallet.TransactionStatus): ActivityStatus => {


### PR DESCRIPTION
# Checklist

- [x] JIRA - 8912
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Turns out ticket LW-8912 actually reported two issues and in #696 we fixed only one of them (pending txs being wrongly at the bottom of the activity list). This PR fixes the other issue which got overlooked, namely that delegation transactions without any stake key (de)registrations were incorrectly transformed to empty events

## Testing

Make a delegation that just changes the pools, without changing their amount and check that the respective tx correctly appears in wallet activity

## Screenshots

Before
<img width="1191" alt="Screenshot 2023-11-08 at 14 16 38" src="https://github.com/input-output-hk/lace/assets/4980147/f4f3bcd9-feea-42f5-aac6-30dc92a6ced0">


After
<img width="849" alt="Screenshot 2023-11-08 at 14 12 58" src="https://github.com/input-output-hk/lace/assets/4980147/21728f69-024f-4e6c-ac3f-6349f3c59f3f">
