### PR TITLE
fix: clears password after successful confirmation

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/DappTransactionSuccess.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/DappTransactionSuccess.tsx
@@ -6,10 +6,12 @@ import Success from '../../../assets/icons/success-staking.svg';
 import styles from './Layout.module.scss';
 import { useAnalyticsContext } from '@providers';
 import { TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
+import { useWalletManager } from '@hooks';
 
 export const DappTransactionSuccess = (): React.ReactElement => {
   const analytics = useAnalyticsContext();
   const { t } = useTranslation();
+  const { clearPassword } = useWalletManager();
 
   const onClose = async () => {
     await analytics?.sendEventToPostHog(PostHogAction.SendAllDoneCloseClick, {
@@ -17,6 +19,10 @@ export const DappTransactionSuccess = (): React.ReactElement => {
     });
     window.close();
   };
+
+  useEffect(() => {
+    clearPassword();
+  }, [clearPassword]);
 
   useEffect(() => {
     analytics?.sendEventToPostHog(PostHogAction.SendAllDoneView, {

--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -60,6 +60,7 @@ export interface UseWalletManager {
   saveHardwareWallet: (wallet: Wallet.CardanoWalletByChain, chainName?: Wallet.ChainName) => Promise<void>;
   deleteWallet: (isForgotPasswordFlow?: boolean) => Promise<void>;
   executeWithPassword: <T>(password: string, promiseFn: () => Promise<T>, cleanPassword?: boolean) => Promise<T>;
+  clearPassword: () => void;
   switchNetwork: (chainName: Wallet.ChainName) => Promise<void>;
   updateAddresses: (args: {
     addresses: Wallet.KeyManagement.GroupedAddress[];
@@ -143,6 +144,13 @@ export const useWalletManager = (): UseWalletManager => {
     },
     [backgroundService]
   );
+
+  /**
+   * Clears the wallet password
+   */
+  const clearPassword = useCallback(() => {
+    backgroundService.setWalletPassword();
+  }, [backgroundService]);
 
   /**
    * Deletes wallet info in storage, which should be stored encrypted with the wallet password as lock
@@ -481,6 +489,7 @@ export const useWalletManager = (): UseWalletManager => {
     saveHardwareWallet,
     deleteWallet,
     executeWithPassword,
+    clearPassword,
     switchNetwork,
     updateAddresses
   };


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-9273
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution
We clear the password field after a successful confirmation of a transaction. 

## Testing

- Try to send a transaction after a successful confirmation without having closed the confirmation screen in dapp connector

## Screenshots

