### PR TITLE
test(extension): e2e - set specific chrome/chromedriver version

### DIFF
--- a/.github/workflows/e2e-tests-linux.yml
+++ b/.github/workflows/e2e-tests-linux.yml
@@ -46,6 +46,11 @@ jobs:
         run: ./decrypt_secret.sh
         env:
           WALLET_1_PASSWORD: ${{ secrets.WALLET_PASSWORD_TESTNET }}
+      - name: Downgrade chrome
+        run: |
+          wget -q -O /tmp/chrome.deb http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_120.0.6099.216-1_amd64.deb \
+            && sudo apt install -y --allow-downgrades /tmp/chrome.deb \
+            && rm /tmp/chrome.deb
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:
@@ -53,10 +58,14 @@ jobs:
       - name: Start XVFB
         run: |
           Xvfb :99 &
+      - name: setup chromedriver
+        uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: '120.0.6099.216'
       - name: Start Chrome driver
         run: |
           if [ ${BROWSER} == "chrome" ]; then
-            ${CHROMEWEBDRIVER}/chromedriver -port=4444 &
+            chromedriver -port=4444 &
           else
             echo "Skipping start of ChromeDriver"
           fi


### PR DESCRIPTION
Latest chrome version 121 introduced a bug (?) when running multiple tests:

`WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance","source":"javascript","timestamp":1706755040366}
`
This PR downgrades Chrome and chromedriver to version 120. It is a temporary solution and should be removed when problem above is fixed in Chrome. 