### PR TITLE
fix(extension): reload app on ledger disconnect during onboarding

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -307,6 +307,8 @@ export const HardwareWalletFlow = ({
   const onRetry = () => {
     setIsErrorDialogVisible(false);
     goBackToConnect();
+    // TODO: Remove this workaround with full app reload when SDK allows to connect Hardware Wallet for the 2nd time.
+    onAppReload();
   };
 
   const handleStartOver = () => {

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupWalletNameStep.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupWalletNameStep.tsx
@@ -63,6 +63,7 @@ export const WalletSetupWalletNameStep = ({
         label={translations.walletName}
         value={walletName}
         onChange={handleNameChange}
+        autoFocus
       />
       {isDirty && walletName && !isNameValid && (
         <p className={styles.formError} data-testid="wallet-setup-register-name-error">


### PR DESCRIPTION
# Checklist

- [ ] JIRA - [LW-8720](https://input-output.atlassian.net/browse/LW-8720)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Use workaround with full app reload when SDK allows to connect Hardware Wallet for the 2nd time.

## Testing

Follow steps described in the ticket

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-8720]: https://input-output.atlassian.net/browse/LW-8720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ