### PR TITLE
feat: move the register screen after the mnemonic screen for create and restore flow

### DIFF
--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -102,7 +102,8 @@
       "noMatchPassword": "Oops! The passwords don't match.",
       "enterWallet": "Enter wallet",
       "secondLevelPasswordStrengthFeedback": "Getting there! Add some symbols and numbers to make it stronger.",
-      "firstLevelPasswordStrengthFeedback": "Weak password. Add some numbers and characters to make it stronger."
+      "firstLevelPasswordStrengthFeedback": "Weak password. Add some numbers and characters to make it stronger.",
+      "next": "Next"
     },
     "dappTransaction": {
       "asset": "Asset",

--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -1615,7 +1615,6 @@
       "writePassphraseSubtitle1": "Consider your recovery phrase as the master key to your wallet.",
       "writePassphraseSubtitle2": "Watch video.",
       "passphraseError": "Make sure the words of your recovery phrase are in the right order and spelled correctly.",
-      "enterWallet": "Enter wallet",
       "copyToClipboard": "Copy to clipboard",
       "pasteFromClipboard": "Paste from clipboard"
     },

--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -100,6 +100,7 @@
       "confirmPasswordInputLabel": "Confirm password",
       "nameRequiredMessage": "Wallet name is required",
       "noMatchPassword": "Oops! The passwords don't match.",
+      "enterWallet": "Enter wallet",
       "secondLevelPasswordStrengthFeedback": "Getting there! Add some symbols and numbers to make it stronger.",
       "firstLevelPasswordStrengthFeedback": "Weak password. Add some numbers and characters to make it stronger."
     },

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/create-wallet/steps/Setup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/create-wallet/steps/Setup.tsx
@@ -19,7 +19,7 @@ export const Setup = (): JSX.Element => {
     confirmPasswordInputLabel: t('package.core.walletNameAndPasswordSetupStep.confirmPasswordInputLabel'),
     nameRequiredMessage: t('package.core.walletNameAndPasswordSetupStep.nameRequiredMessage'),
     noMatchPassword: t('package.core.walletNameAndPasswordSetupStep.noMatchPassword'),
-    enterWallet: t('package.core.walletNameAndPasswordSetupStep.enterWallet'),
+    confirmButton: t('package.core.walletNameAndPasswordSetupStep.next'),
     secondLevelPasswordStrengthFeedback: t(
       'package.core.walletNameAndPasswordSetupStep.secondLevelPasswordStrengthFeedback'
     ),

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/create-wallet/steps/Setup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/create-wallet/steps/Setup.tsx
@@ -3,10 +3,30 @@ import { walletRoutePaths } from '@routes';
 import React from 'react';
 import { useHistory } from 'react-router';
 import { useCreateWallet } from '../context';
+import { useTranslation } from 'react-i18next';
 
 export const Setup = (): JSX.Element => {
   const history = useHistory();
   const { setName, setPassword, onChange, data } = useCreateWallet();
+  const { t } = useTranslation();
+
+  const translations = {
+    title: t('package.core.walletNameAndPasswordSetupStep.title'),
+    description: t('package.core.walletNameAndPasswordSetupStep.description'),
+    nameInputLabel: t('package.core.walletNameAndPasswordSetupStep.nameInputLabel'),
+    nameMaxLength: t('package.core.walletNameAndPasswordSetupStep.nameMaxLength'),
+    passwordInputLabel: t('package.core.walletNameAndPasswordSetupStep.passwordInputLabel'),
+    confirmPasswordInputLabel: t('package.core.walletNameAndPasswordSetupStep.confirmPasswordInputLabel'),
+    nameRequiredMessage: t('package.core.walletNameAndPasswordSetupStep.nameRequiredMessage'),
+    noMatchPassword: t('package.core.walletNameAndPasswordSetupStep.noMatchPassword'),
+    enterWallet: t('package.core.walletNameAndPasswordSetupStep.enterWallet'),
+    secondLevelPasswordStrengthFeedback: t(
+      'package.core.walletNameAndPasswordSetupStep.secondLevelPasswordStrengthFeedback'
+    ),
+    firstLevelPasswordStrengthFeedback: t(
+      'package.core.walletNameAndPasswordSetupStep.firstLevelPasswordStrengthFeedback'
+    )
+  };
 
   return (
     <WalletSetupNamePasswordStep
@@ -18,6 +38,7 @@ export const Setup = (): JSX.Element => {
         setPassword(password);
         history.push(walletRoutePaths.newWallet.create.keepSecure);
       }}
+      translations={translations}
     />
   );
 };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/steps/Setup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/steps/Setup.tsx
@@ -3,10 +3,30 @@ import React from 'react';
 import { useHistory } from 'react-router';
 import { useRestoreWallet } from '../context';
 import { walletRoutePaths } from '@routes/wallet-paths';
+import { useTranslation } from 'react-i18next';
 
 export const Setup = (): JSX.Element => {
   const history = useHistory();
   const { setName, setPassword, onChange, data } = useRestoreWallet();
+  const { t } = useTranslation();
+
+  const translations = {
+    title: t('package.core.walletNameAndPasswordSetupStep.title'),
+    description: t('package.core.walletNameAndPasswordSetupStep.description'),
+    nameInputLabel: t('package.core.walletNameAndPasswordSetupStep.nameInputLabel'),
+    nameMaxLength: t('package.core.walletNameAndPasswordSetupStep.nameMaxLength'),
+    passwordInputLabel: t('package.core.walletNameAndPasswordSetupStep.passwordInputLabel'),
+    confirmPasswordInputLabel: t('package.core.walletNameAndPasswordSetupStep.confirmPasswordInputLabel'),
+    nameRequiredMessage: t('package.core.walletNameAndPasswordSetupStep.nameRequiredMessage'),
+    noMatchPassword: t('package.core.walletNameAndPasswordSetupStep.noMatchPassword'),
+    enterWallet: t('package.core.walletNameAndPasswordSetupStep.enterWallet'),
+    secondLevelPasswordStrengthFeedback: t(
+      'package.core.walletNameAndPasswordSetupStep.secondLevelPasswordStrengthFeedback'
+    ),
+    firstLevelPasswordStrengthFeedback: t(
+      'package.core.walletNameAndPasswordSetupStep.firstLevelPasswordStrengthFeedback'
+    )
+  };
 
   return (
     <WalletSetupNamePasswordStep
@@ -18,6 +38,7 @@ export const Setup = (): JSX.Element => {
         setPassword(password);
         history.push(walletRoutePaths.newWallet.restore.keepSecure);
       }}
+      translations={translations}
     />
   );
 };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/steps/Setup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/steps/Setup.tsx
@@ -19,7 +19,7 @@ export const Setup = (): JSX.Element => {
     confirmPasswordInputLabel: t('package.core.walletNameAndPasswordSetupStep.confirmPasswordInputLabel'),
     nameRequiredMessage: t('package.core.walletNameAndPasswordSetupStep.nameRequiredMessage'),
     noMatchPassword: t('package.core.walletNameAndPasswordSetupStep.noMatchPassword'),
-    enterWallet: t('package.core.walletNameAndPasswordSetupStep.enterWallet'),
+    confirmButton: t('package.core.walletNameAndPasswordSetupStep.next'),
     secondLevelPasswordStrengthFeedback: t(
       'package.core.walletNameAndPasswordSetupStep.secondLevelPasswordStrengthFeedback'
     ),

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetup.tsx
@@ -21,7 +21,7 @@ export interface WalletSetupProps {
   initialStep?: WalletSetupSteps;
 }
 
-export const WalletSetup = ({ initialStep = WalletSetupSteps.Register }: WalletSetupProps): React.ReactElement => {
+export const WalletSetup = ({ initialStep = WalletSetupSteps.Mnemonic }: WalletSetupProps): React.ReactElement => {
   const history = useHistory();
   const { path } = useRouteMatch();
   const analytics = useAnalyticsContext();

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -124,6 +124,24 @@ export const WalletSetupWizard = ({
     closeButton: t('core.mnemonicVideoPopupContent.closeButton')
   };
 
+  const walletSetupNamePasswordStepTranslations = {
+    title: t('package.core.walletNameAndPasswordSetupStep.title'),
+    description: t('package.core.walletNameAndPasswordSetupStep.description'),
+    nameInputLabel: t('package.core.walletNameAndPasswordSetupStep.nameInputLabel'),
+    nameMaxLength: t('package.core.walletNameAndPasswordSetupStep.nameMaxLength'),
+    passwordInputLabel: t('package.core.walletNameAndPasswordSetupStep.passwordInputLabel'),
+    confirmPasswordInputLabel: t('package.core.walletNameAndPasswordSetupStep.confirmPasswordInputLabel'),
+    nameRequiredMessage: t('package.core.walletNameAndPasswordSetupStep.nameRequiredMessage'),
+    noMatchPassword: t('package.core.walletNameAndPasswordSetupStep.noMatchPassword'),
+    enterWallet: t('package.core.walletNameAndPasswordSetupStep.enterWallet'),
+    secondLevelPasswordStrengthFeedback: t(
+      'package.core.walletNameAndPasswordSetupStep.secondLevelPasswordStrengthFeedback'
+    ),
+    firstLevelPasswordStrengthFeedback: t(
+      'package.core.walletNameAndPasswordSetupStep.firstLevelPasswordStrengthFeedback'
+    )
+  };
+
   const moveBack = () => {
     const prevStep = walletSetupWizard[currentStep].prev;
 
@@ -258,7 +276,11 @@ export const WalletSetupWizard = ({
         </Suspense>
       )}
       {currentStep === WalletSetupSteps.Register && (
-        <WalletSetupNamePasswordStep onBack={moveBack} onNext={handleSubmit} />
+        <WalletSetupNamePasswordStep
+          onBack={moveBack}
+          onNext={handleSubmit}
+          translations={walletSetupNamePasswordStepTranslations}
+        />
       )}
       {setupType === SetupType.CREATE && isResetMnemonicModalOpen && (
         <WarningModal

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -133,7 +133,7 @@ export const WalletSetupWizard = ({
     confirmPasswordInputLabel: t('package.core.walletNameAndPasswordSetupStep.confirmPasswordInputLabel'),
     nameRequiredMessage: t('package.core.walletNameAndPasswordSetupStep.nameRequiredMessage'),
     noMatchPassword: t('package.core.walletNameAndPasswordSetupStep.noMatchPassword'),
-    enterWallet: t('package.core.walletNameAndPasswordSetupStep.enterWallet'),
+    confirmButton: t('package.core.walletNameAndPasswordSetupStep.enterWallet'),
     secondLevelPasswordStrengthFeedback: t(
       'package.core.walletNameAndPasswordSetupStep.secondLevelPasswordStrengthFeedback'
     ),

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupNamePasswordStep/WalletSetupNamePasswordStep.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupNamePasswordStep/WalletSetupNamePasswordStep.tsx
@@ -15,12 +15,24 @@ import {
 import { WalletNameInput } from './WalletNameInput';
 import { WalletPasswordConfirmationInput } from './WalletPasswordConfirmationInput';
 import { WalletSetupStepLayoutRevamp } from '../../WalletSetupRevamp';
+import { TranslationsFor } from '@ui/utils/types';
 
 export interface WalletSetupNamePasswordStepProps {
   onBack: () => void;
   onNext: (params: WalletSetupNamePasswordSubmitParams) => void;
   initialWalletName?: string;
   onChange?: (state: { name: string; password: string }) => void;
+  translations: TranslationsFor<
+    | 'title'
+    | 'description'
+    | 'nameInputLabel'
+    | 'passwordInputLabel'
+    | 'confirmPasswordInputLabel'
+    | 'noMatchPassword'
+    | 'nameMaxLength'
+    | 'nameRequiredMessage'
+    | 'enterWallet'
+  >;
 }
 
 const INITIAL_WALLET_NAME = 'Wallet 1';
@@ -29,7 +41,8 @@ export const WalletSetupNamePasswordStep = ({
   onBack,
   onNext,
   initialWalletName = INITIAL_WALLET_NAME,
-  onChange
+  onChange,
+  translations
 }: WalletSetupNamePasswordStepProps): React.ReactElement => {
   const { t } = useTranslate();
   const [password, setPassword] = useState('');
@@ -43,15 +56,11 @@ export const WalletSetupNamePasswordStep = ({
   const complexityBarList: BarStates = useMemo(() => getComplexityBarStateList(score), [score]);
 
   const passwordConfirmationErrorMessage =
-    passHasBeenValidated && password !== passwordConfirmation
-      ? t('package.core.walletNameAndPasswordSetupStep.noMatchPassword')
-      : '';
+    passHasBeenValidated && password !== passwordConfirmation ? translations.noMatchPassword : '';
 
   const walletNameErrorMessage = useMemo(() => {
-    const validationError = validateNameLength(walletName)
-      ? t('package.core.walletNameAndPasswordSetupStep.nameMaxLength')
-      : '';
-    return walletName ? validationError : t('package.core.walletNameAndPasswordSetupStep.nameRequiredMessage');
+    const validationError = validateNameLength(walletName) ? translations.nameMaxLength : '';
+    return walletName ? validationError : translations.nameRequiredMessage;
   }, [t, walletName]);
 
   const isNextButtonEnabled = () => {
@@ -87,18 +96,18 @@ export const WalletSetupNamePasswordStep = ({
 
   return (
     <WalletSetupStepLayoutRevamp
-      title={t('package.core.walletNameAndPasswordSetupStep.title')}
-      description={t('package.core.walletNameAndPasswordSetupStep.description')}
+      title={translations.title}
+      description={translations.description}
       onBack={onBack}
       onNext={handleNextButtonClick}
       isNextEnabled={isNextButtonEnabled()}
       currentTimelineStep={WalletTimelineSteps.WALLET_SETUP}
-      nextLabel={t('package.core.walletNameAndPasswordSetupStep.enterWallet')}
+      nextLabel={translations.enterWallet}
     >
       <div className={styles.walletPasswordAndNameContainer}>
         <WalletNameInput
           value={walletName}
-          label={t('package.core.walletNameAndPasswordSetupStep.nameInputLabel')}
+          label={translations.nameInputLabel}
           onChange={handleNameChange}
           maxLength={WALLET_NAME_INPUT_MAX_LENGTH}
           shouldShowErrorMessage={shouldShowNameErrorMessage}
@@ -107,7 +116,7 @@ export const WalletSetupNamePasswordStep = ({
         <PasswordVerification
           className={styles.input}
           value={password}
-          label={t('package.core.walletNameAndPasswordSetupStep.passwordInputLabel')}
+          label={translations.passwordInputLabel}
           onChange={handlePasswordChange}
           level={score}
           feedbacks={passwordStrengthFeedbackMap[score] && [t(passwordStrengthFeedbackMap[score])]}
@@ -118,7 +127,7 @@ export const WalletSetupNamePasswordStep = ({
           isVisible={score >= MINIMUM_PASSWORD_LEVEL_REQUIRED}
           value={passwordConfirmation}
           onChange={handlePasswordConfirmationChange}
-          label={t('package.core.walletNameAndPasswordSetupStep.confirmPasswordInputLabel')}
+          label={translations.confirmPasswordInputLabel}
           errorMessage={passwordConfirmationErrorMessage}
           shouldShowErrorMessage={!!passwordConfirmationErrorMessage}
         />

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupNamePasswordStep/WalletSetupNamePasswordStep.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupNamePasswordStep/WalletSetupNamePasswordStep.tsx
@@ -31,7 +31,7 @@ export interface WalletSetupNamePasswordStepProps {
     | 'noMatchPassword'
     | 'nameMaxLength'
     | 'nameRequiredMessage'
-    | 'enterWallet'
+    | 'confirmButton'
   >;
 }
 
@@ -61,7 +61,7 @@ export const WalletSetupNamePasswordStep = ({
   const walletNameErrorMessage = useMemo(() => {
     const validationError = validateNameLength(walletName) ? translations.nameMaxLength : '';
     return walletName ? validationError : translations.nameRequiredMessage;
-  }, [t, walletName]);
+  }, [t, walletName, translations.nameMaxLength, translations.nameRequiredMessage]);
 
   const isNextButtonEnabled = () => {
     const hasMinimumLevelRequired = score >= MINIMUM_PASSWORD_LEVEL_REQUIRED;
@@ -102,7 +102,7 @@ export const WalletSetupNamePasswordStep = ({
       onNext={handleNextButtonClick}
       isNextEnabled={isNextButtonEnabled()}
       currentTimelineStep={WalletTimelineSteps.WALLET_SETUP}
-      nextLabel={translations.enterWallet}
+      nextLabel={translations.confirmButton}
     >
       <div className={styles.walletPasswordAndNameContainer}>
         <WalletNameInput

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupNamePasswordStep/WalletSetupNamePasswordStep.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupNamePasswordStep/WalletSetupNamePasswordStep.tsx
@@ -93,6 +93,7 @@ export const WalletSetupNamePasswordStep = ({
       onNext={handleNextButtonClick}
       isNextEnabled={isNextButtonEnabled()}
       currentTimelineStep={WalletTimelineSteps.WALLET_SETUP}
+      nextLabel={t('package.core.walletNameAndPasswordSetupStep.enterWallet')}
     >
       <div className={styles.walletPasswordAndNameContainer}>
         <WalletNameInput

--- a/packages/core/src/ui/components/WalletSetup/WalletSetupStepLayout.tsx
+++ b/packages/core/src/ui/components/WalletSetup/WalletSetupStepLayout.tsx
@@ -48,8 +48,8 @@ const removeLegalAndAnalyticsStep = (
 
 const getTimelineSteps = (currentStep: WalletTimelineSteps, isHardwareWallet: boolean, flow: WalletSetupFlow) => {
   const inMemoryWalletSteps = [
-    { key: WalletTimelineSteps.WALLET_SETUP, name: i18n.t('package.core.walletSetupStep.walletSetup') },
     { key: WalletTimelineSteps.RECOVERY_PHRASE, name: i18n.t('package.core.walletSetupStep.recoveryPhrase') },
+    { key: WalletTimelineSteps.WALLET_SETUP, name: i18n.t('package.core.walletSetupStep.walletSetup') },
     { key: WalletTimelineSteps.ALL_DONE, name: i18n.t('package.core.walletSetupStep.enterWallet') }
   ];
 

--- a/packages/core/src/ui/components/WalletSetup/wallet-steps.ts
+++ b/packages/core/src/ui/components/WalletSetup/wallet-steps.ts
@@ -1,14 +1,10 @@
 import { WalletSetupSteps, WalletSetupWizard } from './wallet-steps.common';
 
 export const walletSetupWizard: WalletSetupWizard = {
-  [WalletSetupSteps.Register]: {
-    next: WalletSetupSteps.Mnemonic
-  },
   [WalletSetupSteps.Mnemonic]: {
-    prev: WalletSetupSteps.Register,
-    next: WalletSetupSteps.Create
+    next: WalletSetupSteps.Register
   },
-  [WalletSetupSteps.Create]: {
+  [WalletSetupSteps.Register]: {
     prev: WalletSetupSteps.Mnemonic
   }
 };

--- a/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupMnemonicStepRevamp/WalletSetupMnemonicStepRevamp.tsx
+++ b/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupMnemonicStepRevamp/WalletSetupMnemonicStepRevamp.tsx
@@ -27,7 +27,6 @@ export interface WalletSetupMnemonicStepProps {
     | 'writePassphraseSubtitle1'
     | 'writePassphraseSubtitle2'
     | 'passphraseError'
-    | 'enterWallet'
     | 'copyToClipboard'
     | 'pasteFromClipboard'
   >;
@@ -145,7 +144,6 @@ export const WalletSetupMnemonicStepRevamp = ({
             </Button>
           )
         }
-        nextLabel={mnemonicStage === 'input' && translations.enterWallet}
         isNextEnabled={isSubmitEnabled}
       >
         {mnemonicStage === 'writedown' ? (

--- a/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupMnemonicStepRevamp/WalletSetupMnemonicVerificationStepRevamp.tsx
+++ b/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupMnemonicStepRevamp/WalletSetupMnemonicVerificationStepRevamp.tsx
@@ -21,9 +21,7 @@ export interface WalletSetupMnemonicVerificationStepProps {
   onSubmit: () => void;
   isSubmitEnabled: boolean;
   mnemonicWordsInStep?: number;
-  translations: TranslationsFor<
-    'enterPassphrase' | 'passphraseError' | 'enterPassphraseLength' | 'enterWallet' | 'pasteFromClipboard'
-  >;
+  translations: TranslationsFor<'enterPassphrase' | 'passphraseError' | 'enterPassphraseLength' | 'pasteFromClipboard'>;
   suggestionList?: Array<string>;
   defaultMnemonicLength?: number;
   onSetMnemonicLength?: (length: number) => void;
@@ -79,7 +77,6 @@ export const WalletSetupMnemonicVerificationStepRevamp = ({
         </Button>
       }
       currentTimelineStep={WalletTimelineSteps.RECOVERY_PHRASE}
-      nextLabel={translations.enterWallet}
       isNextEnabled={isSubmitEnabled}
     >
       <div className={styles.mnemonicContainer}>

--- a/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupStepLayoutRevamp.tsx
+++ b/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupStepLayoutRevamp.tsx
@@ -39,8 +39,8 @@ const removeLegalAndAnalyticsStep = (
 
 const getTimelineSteps = (currentStep: WalletTimelineSteps, isHardwareWallet: boolean, flow: WalletSetupFlow) => {
   const inMemoryWalletSteps = [
-    { key: WalletTimelineSteps.WALLET_SETUP, name: i18n.t('package.core.walletSetupStep.walletSetup') },
     { key: WalletTimelineSteps.RECOVERY_PHRASE, name: i18n.t('package.core.walletSetupStep.recoveryPhrase') },
+    { key: WalletTimelineSteps.WALLET_SETUP, name: i18n.t('package.core.walletSetupStep.walletSetup') },
     { key: WalletTimelineSteps.ALL_DONE, name: i18n.t('package.core.walletSetupStep.enterWallet') }
   ];
 

--- a/packages/core/src/ui/lib/translations/en.json
+++ b/packages/core/src/ui/lib/translations/en.json
@@ -397,19 +397,6 @@
       "seeWalletBalance": "See your wallet balance",
       "seeWalletAddresses": "See your wallet different addresses, including reward accounts"
     },
-    "walletNameAndPasswordSetupStep": {
-      "title": "Let's set up your new wallet",
-      "description": "Choose a name to identify your wallet and set up your password to unlock your wallet and make transactions.",
-      "nameInputLabel": "Wallet name",
-      "nameMaxLength": "Max. 20 characters",
-      "passwordInputLabel": "Password",
-      "confirmPasswordInputLabel": "Confirm password",
-      "nameRequiredMessage": "Wallet name is required",
-      "noMatchPassword": "Oops! The passwords don't match.",
-      "enterWallet": "Enter wallet",
-      "secondLevelPasswordStrengthFeedback": "Getting there! Add some symbols and numbers to make it stronger.",
-      "firstLevelPasswordStrengthFeedback": "Weak password. Add some numbers and characters to make it stronger."
-    },
     "dappTransaction": {
       "asset": "Asset",
       "burn": "Burn",

--- a/packages/core/src/ui/lib/translations/en.json
+++ b/packages/core/src/ui/lib/translations/en.json
@@ -406,6 +406,7 @@
       "confirmPasswordInputLabel": "Confirm password",
       "nameRequiredMessage": "Wallet name is required",
       "noMatchPassword": "Oops! The passwords don't match.",
+      "enterWallet": "Enter wallet",
       "secondLevelPasswordStrengthFeedback": "Getting there! Add some symbols and numbers to make it stronger.",
       "firstLevelPasswordStrengthFeedback": "Weak password. Add some numbers and characters to make it stronger."
     },


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-10000
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

This PR moves the register screen after the mnemonic screen on the  create and restore onboarding flow

## Testing

Follow the normal onboarding flow

## Screenshots

<img width="918" alt="Screenshot 2024-03-11 at 18 22 07" src="https://github.com/input-output-hk/lace/assets/48496855/a86320e7-255d-4c48-a293-fa10d17430dc">

<img width="881" alt="Screenshot 2024-03-11 at 18 22 38" src="https://github.com/input-output-hk/lace/assets/48496855/17e92a17-76db-418d-8d65-a4530801f833">

