### PR TITLE
fix(ui, extension): Multi-wallet and multi-account copywriting [LW-9292]

### DIFF
--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -356,7 +356,7 @@
     "sign.data.success.description": "Data signed",
     "sign.data.failure.description": "Signing failed. Please try again",
     "list.title": "Authorized DApps",
-    "list.subTitle": "This is the list of the dApps you have authorized to interact with your wallet. You can remove them at anytime.",
+    "list.subTitle": "You have authorized these DApps to interact with all your wallets & accounts. You can modify this at any time.",
     "list.subTitleEmpty": "This is where you'll find any DApps you authorize to interact with your wallet.",
     "list.removedSuccess": "DApp disconnected",
     "list.removedFailure": "DApp disconnection unsuccessful",

--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -789,7 +789,7 @@
         },
         "accounts": {
           "title": "Accounts",
-          "description": "Select your preferred account.",
+          "description": "Activate your preferred account.",
           "unlockLabel": "Enable"
         },
         "general": {

--- a/packages/ui/src/design-tokens/theme/dark-theme.css.ts
+++ b/packages/ui/src/design-tokens/theme/dark-theme.css.ts
@@ -175,8 +175,8 @@ const colors: Colors = {
     lightColorScheme.$secondary_data_pink,
 
   $dialog_container_bgColor: darkColorScheme.$primary_light_black,
-  $dialog_title_color: darkColorScheme.$primary_grey,
-  $dialog_description_color: darkColorScheme.$primary_grey,
+  $dialog_title_color: darkColorScheme.$primary_white,
+  $dialog_description_color: darkColorScheme.$primary_light_grey,
 
   $side_drawer_container_bgColor: darkColorScheme.$primary_light_black,
   $side_drawer_separator_bgColor: darkColorScheme.$primary_mid_grey,


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-9292
- [x] Screenshots added.

---

## Proposed solution

This PR fixes some copywriting in regards to multi-wallet and multi-account features. Also includes a fix of the ui dialog dark theme styles.

## Screenshots

Dialog dark theme styles have been corrected:
<img width="509" alt="Bildschirmfoto 2024-01-23 um 17 39 26" src="https://github.com/input-output-hk/lace/assets/172414/4d2280ad-7413-4dd4-890e-3580d030b155">

The description text for the accounts menu has been updated:
<img width="499" alt="Bildschirmfoto 2024-01-23 um 17 38 59" src="https://github.com/input-output-hk/lace/assets/172414/913cf0b7-6362-4415-a1f2-09ede84b8b6a">

The copy for authorized dapps has been updated:
<img width="359" alt="Bildschirmfoto 2024-01-23 um 17 40 15" src="https://github.com/input-output-hk/lace/assets/172414/b916ae4c-6157-4633-8091-6313f2cd5946">
