### PR TITLE
fix(staking): [LW-8689] change wording/name of pool migration banner

### DIFF
--- a/packages/staking/src/features/i18n/translations/en.ts
+++ b/packages/staking/src/features/i18n/translations/en.ts
@@ -110,9 +110,9 @@ export const en: Translations = {
   'overview.banners.pendingFirstDelegation.message':
     'You will see your staking portfolio here once the transaction has been validated',
   'overview.banners.pendingFirstDelegation.title': 'Your staking transaction has been submitted',
-  'overview.banners.pendingPoolMigration.message':
-    'You will continue to receive rewards from your former stake pool(s) for two epochs',
-  'overview.banners.pendingPoolMigration.title': 'You are migrating stake pool(s)',
+  'overview.banners.pendingPortfolioModification.message':
+    'In case of changing pools you will continue to receive rewards from your former stake pool(s) for two epochs',
+  'overview.banners.pendingPortfolioModification.title': 'You are modifying your staking portfolio',
   'overview.banners.portfolioDrifted.message':
     'Make sure to rebalance your staking ratios if you want to match your preferences',
   'overview.banners.portfolioDrifted.title': 'Your current delegation portfolio has shifted',

--- a/packages/staking/src/features/i18n/types.ts
+++ b/packages/staking/src/features/i18n/types.ts
@@ -192,7 +192,7 @@ type KeysStructure = {
         title: '';
         message: '';
       };
-      pendingPoolMigration: {
+      pendingPortfolioModification: {
         title: '';
         message: '';
       };

--- a/packages/staking/src/features/overview/StakingNotificationBanners/StakingNotificationBanners.tsx
+++ b/packages/staking/src/features/overview/StakingNotificationBanners/StakingNotificationBanners.tsx
@@ -40,13 +40,13 @@ export const StakingNotificationBanners = ({ popupView, notifications }: Staking
         description={t('overview.banners.pendingFirstDelegation.message')}
       />
     ),
-    pendingPoolMigration: (
+    pendingPortfolioModification: (
       <Banner
         popupView={popupView}
         withIcon
         customIcon={<InfoIcon className={styles.bannerInfoIcon} />}
-        message={t('overview.banners.pendingPoolMigration.title')}
-        description={t('overview.banners.pendingPoolMigration.message')}
+        message={t('overview.banners.pendingPortfolioModification.title')}
+        description={t('overview.banners.pendingPortfolioModification.message')}
       />
     ),
     poolRetiredOrSaturated: (

--- a/packages/staking/src/features/overview/StakingNotificationBanners/getCurrentStakingNotifications.ts
+++ b/packages/staking/src/features/overview/StakingNotificationBanners/getCurrentStakingNotifications.ts
@@ -15,7 +15,7 @@ export const getCurrentStakingNotifications = ({
   const pendingDelegationTransaction = hasPendingDelegationTransaction(walletActivities);
 
   if (pendingDelegationTransaction) {
-    return currentPortfolio.length === 0 ? ['pendingFirstDelegation'] : ['pendingPoolMigration'];
+    return currentPortfolio.length === 0 ? ['pendingFirstDelegation'] : ['pendingPortfolioModification'];
   }
 
   return [

--- a/packages/staking/src/features/overview/StakingNotificationBanners/types.ts
+++ b/packages/staking/src/features/overview/StakingNotificationBanners/types.ts
@@ -1,5 +1,5 @@
 export type StakingNotificationType =
   | 'pendingFirstDelegation'
-  | 'pendingPoolMigration'
+  | 'pendingPortfolioModification'
   | 'portfolioDrifted'
   | 'poolRetiredOrSaturated';

--- a/packages/staking/src/features/overview/types.ts
+++ b/packages/staking/src/features/overview/types.ts
@@ -1,1 +1,1 @@
-export type StakingNotificationType = 'pendingFirstDelegation' | 'pendingPoolMigration' | 'portfolioDrifted';
+export type StakingNotificationType = 'pendingFirstDelegation' | 'pendingPortfolioModification' | 'portfolioDrifted';


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-8689
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

This PR just changes the wording of the message but the main bug reported unfortunately remains, explanation below

When changing the delegation portfolio, the `distribution$` observable is apparently updates as soon as the delegation tx is submitted, not waiting for its confirmation (interestingly, only re-delegations seem to be impacted, not first delegations). This results in the bug reported in the ticket, i.e. that user sees the new portfolio even while the delegation tx is pending.

I made a follow-up ticket LW-9025 to fix the `distribution$` observable in the SDK

I heavily considered making a workaround in the frontend - basically "caching" the old distribution while a delegation transaction is pending but I concluded this can do more harm than good. First, it would "work" only for the window from which the tx was sent, and moreover, in case of switching the network to one with a pending delegation tx the distribution from the previous network would remain (as we don't re-initialize the store, AFAIK) which would be also wrong. Future changes in the frontend/sdk may further break this workaround as it would have to make assumptions on otherwise loosely coupled structures (wallet activities vs portfolio distribution)

## Testing

* Make a delegation and check that the update message is shown

## Screenshots

![Screenshot 2023-11-08 at 18 27 53](https://github.com/input-output-hk/lace/assets/4980147/b91ab203-98d8-42b5-aa09-2875bd1380b2)

