### PR TITLE
feat(core, extension): add balance style to the dapp bridge [LW-9887]

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/DappTransactionContainer.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/DappTransactionContainer.tsx
@@ -177,7 +177,7 @@ export const DappTransactionContainer = withAddressBookContext(
             fromAddress={fromAddressTokens}
             errorMessage={errorMessage}
             toAddress={toAddressTokens}
-            collateral={Wallet.util.lovelacesToAdaString(txCollateral.toString())}
+            collateral={txCollateral}
           />
         ) : (
           <Skeleton loading />

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/DappTransactionContainer.test.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/DappTransactionContainer.test.tsx
@@ -331,7 +331,7 @@ describe('Testing DappTransactionContainer component', () => {
         fiatCurrencyPrice: 2,
         errorMessage,
         coinSymbol: 'ADA',
-        collateral: '1.00',
+        collateral: BigInt(1_000_000),
         txInspectionDetails
       },
       {}

--- a/packages/core/src/ui/components/ActivityDetail/TransactionFee.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/TransactionFee.tsx
@@ -11,6 +11,7 @@ export interface TransactionFeeProps {
   testId?: string;
   tooltipInfo?: string;
   displayFiat?: boolean;
+  highlightPositiveAmount?: boolean;
 }
 export const TransactionFee = ({
   fee,
@@ -20,7 +21,8 @@ export const TransactionFee = ({
   className,
   testId,
   tooltipInfo,
-  displayFiat
+  displayFiat,
+  highlightPositiveAmount
 }: TransactionFeeProps): React.ReactElement => {
   const { t } = useTranslate();
 
@@ -33,6 +35,7 @@ export const TransactionFee = ({
       data-testid={testId ?? 'fee'}
       className={className}
       displayFiat={displayFiat}
+      highlightPositiveAmount={highlightPositiveAmount}
     />
   );
 };

--- a/packages/core/src/ui/components/DappAddressSections/DappAddressSections.module.scss
+++ b/packages/core/src/ui/components/DappAddressSections/DappAddressSections.module.scss
@@ -1,18 +1,23 @@
 @import '../../styles/theme.scss';
 @import '../../../../../common/src/ui/styles/abstracts/_typography.scss';
 
+.label {
+  color: var(--text-color-primary, #ffffff) !important;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.value {
+  color: var(--text-color-primary, #ffffff) !important;
+  font-size: 14px;
+  font-weight: 500;
+}
+
 .address {
   display: flex;
   justify-content: space-between;
   padding: size_unit(2.5) 0;
 }
-
-.addressInfo {
-  color: var(--text-color-primary, #ffffff) !important;
-  font-size: medium;
-  font-weight: 500;
-}
-
 
 .summaryContent {
   padding-bottom: size_unit(2.5);

--- a/packages/core/src/ui/components/DappAddressSections/DappAddressSections.module.scss
+++ b/packages/core/src/ui/components/DappAddressSections/DappAddressSections.module.scss
@@ -23,3 +23,7 @@
   justify-content: space-between;
   align-items: end;
 }
+
+.positiveAmount {
+  color: var(--data-green, #2CB67D) !important;
+}

--- a/packages/core/src/ui/components/DappAddressSections/DappAddressSections.tsx
+++ b/packages/core/src/ui/components/DappAddressSections/DappAddressSections.tsx
@@ -9,6 +9,7 @@ import styles from './DappAddressSections.module.scss';
 import { useTranslate } from '@src/ui/hooks';
 
 import { TransactionAssets, SummaryExpander, DappTransactionSummary } from '@lace/ui';
+import classNames from 'classnames';
 
 interface GroupedAddressAssets {
   nfts: Array<AssetInfoWithAmount>;
@@ -113,20 +114,20 @@ export const DappAddressSections = ({
           {[...groupedFromAddresses.entries()].map(([address, addressData]) => (
             <>
               <div key={address} className={styles.address}>
-                <Text className={styles.addressInfo} data-testid="dapp-transaction-from-address-title">
+                <Text className={styles.label} data-testid="dapp-transaction-from-address-title">
                   {t('package.core.dappTransaction.address')}
                 </Text>
-                <Text className={styles.addressInfo} data-testid="dapp-transaction-from-address-address">
+                <Text className={styles.value} data-testid="dapp-transaction-from-address-address">
                   {addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}
                 </Text>
               </div>
               {(addressData.tokens.length > 0 || addressData.coins.length > 0) && (
                 <>
                   <div className={styles.tokenCount}>
-                    <Title level={5} data-testid="dapp-transaction-tokens-title">
+                    <Title level={5} className={styles.label} data-testid="dapp-transaction-tokens-title">
                       {t('package.core.dappTransaction.tokens')}
                     </Title>
-                    <Title level={5}>
+                    <Title level={5} className={styles.value}>
                       -{getTokenQuantity(addressData.tokens, addressData.coins)} {itemsCountCopy}
                     </Title>
                   </div>
@@ -164,20 +165,20 @@ export const DappAddressSections = ({
           {[...groupedToAddresses.entries()].map(([address, addressData]) => (
             <>
               <div key={address} className={styles.address}>
-                <Text className={styles.addressInfo} data-testid="dapp-transaction-to-address-title">
+                <Text className={styles.label} data-testid="dapp-transaction-to-address-title">
                   {t('package.core.dappTransaction.address')}
                 </Text>
-                <Text className={styles.addressInfo} data-testid="dapp-transaction-to-address">
+                <Text className={styles.value} data-testid="dapp-transaction-to-address">
                   {addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}
                 </Text>
               </div>
               {(addressData.tokens.length > 0 || addressData.coins.length > 0) && (
                 <>
                   <div className={styles.tokenCount}>
-                    <Title level={5} data-testid="dapp-transaction-tokens-title">
+                    <Title level={5} className={styles.label} data-testid="dapp-transaction-tokens-title">
                       {t('package.core.dappTransaction.tokens')}
                     </Title>
-                    <Title level={5} className={styles.positiveAmount}>
+                    <Title level={5} className={classNames(styles.value, styles.positiveAmount)}>
                       {getTokenQuantity(addressData.tokens, addressData.coins)} {itemsCountCopy}
                     </Title>
                   </div>
@@ -195,10 +196,10 @@ export const DappAddressSections = ({
               {addressData.nfts.length > 0 && (
                 <>
                   <div className={styles.tokenCount}>
-                    <Title level={5} data-testid="dapp-transaction-nfts-title">
+                    <Title level={5} className={styles.label} data-testid="dapp-transaction-nfts-title">
                       {t('package.core.dappTransaction.nfts')}
                     </Title>
-                    <Title level={5} className={styles.positiveAmount}>
+                    <Title level={5} className={classNames(styles.value, styles.positiveAmount)}>
                       {addressData.nfts.length} {itemsCountCopy}
                     </Title>
                   </div>

--- a/packages/core/src/ui/components/DappAddressSections/DappAddressSections.tsx
+++ b/packages/core/src/ui/components/DappAddressSections/DappAddressSections.tsx
@@ -177,15 +177,15 @@ export const DappAddressSections = ({
                     <Title level={5} data-testid="dapp-transaction-tokens-title">
                       {t('package.core.dappTransaction.tokens')}
                     </Title>
-                    <Title level={5}>
-                      +{getTokenQuantity(addressData.tokens, addressData.coins)} {itemsCountCopy}
+                    <Title level={5} className={styles.positiveAmount}>
+                      {getTokenQuantity(addressData.tokens, addressData.coins)} {itemsCountCopy}
                     </Title>
                   </div>
                   {addressData.coins.map((coin) => (
                     <DappTransactionSummary
                       key={`${address}${coin}`}
                       cardanoSymbol={coinSymbol}
-                      transactionAmount={`+${getStringFromLovelace(coin)}`}
+                      transactionAmount={getStringFromLovelace(coin)}
                     />
                   ))}
                   {displayGroupedTokens(addressData.tokens)}
@@ -198,8 +198,8 @@ export const DappAddressSections = ({
                     <Title level={5} data-testid="dapp-transaction-nfts-title">
                       {t('package.core.dappTransaction.nfts')}
                     </Title>
-                    <Title level={5}>
-                      +{addressData.nfts.length} {itemsCountCopy}
+                    <Title level={5} className={styles.positiveAmount}>
+                      {addressData.nfts.length} {itemsCountCopy}
                     </Title>
                   </div>
                   {displayGroupedNFTs(addressData.nfts)}

--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.module.scss
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.module.scss
@@ -22,3 +22,7 @@
 .transactionAssetsContainer {
   margin-bottom: size_unit(2.5);
 }
+
+.positiveAmount {
+  color: var(--data-green);
+}

--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.module.scss
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.module.scss
@@ -11,7 +11,6 @@
 }
 
 .feeContainer {
-  opacity: 50%;
   padding-bottom: size_unit(2.5);
 }
 

--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.stories.tsx
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.stories.tsx
@@ -23,6 +23,8 @@ const data: ComponentProps<typeof DappTransaction> = {
   fiatCurrencyCode: 'usd',
   fromAddress: new Map(),
   toAddress: new Map(),
+  // eslint-disable-next-line no-magic-numbers
+  collateral: 150_000 as unknown as bigint,
   txInspectionDetails: {
     assets: new Map(),
     // eslint-disable-next-line no-magic-numbers

--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
@@ -30,7 +30,7 @@ export interface DappTransactionProps {
   /** tokens send to being sent to or from the user */
   fromAddress: Map<Cardano.PaymentAddress, TokenTransferValue>;
   toAddress: Map<Cardano.PaymentAddress, TokenTransferValue>;
-  collateral?: string;
+  collateral?: bigint;
 }
 
 const isNFT = (asset: AssetInfoWithAmount) => asset.assetInfo.supply === BigInt(1);
@@ -150,9 +150,9 @@ export const DappTransaction = ({
           })}
         </div>
 
-        {collateral && (
+        {collateral !== undefined && collateral !== BigInt(0) && (
           <Collateral
-            collateral={collateral}
+            collateral={Wallet.util.lovelacesToAdaString(collateral.toString())}
             amountTransformer={amountTransformer({
               price: fiatCurrencyPrice,
               code: fiatCurrencyCode

--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
@@ -13,6 +13,7 @@ import { TransactionFee, Collateral } from '@ui/components/ActivityDetail';
 
 import { TransactionType, DappTransactionSummary, TransactionAssets } from '@lace/ui';
 import { DappAddressSections } from '../DappAddressSections/DappAddressSections';
+import cn from 'classnames';
 
 const amountTransformer = (fiat: { price: number; code: string }) => (ada: string) =>
   `${Wallet.util.convertAdaToFiat({ ada, fiat: fiat.price })} ${fiat.code}`;
@@ -165,15 +166,16 @@ export const DappTransaction = ({
 
         {returnedDeposit !== BigInt(0) && (
           <TransactionFee
-            fee={`+${Wallet.util.lovelacesToAdaString(returnedDeposit.toString())}`}
+            fee={Wallet.util.lovelacesToAdaString(returnedDeposit.toString())}
             testId="returned-deposit"
             label={t('package.core.dappTransaction.returnedDeposit')}
             coinSymbol={coinSymbol}
-            className={styles.depositContainer}
+            className={cn([styles.depositContainer, styles.positiveAmount])}
             displayFiat={false}
             amountTransformer={() =>
               `${Wallet.util.lovelacesToAdaString(returnedDeposit.toString())} ${fiatCurrencyCode}`
             }
+            highlightPositiveAmount
           />
         )}
 

--- a/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-assets.component.tsx
+++ b/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-assets.component.tsx
@@ -78,7 +78,7 @@ export const TransactionAssets = ({
             alignItems="center"
             className={styles.balanceDetailContainer}
           >
-            <Typography.Body.Normal
+            <Typography.Body.Small
               className={classNames(styles.label, {
                 [styles.positiveBalance]: !isNegativeBalance,
                 [styles.negativeBalance]: isNegativeBalance,
@@ -87,7 +87,7 @@ export const TransactionAssets = ({
               <span data-testid={testId}>
                 {balance} {tokenName}
               </span>
-            </Typography.Body.Normal>
+            </Typography.Body.Small>
           </Flex>
         </Cell>
       </Grid>

--- a/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-assets.component.tsx
+++ b/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-assets.component.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import classNames from 'classnames';
+
 import DarkFallBack from '../../assets/images/dark-mode-fallback.png';
 import LightFallBack from '../../assets/images/light-mode-fallback.png';
 import { ThemeColorScheme } from '../../design-tokens';
@@ -9,13 +11,13 @@ import { Grid, Cell } from '../grid';
 import { UserProfile } from '../profile-picture';
 import * as Typography from '../typography';
 
-import * as cx from './dapp-transaction-summary.css';
+import * as styles from './dapp-transaction-summary.css';
 
 import type { OmitClassName } from '../../types';
 
 type Props = OmitClassName<'div'> & {
   imageSrc: string | undefined;
-  balance?: string;
+  balance: string;
   tokenName?: string;
   coins?: string;
   testId?: string;
@@ -41,6 +43,7 @@ export const TransactionAssets = ({
   ...props
 }: Readonly<Props>): JSX.Element => {
   const { theme } = useThemeVariant();
+  const isNegativeBalance = balance.includes('-');
 
   const setThemeFallbackImagine =
     theme === ThemeColorScheme.Dark ? DarkFallBack : LightFallBack;
@@ -58,7 +61,7 @@ export const TransactionAssets = ({
   };
 
   return (
-    <div className={cx.assetsContainer}>
+    <div className={styles.assetsContainer}>
       <Grid {...props} columns="$fitContent">
         <Cell>
           <UserProfile
@@ -73,9 +76,14 @@ export const TransactionAssets = ({
           <Flex
             justifyContent="flex-end"
             alignItems="center"
-            className={cx.balanceDetailContainer}
+            className={styles.balanceDetailContainer}
           >
-            <Typography.Body.Normal className={cx.label}>
+            <Typography.Body.Normal
+              className={classNames(styles.label, {
+                [styles.positiveBalance]: !isNegativeBalance,
+                [styles.negativeBalance]: isNegativeBalance,
+              })}
+            >
               <span data-testid={testId}>
                 {balance} {tokenName}
               </span>

--- a/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-summary.component.tsx
+++ b/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-summary.component.tsx
@@ -2,12 +2,13 @@
 import React from 'react';
 
 import { ReactComponent as AdaComponent } from '@lace/icons/dist/AdaComponent';
+import classNames from 'classnames';
 
 import { Flex } from '../flex';
 import { Grid, Cell } from '../grid';
 import * as Typography from '../typography';
 
-import * as cx from './dapp-transaction-summary.css';
+import * as styles from './dapp-transaction-summary.css';
 
 import type { OmitClassName } from '../../types';
 
@@ -23,24 +24,27 @@ export const TransactionSummary = ({
   cardanoSymbol,
   ...props
 }: Readonly<Props>): JSX.Element => (
-  <div className={cx.txSummaryContainer}>
+  <div className={styles.txSummaryContainer}>
     {title !== undefined && (
       <Flex justifyContent="flex-start">
-        <Typography.Body.Large className={cx.txSummaryTitle}>
+        <Typography.Body.Large className={styles.txSummaryTitle}>
           {title}
         </Typography.Body.Large>
       </Flex>
     )}
-    <div className={cx.txAmountContainer}>
+    <div className={styles.txAmountContainer}>
       <Grid {...props} alignItems="$center" columns="$2">
         <Cell>
-          <AdaComponent className={cx.adaIcon} />
+          <AdaComponent className={styles.adaIcon} />
         </Cell>
         <Cell>
           <Flex justifyContent="flex-end">
             <Typography.Body.Normal
-              className={cx.label}
-              data-testid="dapp-transaction-amount-value"
+              className={classNames(styles.label, {
+                [styles.positiveBalance]: !transactionAmount.includes('-'),
+                [styles.negativeBalance]: transactionAmount.includes('-'),
+              })}
+              data-testId="dapp-transaction-amount-value"
             >
               {transactionAmount} {cardanoSymbol}
             </Typography.Body.Normal>

--- a/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-summary.component.tsx
+++ b/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-summary.component.tsx
@@ -39,7 +39,7 @@ export const TransactionSummary = ({
         </Cell>
         <Cell>
           <Flex justifyContent="flex-end">
-            <Typography.Body.Normal
+            <Typography.Body.Small
               className={classNames(styles.label, {
                 [styles.positiveBalance]: !transactionAmount.includes('-'),
                 [styles.negativeBalance]: transactionAmount.includes('-'),
@@ -47,7 +47,7 @@ export const TransactionSummary = ({
               data-testId="dapp-transaction-amount-value"
             >
               {transactionAmount} {cardanoSymbol}
-            </Typography.Body.Normal>
+            </Typography.Body.Small>
           </Flex>
         </Cell>
       </Grid>

--- a/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-summary.css.ts
+++ b/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-summary.css.ts
@@ -5,8 +5,15 @@ export const transactionTypeContainer = style({
 });
 
 export const label = sx({
-  color: '$dapp_transaction_summary_label',
   fontWeight: '$semibold',
+});
+
+export const positiveBalance = sx({
+  color: '$dapp_transaction_summary_positive_balance_label_color',
+});
+
+export const negativeBalance = sx({
+  color: '$dapp_transaction_summary_label',
 });
 
 export const txSummaryTitle = style([

--- a/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-summary.stories.tsx
+++ b/packages/ui/src/design-system/dapp-transaction-summary/dapp-transaction-summary.stories.tsx
@@ -48,7 +48,7 @@ const items = [
   },
   {
     imageSrc: token2,
-    balance: '-1000.00',
+    balance: '1000.00',
     tokenName: 'Lapisluzzz',
     recipient: '',
   },

--- a/packages/ui/src/design-system/transaction-summary/transaction-summary-amount.component.tsx
+++ b/packages/ui/src/design-system/transaction-summary/transaction-summary-amount.component.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import { ReactComponent as InfoIcon } from '@lace/icons/dist/InfoComponent';
+import classNames from 'classnames';
 
 import { Box } from '../box';
 import { Flex } from '../flex';
 import { Grid, Cell } from '../grid';
 import { Tooltip } from '../tooltip';
 import * as Typography from '../typography';
-import classNames from 'classnames';
 
 import * as cx from './transaction-summary.css';
 

--- a/packages/ui/src/design-system/transaction-summary/transaction-summary-amount.component.tsx
+++ b/packages/ui/src/design-system/transaction-summary/transaction-summary-amount.component.tsx
@@ -7,6 +7,7 @@ import { Flex } from '../flex';
 import { Grid, Cell } from '../grid';
 import { Tooltip } from '../tooltip';
 import * as Typography from '../typography';
+import classNames from 'classnames';
 
 import * as cx from './transaction-summary.css';
 
@@ -20,6 +21,7 @@ type Props = OmitClassName<'div'> & {
   'data-testid'?: string;
   className?: string;
   displayFiat?: boolean;
+  highlightPositiveAmount?: boolean;
 };
 
 const makeTestId = (namespace = '', path = ''): string | undefined => {
@@ -33,10 +35,12 @@ export const Amount = ({
   tooltip,
   className,
   displayFiat = true,
+  highlightPositiveAmount,
   ...props
 }: Readonly<Props>): JSX.Element => {
   const testId = props['data-testid'];
-
+  const shouldHighlightPositiveAmount =
+    highlightPositiveAmount === true && !amount.includes('-');
   return (
     <div className={className}>
       <Grid {...props} data-testid={makeTestId(testId, 'root')} columns="$2">
@@ -64,19 +68,22 @@ export const Amount = ({
         </Cell>
         <Cell>
           <Flex flexDirection="column" alignItems="flex-end" h="$fill">
-            <Typography.Body.Normal
-              className={cx.text}
+            <Typography.Body.Small
+              className={classNames(cx.text, {
+                [cx.normalAmount]: !shouldHighlightPositiveAmount,
+                [cx.highlightedAmount]: shouldHighlightPositiveAmount,
+              })}
               data-testid={makeTestId(testId, 'amount')}
             >
               {amount}
-            </Typography.Body.Normal>
+            </Typography.Body.Small>
             {displayFiat && (
-              <Typography.Body.Normal
+              <Typography.Body.Small
                 className={cx.secondaryText}
                 data-testid={makeTestId(testId, 'fiat')}
               >
                 {fiatPrice}
-              </Typography.Body.Normal>
+              </Typography.Body.Small>
             )}
           </Flex>
         </Cell>

--- a/packages/ui/src/design-system/transaction-summary/transaction-summary.css.ts
+++ b/packages/ui/src/design-system/transaction-summary/transaction-summary.css.ts
@@ -2,12 +2,13 @@ import { sx, style } from '../../design-tokens';
 
 export const label = sx({
   color: '$transaction_summary_label_color',
-  fontWeight: '$semibold',
+  fontWeight: '$bold',
 });
 
 export const text = style([
   sx({
-    fontWeight: '$medium',
+    color: '$transaction_summary_label_color',
+    fontWeight: '$semibold',
   }),
   {
     wordBreak: 'break-all',
@@ -17,7 +18,7 @@ export const text = style([
 export const secondaryText = style([
   sx({
     color: '$transaction_summary_secondary_label_color',
-    fontWeight: '$medium',
+    fontWeight: '$semibold',
   }),
   {
     wordBreak: 'break-all',

--- a/packages/ui/src/design-system/transaction-summary/transaction-summary.css.ts
+++ b/packages/ui/src/design-system/transaction-summary/transaction-summary.css.ts
@@ -7,7 +7,6 @@ export const label = sx({
 
 export const text = style([
   sx({
-    color: '$transaction_summary_label_color',
     fontWeight: '$medium',
   }),
   {
@@ -37,5 +36,17 @@ export const tooltip = style([
 export const tooltipText = style([
   sx({
     display: 'flex',
+  }),
+]);
+
+export const normalAmount = style([
+  sx({
+    color: '$transaction_summary_amount_color',
+  }),
+]);
+
+export const highlightedAmount = style([
+  sx({
+    color: '$transaction_summary_highlighted_amount_color',
   }),
 ]);

--- a/packages/ui/src/design-system/transaction-summary/transaction-summary.stories.tsx
+++ b/packages/ui/src/design-system/transaction-summary/transaction-summary.stories.tsx
@@ -56,15 +56,20 @@ const Example = (): JSX.Element => (
               <Amount amount="102.00 ADA" fiatPrice="84.45 USD" />
             </Cell>
             <Cell>
-              <Amount amount="102.00 ADA" fiatPrice="84.45 USD" />
-            </Cell>
-            <Cell>
               <Amount
                 label="With Tooltip"
                 tooltip="This is a sample tooltip text"
                 amount="102.00 ADA"
                 fiatPrice="84.45 USD"
                 data-testid="sample"
+              />
+            </Cell>
+            <Cell>
+              <Amount
+                label="Received"
+                amount="102.00 ADA"
+                fiatPrice="84.45 USD"
+                highlightPositiveAmount
               />
             </Cell>
           </Grid>

--- a/packages/ui/src/design-tokens/colors.data.ts
+++ b/packages/ui/src/design-tokens/colors.data.ts
@@ -161,7 +161,10 @@ export const colors = {
   $summary_expander_trigger_label_color_pressed: '',
 
   $transaction_summary_label_color: '',
+  $transaction_summary_amount_color: '',
+  $transaction_summary_highlighted_amount_color: '',
   $transaction_summary_secondary_label_color: '',
+  $dapp_transaction_summary_positive_balance_label_color: '',
 
   $dapp_transaction_summary_type_label_color: '',
   $dapp_transaction_summary_label: '',

--- a/packages/ui/src/design-tokens/theme/dark-theme.css.ts
+++ b/packages/ui/src/design-tokens/theme/dark-theme.css.ts
@@ -232,8 +232,13 @@ const colors: Colors = {
     darkColorScheme.$primary_mid_grey,
 
   $transaction_summary_label_color: darkColorScheme.$primary_white,
+  $transaction_summary_amount_color: darkColorScheme.$primary_white,
+  $transaction_summary_highlighted_amount_color:
+    darkColorScheme.$secondary_data_green,
   $transaction_summary_secondary_label_color:
     darkColorScheme.$primary_light_grey,
+  $dapp_transaction_summary_positive_balance_label_color:
+    darkColorScheme.$secondary_data_green,
 
   $dapp_transaction_summary_type_label_color:
     darkColorScheme.$primary_accent_purple,

--- a/packages/ui/src/design-tokens/theme/light-theme.css.ts
+++ b/packages/ui/src/design-tokens/theme/light-theme.css.ts
@@ -252,8 +252,13 @@ const colors: Colors = {
     lightColorScheme.$primary_light_grey_plus,
 
   $transaction_summary_label_color: lightColorScheme.$primary_black,
+  $transaction_summary_amount_color: lightColorScheme.$primary_black,
+  $transaction_summary_highlighted_amount_color:
+    lightColorScheme.$secondary_data_green,
   $transaction_summary_secondary_label_color:
     lightColorScheme.$primary_dark_grey,
+  $dapp_transaction_summary_positive_balance_label_color:
+    lightColorScheme.$secondary_data_green,
 
   $dapp_transaction_summary_type_label_color:
     lightColorScheme.$primary_accent_purple,


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-9887
- [x] Screenshots added.

---

## Proposed solution

There has been a small style change in the wallet activity to differentiate operations that are negative or positive so users don’t have any doubt about the balance change in their wallet. This task is about bringing the same styling to the dapp bridge.

## Testing

Try various DApp transactions and check that:
- All positive amounts are rendered in green (without a + sign) - except for collateral which is always displayed in default style
- Items that are not present in the Tx, or with value 0, should not be displayed (collateral, deposit)
- font sizes are unified for all tx summary amounts

## Screenshots

![Bildschirmfoto 2024-03-20 um 12 42 26](https://github.com/input-output-hk/lace/assets/172414/05f5dddf-1d5c-4250-a54d-b0c5ee2dec68)

