### PR TITLE
feat(extension): add missing ros tooltip for stake pools table

### DIFF
--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -1092,7 +1092,7 @@
         },
         "ros": {
           "title": "ROS",
-          "tooltip": "Estimated 'Return On Stake' based on previous pool performance"
+          "tooltip": "An estimation of the potential rewards you will earn per epoch if you delegate the intended amount of stake. The system looks at the pool's parameters and historical performance data to calculate potential rewards, assuming that the pool reaches optimal saturation."
         },
         "saturation": {
           "title": "Saturation",

--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -1090,7 +1090,7 @@
           "title": "Cost",
           "tooltip": "The cost is not directly paid by the delegator; they are deducted from a pool's rewards, consisting of a fixed cost and a variable cost, which fund the pool's operational costs"
         },
-        "ros": {
+        "apy": {
           "title": "ROS",
           "tooltip": "An estimation of the potential rewards you will earn per epoch if you delegate the intended amount of stake. The system looks at the pool's parameters and historical performance data to calculate potential rewards, assuming that the pool reaches optimal saturation."
         },

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolsTable/StakePoolsTable.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolsTable/StakePoolsTable.tsx
@@ -63,7 +63,7 @@ export const StakePoolsTable = ({ scrollableTargetId }: stakePoolsTableProps): R
 
   const tableHeaderTranslations: TranslationsFor<MetricType> = {
     ticker: t('cardano.stakePoolTableBrowser.tableHeader.ticker.title'),
-    apy: t('cardano.stakePoolTableBrowser.tableHeader.ros.title'),
+    apy: t('cardano.stakePoolTableBrowser.tableHeader.apy.title'),
     cost: t('cardano.stakePoolTableBrowser.tableHeader.cost.title'),
     saturation: t('cardano.stakePoolTableBrowser.tableHeader.saturation.title'),
     margin: t('cardano.stakePoolTableBrowser.tableHeader.margin.title'),
@@ -73,7 +73,7 @@ export const StakePoolsTable = ({ scrollableTargetId }: stakePoolsTableProps): R
   };
   const tableHeaderTooltipsTranslations: TranslationsFor<MetricType> = {
     ticker: t('cardano.stakePoolTableBrowser.tableHeader.ticker.tooltip'),
-    apy: t('cardano.stakePoolTableBrowser.tableHeader.ros.tooltip'),
+    apy: t('cardano.stakePoolTableBrowser.tableHeader.apy.tooltip'),
     cost: t('cardano.stakePoolTableBrowser.tableHeader.cost.tooltip'),
     saturation: t('cardano.stakePoolTableBrowser.tableHeader.saturation.tooltip'),
     margin: t('cardano.stakePoolTableBrowser.tableHeader.margin.tooltip'),

--- a/packages/staking/src/features/BrowsePools/BrowsePools.tsx
+++ b/packages/staking/src/features/BrowsePools/BrowsePools.tsx
@@ -54,7 +54,7 @@ export const BrowsePools = () => {
   const fetchingPools = walletStoreStakePoolSearchResultsStatus === StateStatus.LOADING;
 
   const tableHeaderTranslations = {
-    apy: t('browsePools.stakePoolTableBrowser.tableHeader.ros.title'),
+    apy: t('browsePools.stakePoolTableBrowser.tableHeader.apy.title'),
     blocks: t('browsePools.stakePoolTableBrowser.tableHeader.blocks.title'),
     cost: t('browsePools.stakePoolTableBrowser.tableHeader.cost.title'),
     liveStake: t('browsePools.stakePoolTableBrowser.tableHeader.liveStake.title'),

--- a/packages/staking/src/features/DelegationCard/DelegationTooltip.tsx
+++ b/packages/staking/src/features/DelegationCard/DelegationTooltip.tsx
@@ -19,7 +19,7 @@ export const DelegationTooltip = ({
         description={
           <Box w="$148">
             <Flex justifyContent="space-between">
-              <Box>{t('browsePools.stakePoolTableBrowser.tableHeader.ros.title')}</Box>
+              <Box>{t('browsePools.stakePoolTableBrowser.tableHeader.apy.title')}</Box>
               <Box>{apy ? `${apy}%` : '-'}</Box>
             </Flex>
             <Flex justifyContent="space-between">

--- a/packages/staking/src/features/i18n/translations/en.ts
+++ b/packages/staking/src/features/i18n/translations/en.ts
@@ -35,6 +35,9 @@ export const en: Translations = {
   'browsePools.stakePoolTableBrowser.sortByTitle.saturation': 'Saturation',
   'browsePools.stakePoolTableBrowser.sortByTitle.ticker': 'Ticker name',
   'browsePools.stakePoolTableBrowser.stake': 'Stake',
+  'browsePools.stakePoolTableBrowser.tableHeader.apy.title': 'ROS',
+  'browsePools.stakePoolTableBrowser.tableHeader.apy.tooltip':
+    "An estimation of the potential rewards you will earn per epoch if you delegate the intended amount of stake. The system looks at the pool's parameters and historical performance data to calculate potential rewards, assuming that the pool reaches optimal saturation.",
   'browsePools.stakePoolTableBrowser.tableHeader.blocks.title': 'Blocks',
   'browsePools.stakePoolTableBrowser.tableHeader.blocks.tooltip': 'Total blocks created by the pool.',
   'browsePools.stakePoolTableBrowser.tableHeader.cost.title': 'Cost',
@@ -49,9 +52,6 @@ export const en: Translations = {
   'browsePools.stakePoolTableBrowser.tableHeader.pledge.title': 'Pledge',
   'browsePools.stakePoolTableBrowser.tableHeader.pledge.tooltip':
     'An amount of self‐bonded assets intended to remain staked to the pool for as long as it operates',
-  'browsePools.stakePoolTableBrowser.tableHeader.ros.title': 'ROS',
-  'browsePools.stakePoolTableBrowser.tableHeader.ros.tooltip':
-    "An estimation of the potential rewards you will earn per epoch if you delegate the intended amount of stake. The system looks at the pool's parameters and historical performance data to calculate potential rewards, assuming that the pool reaches optimal saturation.",
   'browsePools.stakePoolTableBrowser.tableHeader.saturation.title': 'Saturation',
   'browsePools.stakePoolTableBrowser.tableHeader.saturation.tooltip':
     'Once a pool reaches the point of saturation, it will offer diminishing rewards',

--- a/packages/staking/src/features/i18n/translations/en.ts
+++ b/packages/staking/src/features/i18n/translations/en.ts
@@ -51,7 +51,7 @@ export const en: Translations = {
     'An amount of self‐bonded assets intended to remain staked to the pool for as long as it operates',
   'browsePools.stakePoolTableBrowser.tableHeader.ros.title': 'ROS',
   'browsePools.stakePoolTableBrowser.tableHeader.ros.tooltip':
-    "Estimated 'Return On Stake' based on previous pool performance",
+    "An estimation of the potential rewards you will earn per epoch if you delegate the intended amount of stake. The system looks at the pool's parameters and historical performance data to calculate potential rewards, assuming that the pool reaches optimal saturation.",
   'browsePools.stakePoolTableBrowser.tableHeader.saturation.title': 'Saturation',
   'browsePools.stakePoolTableBrowser.tableHeader.saturation.tooltip':
     'Once a pool reaches the point of saturation, it will offer diminishing rewards',

--- a/packages/staking/src/features/i18n/types.ts
+++ b/packages/staking/src/features/i18n/types.ts
@@ -72,7 +72,7 @@ type KeysStructure = {
           title: '';
           tooltip: '';
         };
-        ros: {
+        apy: {
           title: '';
           tooltip: '';
         };


### PR DESCRIPTION
# Checklist

- [ ] JIRA - [LW-9827](https://input-output.atlassian.net/browse/LW-9827)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Update translations.

## Testing

enable USE_ROS_STAKING_COLUMN feature toggle, hove over ROS column to see the updated tooltip.

## Screenshots

<img width="1050" alt="Screenshot 2024-02-27 at 14 06 39" src="https://github.com/input-output-hk/lace/assets/7934077/2e6bc411-5c7d-4320-9466-05e3072e7f94">


[LW-9827]: https://input-output.atlassian.net/browse/LW-9827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ