### PR TITLE
[LW-9813] Create posthog alias after new wallet is restored

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
@@ -47,5 +47,6 @@ export const userIdServiceProperties: RemoteApiProperties<UserIdServiceInterface
   getUserId: RemoteApiPropertyType.MethodReturningPromise,
   userId$: RemoteApiPropertyType.HotObservable,
   isNewSession: RemoteApiPropertyType.MethodReturningPromise,
-  resetToDefaultValues: RemoteApiPropertyType.MethodReturningPromise
+  resetToDefaultValues: RemoteApiPropertyType.MethodReturningPromise,
+  generateWalletBasedUserId: RemoteApiPropertyType.MethodReturningPromise
 };

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/userIdService.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/userIdService.ts
@@ -190,7 +190,7 @@ export class UserIdService implements UserIdServiceInterface {
     this.sessionTimeout = undefined;
   }
 
-  private generateWalletBasedUserId(extendedAccountPublicKey: Wallet.Crypto.Bip32PublicKeyHex) {
+  generateWalletBasedUserId(extendedAccountPublicKey: Wallet.Crypto.Bip32PublicKeyHex): string {
     console.debug('[ANALYTICS] Wallet based ID not found - generating new one');
     // by requirement, we want to hash the extended account public key twice
     const hash = hashExtendedAccountPublicKey(extendedAccountPublicKey);

--- a/apps/browser-extension-wallet/src/lib/scripts/types/userIdService.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/userIdService.ts
@@ -16,4 +16,5 @@ export interface UserIdService {
   extendLifespan(): Promise<void>;
   resetToDefaultValues(): Promise<void>;
   isNewSession(): Promise<boolean>;
+  generateWalletBasedUserId(extendedAccountPublicKey: Wallet.Crypto.Bip32PublicKeyHex): string;
 }

--- a/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.ts
+++ b/apps/browser-extension-wallet/src/providers/AnalyticsProvider/analyticsTracker/AnalyticsTracker.ts
@@ -81,6 +81,14 @@ export class AnalyticsTracker implements IAnalyticsTracker {
     await this.postHogClient?.sendAliasEvent();
   }
 
+  async sendMergeEvent(extendedAccountPublicKey: Wallet.Crypto.Bip32PublicKeyHex): Promise<void> {
+    const shouldOmitEvent = this.shouldOmitSendEventToPostHog();
+    if (shouldOmitEvent) return;
+    await this.userIdService?.extendLifespan();
+    await this.checkNewSessionStarted();
+    await this.postHogClient?.sendMergeEvent(extendedAccountPublicKey);
+  }
+
   async sendEventToPostHog(action: PostHogAction, properties: PostHogProperties = {}): Promise<void> {
     const isEventExcluded = this.isEventExcluded(action);
     const shouldOmitEvent = this.shouldOmitSendEventToPostHog();

--- a/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/PostHogClient.ts
@@ -152,6 +152,21 @@ export class PostHogClient {
     posthog.alias(alias, id);
   }
 
+  // $merge_dangerously is needed to ensure merge works on users with merge restrictions
+  // https://posthog.com/docs/product-analytics/identify
+  async sendMergeEvent(extendedAccountPublicKey: Wallet.Crypto.Bip32PublicKeyHex): Promise<void> {
+    const id = await this.userIdService.generateWalletBasedUserId(extendedAccountPublicKey);
+    if (!id) {
+      console.debug('[ANALYTICS] Wallet-based ID not found');
+      return;
+    }
+
+    console.debug('[ANALYTICS] Merging wallet-based ID into current user');
+    posthog.capture('$merge_dangerously', {
+      alias: id
+    });
+  }
+
   async sendEvent(action: PostHogAction, properties: PostHogProperties = {}): Promise<void> {
     const payload = {
       ...(await this.getEventMetadata()),

--- a/apps/browser-extension-wallet/src/utils/mocks/test-helpers.tsx
+++ b/apps/browser-extension-wallet/src/utils/mocks/test-helpers.tsx
@@ -633,7 +633,8 @@ export const userIdServiceMock: Record<keyof UserIdService, jest.Mock> = {
   getAliasProperties: jest.fn(),
   userId$: new Subject() as any,
   isNewSession: jest.fn(() => true),
-  resetToDefaultValues: jest.fn()
+  resetToDefaultValues: jest.fn(),
+  generateWalletBasedUserId: jest.fn()
 };
 
 export const postHogClientMocks: Record<keyof typeof PostHogClient.prototype, jest.Mock> = {
@@ -646,7 +647,8 @@ export const postHogClientMocks: Record<keyof typeof PostHogClient.prototype, je
   getExperimentVariant: jest.fn(),
   subscribeToDistinctIdUpdate: jest.fn(),
   shutdown: jest.fn(),
-  sendSessionStartEvent: jest.fn()
+  sendSessionStartEvent: jest.fn(),
+  sendMergeEvent: jest.fn()
 };
 
 export const mockAnalyticsTracker: Record<keyof typeof AnalyticsTracker.prototype, jest.Mock> = {
@@ -654,5 +656,6 @@ export const mockAnalyticsTracker: Record<keyof typeof AnalyticsTracker.prototyp
   setOptedInForEnhancedAnalytics: jest.fn(),
   sendPageNavigationEvent: jest.fn(),
   setChain: jest.fn(),
-  sendAliasEvent: jest.fn()
+  sendAliasEvent: jest.fn(),
+  sendMergeEvent: jest.fn()
 };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/create-wallet/CreateWallet.test.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/create-wallet/CreateWallet.test.tsx
@@ -11,10 +11,23 @@ import { StoreProvider } from '@src/stores';
 import { APP_MODE_BROWSER } from '@src/utils/constants';
 import { AppSettingsProvider, DatabaseProvider } from '@providers';
 import { UseWalletManager } from '@hooks/useWalletManager';
+import { AnalyticsTracker } from '@providers/AnalyticsProvider/analyticsTracker';
+
+jest.mock('@providers/AnalyticsProvider', () => ({
+  useAnalyticsContext: jest.fn<Pick<AnalyticsTracker, 'sendMergeEvent'>, []>().mockReturnValue({
+    sendMergeEvent: jest.fn().mockReturnValue('')
+  })
+}));
 
 jest.mock('@hooks/useWalletManager', () => ({
   useWalletManager: jest.fn().mockReturnValue({
-    createWallet: jest.fn().mockResolvedValue(void 0) as UseWalletManager['createWallet']
+    createWallet: jest.fn().mockResolvedValue({
+      source: {
+        account: {
+          extendedAccountPublicKey: ''
+        }
+      }
+    }) as UseWalletManager['createWallet']
   } as UseWalletManager)
 }));
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/create-wallet/steps/NewRecoveryPhrase.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/create-wallet/steps/NewRecoveryPhrase.tsx
@@ -7,6 +7,7 @@ import { WarningModal } from '@src/views/browser-view/components';
 import { useCreateWallet } from '../context';
 import { walletRoutePaths } from '@routes';
 import { useWalletManager } from '@hooks/useWalletManager';
+import { useAnalyticsContext } from '@providers/AnalyticsProvider';
 
 const noop = (): void => void 0;
 
@@ -22,6 +23,7 @@ export const NewRecoveryPhrase = (): JSX.Element => {
   const { t } = useTranslation();
   const { generatedMnemonic, data } = useCreateWallet();
   const { createWallet } = useWalletManager();
+  const analytics = useAnalyticsContext();
   const [state, setState] = useState<State>(() => ({
     isResetMnemonicModalOpen: false,
     resetMnemonicStage: 'writedown'
@@ -46,10 +48,11 @@ export const NewRecoveryPhrase = (): JSX.Element => {
   }, [data]);
 
   const saveWallet = useCallback(async () => {
-    await createWallet(data);
+    const { source } = await createWallet(data);
+    await analytics.sendMergeEvent(source.account.extendedAccountPublicKey);
     clearSecrets();
     history.push(walletRoutePaths.assets);
-  }, [data, createWallet, history, clearSecrets]);
+  }, [data, createWallet, history, clearSecrets, analytics]);
 
   return (
     <>

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/RestoreWallet.test.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/RestoreWallet.test.tsx
@@ -11,11 +11,24 @@ import { StoreProvider } from '@src/stores';
 import { APP_MODE_BROWSER } from '@src/utils/constants';
 import { AppSettingsProvider, DatabaseProvider } from '@providers';
 import { UseWalletManager } from '@hooks/useWalletManager';
+import { AnalyticsTracker } from '@providers/AnalyticsProvider/analyticsTracker';
 
 jest.mock('@hooks/useWalletManager', () => ({
   useWalletManager: jest.fn().mockReturnValue({
-    createWallet: jest.fn().mockResolvedValue(void 0) as UseWalletManager['createWallet']
+    createWallet: jest.fn().mockResolvedValue({
+      source: {
+        account: {
+          extendedAccountPublicKey: ''
+        }
+      }
+    }) as UseWalletManager['createWallet']
   } as UseWalletManager)
+}));
+
+jest.mock('@providers/AnalyticsProvider', () => ({
+  useAnalyticsContext: jest.fn<Pick<AnalyticsTracker, 'sendMergeEvent'>, []>().mockReturnValue({
+    sendMergeEvent: jest.fn().mockReturnValue('')
+  })
 }));
 
 const keepWalletSecureStep = async () => {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/steps/RestoreRecoveryPhrase.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/steps/RestoreRecoveryPhrase.tsx
@@ -45,22 +45,24 @@ export const RestoreRecoveryPhrase = (): JSX.Element => {
     passphraseError: t('core.walletSetupMnemonicStep.passphraseError')
   };
 
-  const onSubmitForm = useCallback(async () => {
-    event.preventDefault();
-
-    try {
-      const { source } = await createWallet(data);
-      await analytics.sendMergeEvent(source.account.extendedAccountPublicKey);
-    } catch (error) {
-      if (error instanceof WalletConflictError) {
-        toast.notify({ duration: TOAST_DEFAULT_DURATION, text: t('multiWallet.walletAlreadyExists') });
-      } else {
-        throw error;
+  const onSubmitForm = useCallback(
+    async (event: Readonly<React.MouseEvent<HTMLButtonElement>>) => {
+      event.preventDefault();
+      try {
+        const { source } = await createWallet(data);
+        await analytics.sendMergeEvent(source.account.extendedAccountPublicKey);
+      } catch (error) {
+        if (error instanceof WalletConflictError) {
+          toast.notify({ duration: TOAST_DEFAULT_DURATION, text: t('multiWallet.walletAlreadyExists') });
+        } else {
+          throw error;
+        }
       }
-    }
-    clearSecrets();
-    history.push(walletRoutePaths.assets);
-  }, [data, clearSecrets, createWallet, history, t, analytics]);
+      clearSecrets();
+      history.push(walletRoutePaths.assets);
+    },
+    [data, clearSecrets, createWallet, history, t, analytics]
+  );
 
   return (
     <WalletSetupMnemonicVerificationStep

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -202,8 +202,10 @@ export const HardwareWalletFlow = ({
       if (isAnalyticsAccepted) {
         await analytics.sendAliasEvent();
       }
-      // Workaround to enable staking with Ledger right after the onboarding LW-5564
-      window.location.reload();
+
+      if (typeof deviceConnection === 'object') {
+        deviceConnection.transport.close();
+      }
     }
   };
 

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupMnemonicVerificationStep.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupMnemonicVerificationStep.tsx
@@ -11,7 +11,7 @@ export interface WalletSetupMnemonicVerificationStepProps {
   mnemonic: string[];
   onChange: (words: string[]) => void;
   onCancel: () => void;
-  onSubmit: () => void;
+  onSubmit: (event: Readonly<React.MouseEvent<HTMLButtonElement>>) => void;
   onStepNext?: (currentStep: number) => void;
   isSubmitEnabled: boolean;
   mnemonicWordsInStep?: number;
@@ -43,14 +43,14 @@ export const WalletSetupMnemonicVerificationStep = ({
     onCancel();
   };
 
-  const handleNext = () => {
+  const handleNext = (event: Readonly<React.MouseEvent<HTMLButtonElement>>) => {
     if (onStepNext) onStepNext(mnemonicStep);
     if (mnemonicStep < mnemonicSteps - 1) {
       setMnemonicStep(mnemonicStep + 1);
       return;
     }
 
-    onSubmit();
+    onSubmit(event);
   };
 
   const getStepInfoText = () => {

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupStepLayout.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupStepLayout.tsx
@@ -23,7 +23,7 @@ export interface WalletSetupStepLayoutProps {
   description?: React.ReactNode;
   linkText?: React.ReactNode;
   stepInfoText?: string;
-  onNext?: () => void;
+  onNext?: (event: Readonly<React.MouseEvent<HTMLButtonElement>>) => void;
   onBack?: () => void;
   onSkip?: () => void;
   nextLabel?: string;


### PR DESCRIPTION
# Checklist

- [x] JIRA - https://input-output.atlassian.net/browse/LW-9813
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

- Merges posthog users with multiple wallets installed.
- Fixes issues with hardware wallet not aliasing posthog user id due to window reloading


## Testing

Posthog user aliasing
- Create/restore wallet A in one lace installation
- Create/restore wallet B in another lace installation
- Restore wallet B in wallet A installation with multi wallet feature
- Verify wallet B posthog user is merged with wallet A posthog user
- Repeat step with wallet B being a hardware wallet

Hardware wallet operations immediately after onboarding
- Import hardware wallet with user onboarding
- Immediately test hardware wallet operations (staking, sending, etc...)

## Screenshots

Attach screenshots here if implementation involves some UI changes
