### PR TITLE
[LW-9000] Add confirmed transaction metric

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/ConfirmTransaction.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/ConfirmTransaction.tsx
@@ -25,6 +25,7 @@ import { getAssetsInformation, TokenInfo } from '@src/utils/get-assets-informati
 import * as HardwareLedger from '../../../../../../node_modules/@cardano-sdk/hardware-ledger/dist/cjs';
 import { useAnalyticsContext } from '@providers';
 import { TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
+import { txSubmitted$ } from '@providers/AnalyticsProvider/onChain';
 
 const DAPP_TOAST_DURATION = 50;
 
@@ -237,6 +238,12 @@ export const ConfirmTransaction = withAddressBookContext((): React.ReactElement 
   const onConfirm = () => {
     analytics.sendEventToPostHog(PostHogAction.SendTransactionSummaryConfirmClick, {
       [TX_CREATION_TYPE_KEY]: TxCreationType.External
+    });
+
+    txSubmitted$.next({
+      id: tx?.id.toString(),
+      date: new Date().toString(),
+      creationType: TxCreationType.External
     });
 
     isUsingHardwareWallet ? signWithHardwareWallet() : setNextView();

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/context.tsx
@@ -6,6 +6,13 @@ import { ExtensionViews } from './analyticsTracker/types';
 import shallow from 'zustand/shallow';
 import { POSTHOG_EXCLUDED_EVENTS } from '@providers/PostHogClientProvider/client';
 import { usePostHogClientContext } from '@providers/PostHogClientProvider';
+import {
+  createConfirmedTransactionsObservable,
+  getUnconfirmedTransactions,
+  saveUnconfirmedTransactions,
+  sendConfirmedTransactionAnalytics,
+  useOnChainEventAnalytics
+} from './onChain';
 
 interface AnalyticsProviderProps {
   children: React.ReactNode;
@@ -34,8 +41,12 @@ export const AnalyticsProvider = ({
   tracker,
   analyticsDisabled
 }: AnalyticsProviderProps): React.ReactElement => {
-  const { currentChain, view } = useWalletStore(
-    (state) => ({ currentChain: state?.currentChain, view: state.walletUI.appMode }),
+  const { currentChain, view, inMemoryWallet } = useWalletStore(
+    (state) => ({
+      currentChain: state?.currentChain,
+      view: state.walletUI.appMode,
+      inMemoryWallet: state.inMemoryWallet
+    }),
     shallow
   );
   const postHogClient = usePostHogClientContext();
@@ -67,6 +78,17 @@ export const AnalyticsProvider = ({
       window.removeEventListener('popstate', trackActivePageChange);
     };
   }, [analyticsTracker]);
+
+  useOnChainEventAnalytics({
+    observable$: createConfirmedTransactionsObservable(inMemoryWallet),
+    onChainEvent: (onChainTransactionIds) =>
+      sendConfirmedTransactionAnalytics({
+        onChainTransactionIds,
+        sendEventToPostHog: analyticsTracker?.sendEventToPostHog.bind(analyticsTracker),
+        getUnconfirmedTransactionsFn: getUnconfirmedTransactions,
+        saveUnconfirmedTransactionsFn: saveUnconfirmedTransactions
+      })
+  });
 
   return <AnalyticsContext.Provider value={analyticsTracker}>{children}</AnalyticsContext.Provider>;
 };

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/onChain.test.tsx
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/onChain.test.tsx
@@ -1,0 +1,213 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable no-magic-numbers */
+import { sendConfirmedTransactionAnalytics, useOnChainEventAnalytics } from './onChain';
+import { TxCreationType } from './analyticsTracker';
+import { renderHook } from '@testing-library/react-hooks';
+import { Subject } from 'rxjs';
+
+describe('sendConfirmedTransactionAnalytics', () => {
+  const sendEventToPostHog = jest.fn();
+  const getUnconfirmedTransactionsFn = jest.fn();
+  const saveUnconfirmedTransactionsFn = jest.fn();
+
+  beforeEach(() => {
+    sendEventToPostHog.mockClear();
+    getUnconfirmedTransactionsFn.mockClear();
+    saveUnconfirmedTransactionsFn.mockClear();
+  });
+
+  test('should take no action when there are no unconfirmed transactions', async () => {
+    const onChainTransactionIds = ['id1'];
+    getUnconfirmedTransactionsFn.mockReturnValue([]);
+
+    await sendConfirmedTransactionAnalytics({
+      onChainTransactionIds,
+      sendEventToPostHog,
+      getUnconfirmedTransactionsFn,
+      saveUnconfirmedTransactionsFn
+    });
+
+    expect(sendEventToPostHog).not.toHaveBeenCalled();
+    expect(getUnconfirmedTransactionsFn).toHaveBeenCalledTimes(1);
+    expect(saveUnconfirmedTransactionsFn).not.toHaveBeenCalled();
+  });
+
+  test('should take no action if there are no historical transactions and unconfirmed transactions are fresh', async () => {
+    getUnconfirmedTransactionsFn.mockReturnValue([
+      {
+        id: 'id',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      }
+    ]);
+
+    await sendConfirmedTransactionAnalytics({
+      onChainTransactionIds: [],
+      sendEventToPostHog,
+      getUnconfirmedTransactionsFn,
+      saveUnconfirmedTransactionsFn
+    });
+
+    expect(sendEventToPostHog).not.toHaveBeenCalled();
+    expect(getUnconfirmedTransactionsFn).toHaveBeenCalledTimes(1);
+    expect(saveUnconfirmedTransactionsFn).not.toHaveBeenCalled();
+  });
+
+  test('should clear old unconfirmed transactions and parse confirmed transactions', async () => {
+    const onChainTransactionIds = ['id1'];
+    getUnconfirmedTransactionsFn.mockReturnValue([
+      {
+        id: 'id1',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      },
+      {
+        id: 'id2',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      },
+      {
+        id: 'id3',
+        creationType: TxCreationType.Internal,
+        date: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toString()
+      }
+    ]);
+
+    await sendConfirmedTransactionAnalytics({
+      onChainTransactionIds,
+      sendEventToPostHog,
+      getUnconfirmedTransactionsFn,
+      saveUnconfirmedTransactionsFn
+    });
+
+    expect(sendEventToPostHog).toHaveBeenCalledTimes(1);
+    expect(getUnconfirmedTransactionsFn).toHaveBeenCalledTimes(1);
+    expect(saveUnconfirmedTransactionsFn).toHaveBeenCalledWith([
+      {
+        id: 'id2',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      }
+    ]);
+  });
+
+  test('should parse confirmed transactions and clear unconfirmed transactions', async () => {
+    const onChainTransactionIds = ['id1', 'id2'];
+    getUnconfirmedTransactionsFn.mockReturnValue([
+      {
+        id: 'id2',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      }
+    ]);
+
+    await sendConfirmedTransactionAnalytics({
+      onChainTransactionIds,
+      sendEventToPostHog,
+      getUnconfirmedTransactionsFn,
+      saveUnconfirmedTransactionsFn
+    });
+
+    expect(sendEventToPostHog).toHaveBeenCalledTimes(1);
+    expect(getUnconfirmedTransactionsFn).toHaveBeenCalledTimes(1);
+    expect(saveUnconfirmedTransactionsFn).toHaveBeenCalledWith([]);
+  });
+
+  test('should parse confirmed transactions and clear unconfirmed transactions', async () => {
+    const onChainTransactionIds = ['id1', 'id2'];
+    getUnconfirmedTransactionsFn.mockReturnValue([
+      {
+        id: 'id1',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      },
+      {
+        id: 'id2',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      }
+    ]);
+
+    await sendConfirmedTransactionAnalytics({
+      onChainTransactionIds,
+      sendEventToPostHog,
+      getUnconfirmedTransactionsFn,
+      saveUnconfirmedTransactionsFn
+    });
+
+    expect(sendEventToPostHog).toHaveBeenCalledTimes(2);
+    expect(getUnconfirmedTransactionsFn).toHaveBeenCalledTimes(1);
+    expect(saveUnconfirmedTransactionsFn).toHaveBeenCalledWith([]);
+  });
+
+  test('should parse confirmed transactions and clear unconfirmed transactions', async () => {
+    getUnconfirmedTransactionsFn.mockReturnValue([
+      {
+        id: 'id1',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      },
+      {
+        id: 'id2',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      }
+    ]);
+
+    await sendConfirmedTransactionAnalytics({
+      onChainTransactionIds: ['id1'],
+      sendEventToPostHog,
+      getUnconfirmedTransactionsFn,
+      saveUnconfirmedTransactionsFn
+    });
+
+    expect(sendEventToPostHog).toHaveBeenCalledTimes(1);
+    expect(getUnconfirmedTransactionsFn).toHaveBeenCalledTimes(1);
+    expect(saveUnconfirmedTransactionsFn).toHaveBeenCalledWith([
+      {
+        id: 'id2',
+        creationType: TxCreationType.Internal,
+        date: new Date().toString()
+      }
+    ]);
+  });
+});
+
+describe('useOnChainEventAnalytics', () => {
+  const mockRequestLock = jest.fn();
+  const mockOnChainEvent = jest.fn();
+  const mockUseOnChainEventAnalytics = {
+    observable$: new Subject<string[]>(),
+    requestLock: mockRequestLock,
+    onChainEvent: mockOnChainEvent
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should subscribe to the observable and call onChainEvent on each emission', () => {
+    mockRequestLock.mockImplementation((_, __, callback) => callback());
+
+    renderHook(() => useOnChainEventAnalytics(mockUseOnChainEventAnalytics));
+
+    mockUseOnChainEventAnalytics.observable$.next(['1']);
+
+    expect(mockRequestLock).toHaveBeenCalledTimes(1);
+    expect(mockOnChainEvent).toHaveBeenCalledTimes(1);
+    expect(mockOnChainEvent).toHaveBeenCalledWith(['1']);
+  });
+
+  test('should subscribe multiple times to the observable but call onChainEvent only once because of the lock', () => {
+    mockRequestLock.mockImplementationOnce((_, __, callback) => callback()).mockImplementation();
+
+    renderHook(() => useOnChainEventAnalytics(mockUseOnChainEventAnalytics));
+    renderHook(() => useOnChainEventAnalytics(mockUseOnChainEventAnalytics));
+
+    mockUseOnChainEventAnalytics.observable$.next(['1']);
+
+    expect(mockRequestLock).toHaveBeenCalledTimes(2);
+    expect(mockOnChainEvent).toHaveBeenCalledTimes(1);
+    expect(mockOnChainEvent).toHaveBeenCalledWith(['1']);
+  });
+});

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/onChain.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/onChain.ts
@@ -1,0 +1,139 @@
+/* eslint-disable no-magic-numbers, unicorn/no-array-reduce, @typescript-eslint/no-empty-function */
+import { useEffect } from 'react';
+import { PostHogAction, PostHogProperties, TX_CREATION_TYPE_KEY } from './analyticsTracker';
+import { getValueFromLocalStorage, saveValueInLocalStorage } from '@src/utils/local-storage';
+import { ILocalStorage, UnconfirmedTransaction, UnconfirmedTransactions } from '@src/types';
+import { EMPTY, Observable, Subject, filter, map, merge, take } from 'rxjs';
+import { ObservableWallet } from '@cardano-sdk/wallet';
+
+const ONE_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+const LOCK_NAME = 'unconfirmed_transactions';
+
+const isNotStaleTx = (tx: UnconfirmedTransaction) => new Date(tx.date) > new Date(Date.now() - ONE_WEEK);
+
+export const getUnconfirmedTransactions = (): UnconfirmedTransactions =>
+  getValueFromLocalStorage<ILocalStorage, 'unconfirmedTransactions'>('unconfirmedTransactions', []);
+
+export const saveUnconfirmedTransactions = (unconfirmedTransactions: UnconfirmedTransactions): void =>
+  saveValueInLocalStorage<ILocalStorage, 'unconfirmedTransactions'>({
+    key: 'unconfirmedTransactions',
+    value: unconfirmedTransactions
+  });
+
+const addToUnconfirmedTransactions = (unconfirmedTransaction: UnconfirmedTransaction): void => {
+  const unconfirmedTransactions = getUnconfirmedTransactions();
+  unconfirmedTransactions.push(unconfirmedTransaction);
+  saveUnconfirmedTransactions(unconfirmedTransactions);
+};
+
+export const txSubmitted$ = new Subject<UnconfirmedTransaction>();
+
+txSubmitted$.subscribe((unconfirmedTransaction) => {
+  addToUnconfirmedTransactions(unconfirmedTransaction);
+});
+
+const separateTransactions = (
+  unconfirmedTransactions: UnconfirmedTransactions,
+  onChainTransactionIds: string[]
+): { unconfirmedAndFreshTransactions: UnconfirmedTransactions; confirmedTransactions: UnconfirmedTransactions } => {
+  const confirmedTransactions: UnconfirmedTransactions = [];
+  const unconfirmedAndFreshTransactions: UnconfirmedTransactions = [];
+
+  for (const unconfirmedTransaction of unconfirmedTransactions) {
+    const isConfirmed = onChainTransactionIds.includes(unconfirmedTransaction.id);
+    const isFresh = isNotStaleTx(unconfirmedTransaction);
+    if (isConfirmed) {
+      confirmedTransactions.push(unconfirmedTransaction);
+    } else if (isFresh) {
+      unconfirmedAndFreshTransactions.push(unconfirmedTransaction);
+    }
+  }
+
+  return { confirmedTransactions, unconfirmedAndFreshTransactions };
+};
+
+type ConfirmedTransactionsObservable = Observable<string[]>;
+
+export const createConfirmedTransactionsObservable = (
+  inMemoryWallet?: ObservableWallet
+): ConfirmedTransactionsObservable => {
+  if (!inMemoryWallet?.transactions?.outgoing?.onChain$ || !inMemoryWallet?.transactions?.history$) {
+    return EMPTY;
+  }
+
+  const outgoing$ = inMemoryWallet.transactions.outgoing.onChain$.pipe(map((tx) => [tx.id.toString()]));
+
+  const history$ = inMemoryWallet.transactions.history$.pipe(
+    take(1),
+    map((txs) => txs.map((tx) => tx.id.toString()))
+  );
+
+  return merge(outgoing$, history$).pipe(filter((txs) => txs.length > 0));
+};
+
+interface SendConfirmedTransactionAnalytics {
+  onChainTransactionIds: string[];
+  getUnconfirmedTransactionsFn: () => UnconfirmedTransactions;
+  saveUnconfirmedTransactionsFn: (unconfirmedTransactions: UnconfirmedTransactions) => void;
+  sendEventToPostHog?: (action: PostHogAction, properties: PostHogProperties) => Promise<void>;
+}
+
+export const sendConfirmedTransactionAnalytics = async ({
+  onChainTransactionIds,
+  getUnconfirmedTransactionsFn,
+  saveUnconfirmedTransactionsFn,
+  sendEventToPostHog = () => Promise.resolve()
+}: SendConfirmedTransactionAnalytics): Promise<void> => {
+  try {
+    const unconfirmedTransactions = getUnconfirmedTransactionsFn();
+
+    if (unconfirmedTransactions.length === 0) {
+      return;
+    }
+
+    const { confirmedTransactions, unconfirmedAndFreshTransactions } = separateTransactions(
+      unconfirmedTransactions,
+      onChainTransactionIds
+    );
+
+    for (const confirmedTransaction of confirmedTransactions) {
+      await sendEventToPostHog(PostHogAction.SendTransactionConfirmed, {
+        [TX_CREATION_TYPE_KEY]: confirmedTransaction.creationType
+      });
+    }
+
+    if (unconfirmedTransactions.length === unconfirmedAndFreshTransactions.length) {
+      return;
+    }
+
+    saveUnconfirmedTransactionsFn(unconfirmedAndFreshTransactions);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+interface UseOnChainEventAnalytics {
+  observable$?: Observable<string[]>;
+  requestLock?: (name: string, options: LockOptions, callback: () => Promise<void>) => void;
+  onChainEvent: (tx: string[]) => Promise<void>;
+}
+
+export const useOnChainEventAnalytics = ({
+  observable$,
+  requestLock = navigator?.locks?.request.bind(navigator.locks) || (() => Promise.resolve()),
+  onChainEvent
+}: UseOnChainEventAnalytics): void => {
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const subscription = observable$.subscribe(async (onChainTransactions) => {
+      requestLock(LOCK_NAME, { signal: controller.signal }, () => onChainEvent(onChainTransactions));
+    });
+
+    return () => {
+      controller.abort();
+      subscription.unsubscribe();
+    };
+  }, [observable$, requestLock, onChainEvent]);
+};

--- a/apps/browser-extension-wallet/src/types/local-storage.ts
+++ b/apps/browser-extension-wallet/src/types/local-storage.ts
@@ -1,5 +1,5 @@
 import { Wallet } from '@lace/cardano';
-import { EnhancedAnalyticsOptInStatus } from '../providers/AnalyticsProvider/analyticsTracker/types';
+import { EnhancedAnalyticsOptInStatus, TxCreationType } from '../providers/AnalyticsProvider/analyticsTracker/types';
 
 export interface WalletStorage {
   name: string;
@@ -28,6 +28,14 @@ export interface LastStakingInfo {
   poolId?: string;
 }
 
+export interface UnconfirmedTransaction {
+  id: string;
+  creationType: TxCreationType;
+  date: string;
+}
+
+export type UnconfirmedTransactions = UnconfirmedTransaction[];
+
 export interface ILocalStorage {
   currency?: CurrencyInfo;
   appSettings?: AppSettings;
@@ -43,4 +51,5 @@ export interface ILocalStorage {
   isForgotPasswordFlow?: boolean;
   multidelegationFirstVisit?: boolean;
   multidelegationFirstVisitSincePortfolioPersistence?: boolean;
+  unconfirmedTransactions: UnconfirmedTransaction[];
 }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -43,6 +43,7 @@ import { useAddressBookContext, withAddressBookContext } from '@src/features/add
 import { AddressBookSchema } from '@lib/storage';
 import { getAddressToSave } from '@src/utils/validators';
 import { useAnalyticsContext } from '@providers';
+import { txSubmitted$ } from '@providers/AnalyticsProvider/onChain';
 
 const { SendTransaction: Events, AddressBook } = AnalyticsEventNames;
 
@@ -195,6 +196,11 @@ export const Footer = withAddressBookContext(
     const signAndSubmitTransaction = useCallback(async () => {
       const { tx } = await builtTxData.tx.sign();
       await inMemoryWallet.submitTx(tx);
+      txSubmitted$.next({
+        id: tx.id.toString(),
+        date: new Date().toString(),
+        creationType: TxCreationType.Internal
+      });
     }, [builtTxData, inMemoryWallet]);
 
     const handleVerifyPass = useCallback(async () => {

--- a/packages/common/src/analytics/types.ts
+++ b/packages/common/src/analytics/types.ts
@@ -90,6 +90,7 @@ export enum PostHogAction {
   SendTransactionDataReviewTransactionClick = 'send | transaction data | review transaction | click',
   SendTransactionSummaryConfirmClick = 'send | transaction summary | confirm | click',
   SendTransactionConfirmationConfirmClick = 'send | transaction confirmation | confirm | click',
+  SendTransactionConfirmed = 'send | transaction confirmed',
   SendAllDoneView = 'send | all done | view',
   SendAllDoneViewTransactionClick = 'send | all done | view transaction | click',
   SendAllDoneCloseClick = 'send | all done | close | click',


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-9000) 
- [x] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Added new analytics event "Transaction confirmed".

New local storage property `unconfirmedTransactions` added to store transactions that have been submitted and have not been confirmed yet. Once new `ObservableWallet.transactions.outgoing.onChain$` event is emitted the entry from local storage is removed. 

For the edge case where the user closes the application before the transaction is confirmed, `ObservableWallet.transactions.history$` is used on start up and matched against `unconfirmedTransactions`.

For the edge case where the user has more than one window opened (browser view, popup or dapp connector) the `Lock API` is used to allow only one event to be processed at the same time.

Lock API support: https://caniuse.com/mdn-api_lock

## Testing
Test submitting transaction from browser view, popup and dapp connector.
Test submitting transaction then close the browser before transaction is confirmed, open the application again and check that the event in posthog is displayed.
Test submitting transaction and having browser view and popup or dapp connector simultaneously then check that the event in posthog is displayed only once.
Test that unconfirmed transactions older than one week are removed from local storage.

## Screenshots

Attach screenshots here if implementation involves some UI changes
