### PR TITLE
fix(cardano): handle undefined StakePools (caused by react-virtuoso data shape) [LW-9768]

### DIFF
--- a/packages/cardano/src/ui/components/StakePoolSearch/StakePoolSearch.tsx
+++ b/packages/cardano/src/ui/components/StakePoolSearch/StakePoolSearch.tsx
@@ -202,7 +202,7 @@ export const StakePoolSearch = ({
         getPopupContainer={() => document.querySelector('#stakepool-search-bar')}
         placement="bottomLeft"
       >
-        {pools?.map(({ id, name, ticker, logo, saturation, isStakingPool }) => {
+        {pools?.filter(Boolean).map(({ id, name, ticker, logo, saturation, isStakingPool }) => {
           let title = name;
           let subTitle: string | React.ReactElement = ticker || '-';
           if (!name) {


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-9768)

---

## Proposed solution
With the introduction of `react-virtuoso` that leverages infinite scroll / lazy loading for Stake Pools, the data shape of Stake Pools in our store has changed from an array containing only fetched Stake Pools to e.g. `[pool, pool, undefined, undefined]` to render the skeletons (placeholders) in place of pools that are about to be fetched.

This PR filters out the `undefined` values from that array and enables correct rendering of Stake Pools Search for HW (old flow).

Note: In future I suggest bringing back the old data shape and modifying the data only in the components that are using `react-virtuoso` to avoid coupling with particular lazy-loading / virtualisation libraries.

## Testing
Please open the Staking tab in the Popup view using HW.
