### PR TITLE
feat(staking): maintenance 24 Nov 2023

### DIFF
--- a/packages/e2e-tests/src/features/EmptyStatesExtended.feature
+++ b/packages/e2e-tests/src/features/EmptyStatesExtended.feature
@@ -29,7 +29,6 @@ Feature: Empty states
 
   @LW-8447
   Scenario: Extended View - Staking empty state
-    When I disable showing Multidelegation beta banner
     And I navigate to Staking extended page
     Then I see empty state banner for Staking page in extended mode
     When I click "Copy" button on empty state banner

--- a/packages/e2e-tests/src/features/EmptyStatesPopup.feature
+++ b/packages/e2e-tests/src/features/EmptyStatesPopup.feature
@@ -28,7 +28,6 @@ Feature: Empty states
 
   @LW-8470
   Scenario: Popup View - Staking empty state
-    When I disable showing Multidelegation beta banner
     And I navigate to Staking popup page
     Then I see empty state banner for Staking page in popup mode
     When I click "Copy" button on empty state banner

--- a/packages/e2e-tests/src/features/FullExperiencePopup.feature
+++ b/packages/e2e-tests/src/features/FullExperiencePopup.feature
@@ -12,7 +12,6 @@ Feature: Full experience - popup view
 
   @LW-3446
   Scenario Outline: Popup View - <page> opened - "Expand" button click
-    Given I disable showing Multidelegation beta banner
     And I am on <page> popup page
     When I click on "Expand" button
     Then the <page> page is displayed on a new tab in extended view

--- a/packages/e2e-tests/src/features/MultiDelegationPageExtended.feature
+++ b/packages/e2e-tests/src/features/MultiDelegationPageExtended.feature
@@ -7,7 +7,6 @@ Feature: Staking Page - Extended View
   @LW-8931 @Testnet
   Scenario: Extended View - Start Staking component
     Given I save token: "Cardano" balance
-    And I disable showing Multidelegation beta banner
     When I navigate to Staking extended page
     Then I see Start Staking page in extended mode
 
@@ -23,14 +22,12 @@ Feature: Staking Page - Extended View
 
   @LW-8449 @Testnet @Mainnet
   Scenario: Extended View - Staking search control is displayed with appropriate content
-    Given I disable showing Multidelegation beta banner
     When I navigate to Staking extended page
     And I click Browse pools tab
     Then I see the stake pool search control with appropriate content
 
   @LW-8448 @Testnet
   Scenario Outline: Extended View - Stake pool search for "<stake_pool_search_term>" returns the expected number of results <number_of_results> with appropriate content
-    Given I disable showing Multidelegation beta banner
     When I navigate to Staking extended page
     And I click Browse pools tab
     And I input "<stake_pool_search_term>" into stake pool search bar
@@ -49,7 +46,6 @@ Feature: Staking Page - Extended View
 
   @LW-8448 @Mainnet
   Scenario Outline: Extended View - Stake pool search for "<stake_pool_search_term>" returns the expected number of results <number_of_results> with appropriate content
-    Given I disable showing Multidelegation beta banner
     When I navigate to Staking extended page
     And I click Browse pools tab
     And I input "<stake_pool_search_term>" into stake pool search bar
@@ -69,12 +65,10 @@ Feature: Staking Page - Extended View
   @LW-8466 @Testnet @Mainnet
   Scenario: Extended View - "About staking" widget
     Given I am on Staking extended page
-    And I close Multi-delegation beta modal
     Then I see "About staking" widget with all relevant items
 
   @LW-8465 @Testnet @Mainnet
   Scenario Outline: Extended View - "About staking" widget item click - <subtitle>
-    Given I disable showing Multidelegation beta banner
     And I am on Staking extended page
     When I click on a widget item with subtitle: "<subtitle>"
     Then I see a "<type>" article with title "<subtitle>"
@@ -87,13 +81,11 @@ Feature: Staking Page - Extended View
 
   @LW-8469 @Testnet @Mainnet
   Scenario: Extended View - Network info component is present with expected content
-    Given I disable showing Multidelegation beta banner
     When I navigate to Staking extended page
     Then I see the Network Info component with the expected content
 
   @LW-8499 @Testnet @Mainnet
   Scenario Outline: Extended View - Staking - Show tooltip for column names in browse pools section
-    Given I disable showing Multidelegation beta banner
     When I navigate to Staking extended page
     And I click Browse pools tab
     When I hover over "<column_name>" column name in stake pool list
@@ -105,7 +97,6 @@ Feature: Staking Page - Extended View
 
   @LW-8637 @Testnet @Mainnet
   Scenario: Extended View - Staking password screen details
-    Given I disable showing Multidelegation beta banner
     When I navigate to Staking extended page
     And I click Overview tab
     And I click Browse pools tab
@@ -118,7 +109,6 @@ Feature: Staking Page - Extended View
 
   @LW-8445 @Testnet
   Scenario: Extended View - Selecting stakepool from list opens drawer with appropriate details
-    Given I disable showing Multidelegation beta banner
     And I am on Staking extended page
     And I click Browse pools tab
     And I input "ADA Capital" into stake pool search bar
@@ -127,7 +117,6 @@ Feature: Staking Page - Extended View
 
   @LW-8438 @Testnet
   Scenario: Extended View - Staking - Stakepool details drawer - Close drawer
-    Given I disable showing Multidelegation beta banner
     And I am on Staking extended page
     And I click Browse pools tab
     And I input "ADA Capital" into stake pool search bar
@@ -137,7 +126,6 @@ Feature: Staking Page - Extended View
 
   @LW-8463 @Testnet @Mainnet
   Scenario: Extended View - Stake pool list item
-    Given I disable showing Multidelegation beta banner
     And I am on Staking extended page
     And I click Browse pools tab
     And I wait for stake pool list to be populated

--- a/packages/e2e-tests/src/features/MultiDelegationPagePopup.feature
+++ b/packages/e2e-tests/src/features/MultiDelegationPagePopup.feature
@@ -7,7 +7,6 @@ Feature: Staking Page - Popup View
   @LW-8933 @Testnet
   Scenario: Popup View - Start Staking component
     Given I save token: "Cardano" balance
-    And I disable showing Multidelegation beta banner
     When I navigate to Staking popup page
     Then I see Start Staking page in popup mode
 

--- a/packages/e2e-tests/src/features/MultidelegationDelegatedFundsExtended.feature
+++ b/packages/e2e-tests/src/features/MultidelegationDelegatedFundsExtended.feature
@@ -6,7 +6,6 @@ Feature: Staking Page - Extended View
 
   @LW-8436 @LW-8439 @LW-8440 @LW-8598
   Scenario Outline: Extended View - Staking - Close drawer
-    Given I disable showing Multidelegation beta banner
     When I navigate to Staking extended page
     And I click Browse pools tab
     And I pick "1" pools for delegation from browse pools view: "ADA Capital"
@@ -28,7 +27,6 @@ Feature: Staking Page - Extended View
 
   @LW-8450
   Scenario Outline: Extended View - Staking - Hover over currently staking element: <element>
-    Given I disable showing Multidelegation beta banner
     And I navigate to Staking extended page
     When I hover over <element> in currently staking component
     Then I see tooltip for element in currently staking component

--- a/packages/e2e-tests/src/features/MultidelegationDelegatedFundsPopup.feature
+++ b/packages/e2e-tests/src/features/MultidelegationDelegatedFundsPopup.feature
@@ -19,6 +19,7 @@ Feature: Staking Page - Popup View
   @LW-8338
   Scenario Outline: Popup View - Delegated pools cards are present
     Given I open wallet: "<walletName>" in: popup mode
+    And I disable showing Multidelegation beta banner
     And I disable showing Multidelegation persistence banner
     When I navigate to Staking popup page
     And I see Delegation pool cards are displayed for popup view

--- a/packages/e2e-tests/src/features/MultidelegationDelegatedFundsPopup.feature
+++ b/packages/e2e-tests/src/features/MultidelegationDelegatedFundsPopup.feature
@@ -7,20 +7,18 @@ Feature: Staking Page - Popup View
   @LW-8330
   Scenario Outline: Popup View - Delegation card displays correct data
     Given I open wallet: "<walletName>" in: popup mode
-    And I disable showing Multidelegation beta banner
     And I disable showing Multidelegation persistence banner
     When I navigate to Staking popup page
     Then I see Delegation title displayed for multidelegation
     And I see Delegation card displaying correct data
     Examples:
-    | walletName                     |
-    | MultidelegationDelegatedSingle |
-    | MultidelegationDelegatedMulti  |
+      | walletName                     |
+      | MultidelegationDelegatedSingle |
+      | MultidelegationDelegatedMulti  |
 
   @LW-8338
   Scenario Outline: Popup View - Delegated pools cards are present
     Given I open wallet: "<walletName>" in: popup mode
-    And I disable showing Multidelegation beta banner
     And I disable showing Multidelegation persistence banner
     When I navigate to Staking popup page
     And I see Delegation pool cards are displayed for popup view
@@ -31,9 +29,7 @@ Feature: Staking Page - Popup View
 
   @LW-8480
   Scenario Outline: Popup View - Staking - Hover over currently staking element: <element>
-    Given Lace is ready for test
-    And I disable showing Multidelegation beta banner
-    And I navigate to Staking popup page
+    Given I navigate to Staking popup page
     When I hover over <element> in currently staking component
     Then I see tooltip for element in currently staking component
     Examples:

--- a/packages/e2e-tests/src/features/NavigationMainExtended.feature
+++ b/packages/e2e-tests/src/features/NavigationMainExtended.feature
@@ -3,7 +3,6 @@ Feature: Main Navigation - Extended view
 
   Background:
     Given Lace is ready for test
-    And I disable showing Multidelegation beta banner
 
   @LW-2692 @Smoke
   Scenario: Extended view - Main navigation is displayed with all items
@@ -38,13 +37,13 @@ Feature: Main Navigation - Extended view
     When I click on the logo icon
     Then I see Tokens counter with total number of tokens displayed
     Examples:
-      | section      | validateIfSectionIsDisplayed                                         |
-      | Tokens       | I see Tokens counter with total number of tokens displayed           |
-      | NFTs         | I see NFTs counter with total number of NFTs displayed               |
-      | Transactions | Transactions section is displayed                                    |
-      | Staking      | I see Delegation title displayed for multidelegation                 |
-      | Settings     | I see settings page                                                  |
-      | Address Book | I see address book title                                             |
+      | section      | validateIfSectionIsDisplayed                               |
+      | Tokens       | I see Tokens counter with total number of tokens displayed |
+      | NFTs         | I see NFTs counter with total number of NFTs displayed     |
+      | Transactions | Transactions section is displayed                          |
+      | Staking      | I see Delegation title displayed for multidelegation       |
+      | Settings     | I see settings page                                        |
+      | Address Book | I see address book title                                   |
 
   @LW-6662
   Scenario Outline: Extended view - Main Navigation - Right side panel not displayed in <section> section

--- a/packages/e2e-tests/src/features/NavigationMainPopup.feature
+++ b/packages/e2e-tests/src/features/NavigationMainPopup.feature
@@ -32,7 +32,6 @@ Feature: Main Navigation - Popup View
   @LW-2610
   Scenario Outline: Extended view - Click Lace logo - <section>
     And Wallet is synced
-    And I disable showing Multidelegation beta banner
     And I navigate to <section> popup page
     And <validateIfSectionIsDisplayed>
     When I click on the logo icon

--- a/packages/e2e-tests/src/features/e2e/MultidelegationSwitchingPoolsExtendedE2E.feature
+++ b/packages/e2e-tests/src/features/e2e/MultidelegationSwitchingPoolsExtendedE2E.feature
@@ -3,7 +3,6 @@ Feature: Staking Page - Switching pools - Extended Browser View - E2E
 
   Background:
     Given Wallet is synced
-    And I disable showing Multidelegation beta banner
     And I navigate to Staking extended page
 
   @LW-7819 @Testnet @Pending

--- a/packages/e2e-tests/src/hooks/beforeTagHooks.ts
+++ b/packages/e2e-tests/src/hooks/beforeTagHooks.ts
@@ -30,22 +30,31 @@ Before(
   {
     tags: '@AddressBook-extended or @Transactions-Extended or @Tokens-extended or @Staking-Extended or @LockWallet-extended or @Top-Navigation-Extended or @NFTs-Extended or @NFT-Folders-Extended or @SendTx-Bundles-Extended or @SendTx-Simple-Extended or @MainNavigation-Extended or @Send-Transaction-Metadata-Extended or @Settings-Extended or @DAppConnector or @DAppConnector-Extended'
   },
-  async () => await extendedViewWalletInitialization()
+  async () => {
+    await extendedViewWalletInitialization();
+    await localStorageInitializer.disableShowingMultidelegationBetaBanner();
+  }
 );
 
 Before(
   {
     tags: '@Tokens-popup or @Transactions-Popup or @Staking-Popup or @LockWallet-popup or @Top-Navigation-Popup or @AddressBook-popup or @Common-Popup or @SendTx-Simple-Popup or @MainNavigation-Popup or @Settings-Popup or @NFTs-Popup or @NFT-Folders-Popup or @Send-Transaction-Metadata-Popup or @ForgotPassword or @DAppConnector-Popup'
   },
-  async () => await popupViewWalletInitialization()
+  async () => {
+    await popupViewWalletInitialization();
+    await localStorageInitializer.disableShowingMultidelegationBetaBanner();
+  }
 );
 
-Before(
-  { tags: '@EmptyStates-Extended' },
-  async () => await extendedViewWalletInitialization(TestWalletName.TAWalletNoFunds)
-);
+Before({ tags: '@EmptyStates-Extended' }, async () => {
+  await extendedViewWalletInitialization(TestWalletName.TAWalletNoFunds);
+  await localStorageInitializer.disableShowingMultidelegationBetaBanner();
+});
 
-Before({ tags: '@EmptyStates-Popup' }, async () => await popupViewWalletInitialization(TestWalletName.TAWalletNoFunds));
+Before({ tags: '@EmptyStates-Popup' }, async () => {
+  await popupViewWalletInitialization(TestWalletName.TAWalletNoFunds);
+  await localStorageInitializer.disableShowingMultidelegationBetaBanner();
+});
 
 Before(
   { tags: '@SendTx-MultipleSelection-Popup' },
@@ -104,15 +113,15 @@ Before(
   async () => await extendedViewWalletInitialization(TestWalletName.TAWalletDelegatedFunds)
 );
 
-Before(
-  { tags: '@Staking-NonDelegatedFunds-Extended' },
-  async () => await extendedViewWalletInitialization(TestWalletName.TAWalletNonDelegatedFunds)
-);
+Before({ tags: '@Staking-NonDelegatedFunds-Extended' }, async () => {
+  await extendedViewWalletInitialization(TestWalletName.TAWalletNonDelegatedFunds);
+  await localStorageInitializer.disableShowingMultidelegationBetaBanner();
+});
 
-Before(
-  { tags: '@Staking-NonDelegatedFunds-Popup' },
-  async () => await popupViewWalletInitialization(TestWalletName.TAWalletNonDelegatedFunds)
-);
+Before({ tags: '@Staking-NonDelegatedFunds-Popup' }, async () => {
+  await popupViewWalletInitialization(TestWalletName.TAWalletNonDelegatedFunds);
+  await localStorageInitializer.disableShowingMultidelegationBetaBanner();
+});
 
 Before(
   { tags: '@Staking-SwitchingPools-Extended-E2E' },
@@ -126,10 +135,10 @@ Before(
 
 Before({ tags: '@AdaHandle-popup' }, async () => await popupViewWalletInitialization(TestWalletName.WalletAdaHandle));
 
-Before(
-  { tags: '@Multidelegation-SwitchingPools-Extended-E2E' },
-  async () => await extendedViewWalletInitialization(TestWalletName.WalletMultidelegationSwitchPoolsE2E)
-);
+Before({ tags: '@Multidelegation-SwitchingPools-Extended-E2E' }, async () => {
+  await extendedViewWalletInitialization(TestWalletName.WalletMultidelegationSwitchPoolsE2E);
+  await localStorageInitializer.disableShowingMultidelegationBetaBanner();
+});
 
 Before(
   { tags: '@HdWallet-extended' },
@@ -141,12 +150,12 @@ Before(
   async () => await extendedViewWalletInitialization(TestWalletName.WalletSendNftHdWalletE2E)
 );
 
-Before(
-  { tags: '@Multidelegation-DelegatedFunds-Popup' },
-  async () => await popupViewWalletInitialization(TestWalletName.MultidelegationDelegatedSingle)
-);
+Before({ tags: '@Multidelegation-DelegatedFunds-Popup' }, async () => {
+  await popupViewWalletInitialization(TestWalletName.MultidelegationDelegatedSingle);
+  await localStorageInitializer.disableShowingMultidelegationBetaBanner();
+});
 
-Before(
-  { tags: '@Multidelegation-DelegatedFunds-Extended' },
-  async () => await extendedViewWalletInitialization(TestWalletName.MultidelegationDelegatedSingle)
-);
+Before({ tags: '@Multidelegation-DelegatedFunds-Extended' }, async () => {
+  await extendedViewWalletInitialization(TestWalletName.MultidelegationDelegatedSingle);
+  await localStorageInitializer.disableShowingMultidelegationBetaBanner();
+});


### PR DESCRIPTION
Extracting disabling of showing multidelegation beta baner to beforeTagHooks.
This simplifies test steps a bit.
This banner should be disabled in Lace soon so now removing this will require changing only beforeTagHooks file.

Regression test run results on this branch [here](https://dq4ajm5i5q7bz.cloudfront.net/all/linux/chrome/463/index.html#)