### PR TITLE
[LW-9722] staking dashboard renders live stake

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolsTable/StakePoolsTable.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolsTable/StakePoolsTable.tsx
@@ -141,6 +141,7 @@ export const StakePoolsTable = ({ scrollableTargetId, onStake }: stakePoolsTable
           logo,
           stakePool: pool,
           ...stakePool,
+          liveStake: `${stakePool.liveStake.number}${stakePool.liveStake.unit}`,
           hexId: pool.hexId,
           onClick: (): void => {
             analytics.sendEventToMatomo({


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-9722
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution
Live stake column was not rendering on the staking dashboard. I convert the liveStake data.

## Testing
With a new account of HW or an empty account with funds, go to Staking dashboard, it should work. 

## Screenshots

