### PR TITLE
fix(staking): currency tooltip duplication removed

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingInfo/StakingInfo.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingInfo/StakingInfo.tsx
@@ -118,7 +118,7 @@ export const StakingInfo = ({
               <Stats
                 text={t('browserView.staking.stakingInfo.totalRewards.title')}
                 value={
-                  <Tooltip title={`$ ${Wallet.util.convertAdaToFiat({ ada: totalRewards.toString(), fiat })}`}>
+                  <Tooltip title={Wallet.util.convertAdaToFiat({ ada: totalRewards.toString(), fiat })}>
                     <span>{totalRewards}</span>
                     <span className={styles.suffix}>{cardanoCoin.symbol}</span>
                   </Tooltip>
@@ -131,7 +131,7 @@ export const StakingInfo = ({
             <Stats
               text={t('browserView.staking.stakingInfo.lastReward.title')}
               value={
-                <Tooltip title={`$ ${Wallet.util.convertAdaToFiat({ ada: lastReward.toString(), fiat })}`}>
+                <Tooltip title={Wallet.util.convertAdaToFiat({ ada: lastReward.toString(), fiat })}>
                   <span>{lastReward}</span>
                   <span className={styles.suffix}>{cardanoCoin.symbol}</span>
                 </Tooltip>

--- a/packages/staking/src/features/overview/StakingInfoCard/StakingInfoCard.tsx
+++ b/packages/staking/src/features/overview/StakingInfoCard/StakingInfoCard.tsx
@@ -136,7 +136,7 @@ export const StakingInfoCard = ({
             <Stats
               text={t('overview.stakingInfoCard.totalStaked')}
               value={
-                <Tooltip title={fiat && `$ ${Wallet.util.convertAdaToFiat({ ada: totalStaked.toString(), fiat })}`}>
+                <Tooltip title={fiat && Wallet.util.convertAdaToFiat({ ada: totalStaked.toString(), fiat })}>
                   <span>{totalStaked}</span>
                   <span className={styles.suffix}>{cardanoCoinSymbol}</span>
                 </Tooltip>
@@ -163,7 +163,7 @@ export const StakingInfoCard = ({
           <Stats
             text={t('overview.stakingInfoCard.lastReward')}
             value={
-              <Tooltip title={fiat && `$ ${Wallet.util.convertAdaToFiat({ ada: lastReward.toString(), fiat })}`}>
+              <Tooltip title={fiat && Wallet.util.convertAdaToFiat({ ada: lastReward.toString(), fiat })}>
                 <span>{lastReward}</span>
                 <span className={styles.suffix}>{cardanoCoinSymbol}</span>
               </Tooltip>


### PR DESCRIPTION
# Checklist

- [ ] JIRA - [LW-9616](https://input-output.atlassian.net/browse/LW-9616)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Remove duplication of currency

## Testing

With HW and mnemonic, check total staked, total rewards, last reward tooltips for pool overview

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-9616]: https://input-output.atlassian.net/browse/LW-9616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ