### PR TITLE
Revert "Chore/update for sdk conway era"

### DIFF
--- a/apps/browser-extension-wallet/src/api/mock.ts
+++ b/apps/browser-extension-wallet/src/api/mock.ts
@@ -126,9 +126,7 @@ const getDetailsForAll = (): PoolDetails => ({
     livePledge: BigInt('2000000000'),
     saturation: Percent(0.95),
     size: undefined,
-    stake: undefined,
-    lastRos: Percent(1),
-    ros: Percent(2)
+    stake: undefined
   },
   relays: undefined,
   rewardAccount: Wallet.Cardano.RewardAccount('stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj'),

--- a/apps/browser-extension-wallet/src/utils/mocks/test-helpers.tsx
+++ b/apps/browser-extension-wallet/src/utils/mocks/test-helpers.tsx
@@ -262,9 +262,7 @@ export const cardanoStakePoolMock: Wallet.StakePoolSearchResults = {
         saturation: Percent(0.0512),
         stake: undefined,
         size: undefined,
-        apy: Percent(0.013),
-        lastRos: Percent(1),
-        ros: Percent(2)
+        apy: Percent(0.013)
       },
       owners: [
         Wallet.Cardano.RewardAccount('stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj'),

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolsTable/StakePoolsTable.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolsTable/StakePoolsTable.tsx
@@ -26,7 +26,7 @@ type stakePoolsTableProps = {
 };
 
 const DEFAULT_SORT_OPTIONS: StakePoolSortOptions = {
-  field: 'ros',
+  field: 'apy',
   order: 'desc'
 };
 

--- a/packages/cardano/src/wallet/test/mocks/StakepoolSearchProviderStub.ts
+++ b/packages/cardano/src/wallet/test/mocks/StakepoolSearchProviderStub.ts
@@ -20,9 +20,7 @@ export const pools: Partial<Cardano.StakePool>[] = [
       livePledge: BigInt('2000000000'),
       saturation: Percent(0.211),
       size: undefined,
-      stake: undefined,
-      lastRos: Percent(1),
-      ros: Percent(2)
+      stake: undefined
     },
     margin: {
       numerator: 2.01,
@@ -60,9 +58,7 @@ export const pools: Partial<Cardano.StakePool>[] = [
       stake: {
         live: BigInt('201000000'),
         active: BigInt('201000000')
-      },
-      lastRos: Percent(1),
-      ros: Percent(2)
+      }
     },
     metadata: {
       name: 'THE AMSTERDAM NODE',
@@ -96,9 +92,7 @@ export const pools: Partial<Cardano.StakePool>[] = [
       stake: {
         live: BigInt('77000000'),
         active: BigInt('77000000')
-      },
-      lastRos: Percent(1),
-      ros: Percent(2)
+      }
     }
   },
   {
@@ -120,9 +114,7 @@ export const pools: Partial<Cardano.StakePool>[] = [
       stake: {
         live: BigInt('34000000'),
         active: BigInt('34000000')
-      },
-      lastRos: Percent(1),
-      ros: Percent(2)
+      }
     },
     metadata: {
       name: 'stakit.io Pool by TOBG',
@@ -152,9 +144,7 @@ export const pools: Partial<Cardano.StakePool>[] = [
       stake: {
         live: BigInt('53000000'),
         active: BigInt('53000000')
-      },
-      lastRos: Percent(1),
-      ros: Percent(2)
+      }
     },
     margin: {
       numerator: 0.79,
@@ -182,9 +172,7 @@ export const pools: Partial<Cardano.StakePool>[] = [
       stake: {
         live: BigInt('53000000'),
         active: BigInt('53000000')
-      },
-      lastRos: Percent(1),
-      ros: Percent(2)
+      }
     },
     metadata: {
       name: 'VEGASPool',
@@ -214,9 +202,7 @@ const detailsForAll: PoolDetails = {
     stake: {
       live: BigInt('34000000'),
       active: BigInt('34000000')
-    },
-    lastRos: Percent(1),
-    ros: Percent(2)
+    }
   },
   relays: undefined,
   rewardAccount: Cardano.RewardAccount('stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj'),

--- a/packages/cardano/src/wallet/test/mocks/mock.ts
+++ b/packages/cardano/src/wallet/test/mocks/mock.ts
@@ -32,9 +32,7 @@ export const stakePoolMock: Cardano.StakePool = {
     livePledge: BigInt('2000000000'),
     saturation: Percent(0.5),
     stake: undefined,
-    size: undefined,
-    lastRos: Percent(1),
-    ros: Percent(2)
+    size: undefined
   },
   owners: [
     Cardano.RewardAccount('stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj'),

--- a/packages/cardano/src/wallet/util/__tests__/stake-pool-transformer.test.ts
+++ b/packages/cardano/src/wallet/util/__tests__/stake-pool-transformer.test.ts
@@ -40,9 +40,7 @@ const cardanoStakePoolMock: StakePoolSearchResults = {
         saturation: Percent(0.0512),
         stake: undefined,
         size: undefined,
-        apy: Percent(0.013),
-        lastRos: Percent(1),
-        ros: Percent(2)
+        apy: Percent(0.013)
       },
       owners: [
         Cardano.RewardAccount('stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj'),

--- a/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsTable/StakePoolsTable.tsx
@@ -15,7 +15,7 @@ type StakePoolsTableProps = {
 };
 
 const DEFAULT_SORT_OPTIONS: StakePoolSortOptions = {
-  field: 'ros',
+  field: 'apy',
   order: 'desc',
 };
 


### PR DESCRIPTION
Reverts input-output-hk/lace#734

Reason: missing updates for the SDK packages results in broken build & tests.