### PR TITLE
chore: remove lace-ui and lace-staking team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@ yarn.lock               @input-output-hk/lace-core
 /packages/common/       @input-output-hk/lace-core
 /packages/core/         @input-output-hk/lace-core
 /packages/e2e-tests/    @input-output-hk/lace-test-engineers
-/packages/staking/       @input-output-hk/lace-core
+/packages/staking/      @input-output-hk/lace-core
 /packages/ui/           @input-output-hk/lace-core
 
 # Apps

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,12 +2,12 @@
 *                       @input-output-hk/lace-tech-leads
 yarn.lock               @input-output-hk/lace-core
 # Packages Teams
-/packages/ui/           @input-output-hk/lace-ui
-/packages/staking/      @input-output-hk/lace-staking
 /packages/cardano/      @input-output-hk/lace-core
 /packages/common/       @input-output-hk/lace-core
 /packages/core/         @input-output-hk/lace-core
 /packages/e2e-tests/    @input-output-hk/lace-test-engineers
+/packages/staking/       @input-output-hk/lace-core
+/packages/ui/           @input-output-hk/lace-core
 
 # Apps
 /apps/                  @input-output-hk/lace-core


### PR DESCRIPTION
Re-assign `/packages/staking/` and `/packages/ui` to `@input-output-hk/lace-core` as we do not have dedicated squads / teams for those packages any longer.