### PR TITLE
fix(staking): staking activity Tooltip crashes for pools without name [LW-9781]

### DIFF
--- a/packages/staking/src/features/activity/PastEpochsRewards/RewardsChartTooltip.tsx
+++ b/packages/staking/src/features/activity/PastEpochsRewards/RewardsChartTooltip.tsx
@@ -27,7 +27,7 @@ export const RewardsChartTooltip = ({
                 <Flex gap="$8" key={i} alignItems="center">
                   <PoolIndicator color={poolColorMapper(poolId)} />
                   <Flex flexDirection="column">
-                    <Text.Body.Small>{p.payload?.rewards?.[i]?.metadata.name}</Text.Body.Small>
+                    <Text.Body.Small>{p.payload?.rewards?.[i]?.metadata?.name || '-'}</Text.Body.Small>
                     <Text.Body.Small>
                       {t('activity.rewardsChart.rewards')}: {payload[i]?.value} ADA
                     </Text.Body.Small>


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-9781)

---

## Proposed solution
Added fallback value `-` for Stake Pools that are missing `metadata` or `metadata.name` field.

## Testing
Prerequisite: Mnemonics from @ljagiela.

1. Recover the wallet
2. Enter the Staking Activity tab
3. Move your cursor over the bar chart

Before the fix this would crash the app.

## Screenshots
After fix:
<img width="714" alt="image" src="https://github.com/input-output-hk/lace/assets/17825044/3a4c9bb1-2497-446a-a449-ee003955399b">