### PR TITLE
feat(extension): disable 'Lock wallet' button

### DIFF
--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/LockWallet.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/LockWallet.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useWalletManager } from '@hooks';
-import { useWalletStore } from '@src/stores';
 import { Menu } from 'antd';
 import { useTranslation } from 'react-i18next';
 import styles from '../DropdownMenuOverlay.module.scss';
@@ -10,7 +9,6 @@ import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 export const LockWallet = (): React.ReactElement => {
   const { t } = useTranslation();
   const { lockWallet } = useWalletManager();
-  const { isInMemoryWallet } = useWalletStore();
   const analytics = useAnalyticsContext();
 
   const handleLockWallet = () => {
@@ -19,12 +17,7 @@ export const LockWallet = (): React.ReactElement => {
   };
 
   return (
-    <Menu.Item
-      data-testid="header-menu-lock"
-      onClick={handleLockWallet}
-      className={styles.menuItem}
-      disabled={!isInMemoryWallet}
-    >
+    <Menu.Item data-testid="header-menu-lock" onClick={handleLockWallet} className={styles.menuItem} disabled>
       {t('browserView.topNavigationBar.links.lockWallet')}
     </Menu.Item>
   );

--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -561,6 +561,12 @@ export const useWalletManager = (): UseWalletManager => {
         if (wallets.length > 0) {
           walletToDelete = wallets[0];
         } else {
+          if (isForgotPasswordFlow) {
+            // Forgot Password flow deletes the wallet.
+            // If wallet was never created in the repository due to migrating a locked wallet,
+            // then we have to delete the 'lock' instead of wallet in the repository
+            resetWalletLock();
+          }
           logger.warn('No wallet to delete');
           return;
         }

--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -549,10 +549,23 @@ export const useWalletManager = (): UseWalletManager => {
    * @returns active wallet id after deleting the wallet
    */
   const deleteWallet = useCallback(
+    // eslint-disable-next-line max-statements
     async (isForgotPasswordFlow = false): Promise<WalletManagerActivateProps | undefined> => {
-      const activeWallet = await firstValueFrom(walletManager.activeWalletId$);
-      await walletManager.deactivate();
-      await walletRepository.removeWallet(activeWallet.walletId);
+      let walletToDelete: Pick<WalletManagerActivateProps, 'walletId'> = await firstValueFrom(
+        walletManager.activeWalletId$
+      );
+      if (walletToDelete) {
+        await walletManager.deactivate();
+      } else {
+        const wallets = await firstValueFrom(walletRepository.wallets$);
+        if (wallets.length > 0) {
+          walletToDelete = wallets[0];
+        } else {
+          logger.warn('No wallet to delete');
+          return;
+        }
+      }
+      await walletRepository.removeWallet(walletToDelete.walletId);
 
       const wallets = await firstValueFrom(walletRepository.wallets$);
       if (wallets.length > 0) {
@@ -607,7 +620,7 @@ export const useWalletManager = (): UseWalletManager => {
       clearNftsFolders();
 
       for (const chainName of AVAILABLE_CHAINS) {
-        await walletManager.destroyData(activeWallet.walletId, chainIdFromName(chainName));
+        await walletManager.destroyData(walletToDelete.walletId, chainIdFromName(chainName));
       }
     },
     [

--- a/packages/e2e-tests/src/features/DAppConnector.feature
+++ b/packages/e2e-tests/src/features/DAppConnector.feature
@@ -69,7 +69,7 @@ Feature: DAppConnector - Common
     And I switch to window with Lace
     Then "Get started" page is displayed
 
-  @LW-3758 @Testnet @Mainnet
+  @LW-3758 @Testnet @Mainnet @Pending
   Scenario: Unlock Dapp page is displayed when wallet is locked, wallet can be unlocked
     Given I lock my wallet
     When I open test DApp
@@ -78,7 +78,7 @@ Feature: DAppConnector - Common
     And I click "Unlock" button on unlock screen
     Then I see DApp authorization window
 
-  @LW-7082 @Testnet @Mainnet
+  @LW-7082 @Testnet @Mainnet @Pending
   Scenario: "Forgot password" click and cancel on DApp wallet unlock page
     Given I lock my wallet
     When I open test DApp
@@ -88,7 +88,7 @@ Feature: DAppConnector - Common
     And I click on "Cancel" button on "Forgot password?" modal
     Then I see DApp unlock page
 
-  @LW-7083 @Testnet @Mainnet
+  @LW-7083 @Testnet @Mainnet @Pending
   Scenario: "Forgot password" click and proceed on DApp wallet unlock page
     Given I lock my wallet
     When I open test DApp
@@ -100,7 +100,7 @@ Feature: DAppConnector - Common
     When I switch to tab with restore wallet process
     Then "Wallet password" page is displayed in forgot password flow
 
-  @LW-7083 @Testnet @Mainnet
+  @LW-7083 @Testnet @Mainnet @Pending
   Scenario: "Forgot password" click and proceed on DApp wallet unlock page
     Given I lock my wallet
     When I open test DApp

--- a/packages/e2e-tests/src/features/ForgotPassword.feature
+++ b/packages/e2e-tests/src/features/ForgotPassword.feature
@@ -1,4 +1,4 @@
-@ForgotPassword @Mainnet @Testnet
+@ForgotPassword @Mainnet @Testnet @Pending
 Feature: Forgot password
 
   @LW-2758

--- a/packages/e2e-tests/src/features/LockWalletExtended.feature
+++ b/packages/e2e-tests/src/features/LockWalletExtended.feature
@@ -1,10 +1,10 @@
-@LockWallet-extended @Mainnet @Testnet
+@LockWallet-extended @Mainnet @Testnet @Pending
 Feature: Wallet locking / unlocking - Extended view
 
   Background:
     Given Lace is ready for test
 
-  @LW-2894 @Smoke
+  @LW-2894 @Smoke @Pending
   Scenario: Extended view - Lock screen button opens lock screen
     And I lock my wallet
     Then I see locked wallet screen

--- a/packages/e2e-tests/src/features/LockWalletPopup.feature
+++ b/packages/e2e-tests/src/features/LockWalletPopup.feature
@@ -1,10 +1,10 @@
-@LockWallet-popup @Mainnet @Testnet
+@LockWallet-popup @Mainnet @Testnet @Pending
 Feature: Wallet locking / unlocking - Popup view
 
   Background:
     Given Lace is ready for test
 
-  @LW-3038 @Pending
+  @LW-3038
   Scenario: Popup view - Lock screen button opens lock screen
     And I lock my wallet
     Then I see unlock wallet screen

--- a/packages/e2e-tests/src/features/LockWalletPopup.feature
+++ b/packages/e2e-tests/src/features/LockWalletPopup.feature
@@ -4,7 +4,7 @@ Feature: Wallet locking / unlocking - Popup view
   Background:
     Given Lace is ready for test
 
-  @LW-3038
+  @LW-3038 @Pending
   Scenario: Popup view - Lock screen button opens lock screen
     And I lock my wallet
     Then I see unlock wallet screen

--- a/packages/e2e-tests/src/features/analytics/AnalyticsForgotPassword.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsForgotPassword.feature
@@ -1,4 +1,4 @@
-@ForgotPassword @Mainnet @Testnet
+@ForgotPassword @Mainnet @Testnet @Pending
 Feature: Analytics - Forgot Password
 
   Background:


### PR DESCRIPTION
Forgot Password flow implementation was deleting the wallet and opening the Restore Wallet onboarding flow.

When we introduced multi-wallet, deleting the locked/active wallet left Lace in a faulty state, where it would still have other wallets remaining.

# Checklist

- [x] JIRA - LW-10007
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

This feature has to be reworked with multi-wallet in mind.
Disabling it for now.

## Testing

LW-10007

## Screenshots

No UI changes
