### PR TITLE
chore: LW-9969 make single device connection during Trezor onboarding

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -109,10 +109,6 @@ const getHwExtendedAccountPublicKey = async (
         accountIndex
       });
     case WalletType.Trezor:
-      await Wallet.Trezor.TrezorKeyAgent.initializeTrezorTransport({
-        manifest: Wallet.manifest,
-        communicationType: Wallet.KeyManagement.CommunicationType.Web
-      });
       return Wallet.Trezor.TrezorKeyAgent.getXpub({
         communicationType: Wallet.KeyManagement.CommunicationType.Web,
         accountIndex

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -203,7 +203,8 @@ export const HardwareWalletFlow = ({
         await analytics.sendAliasEvent();
       }
 
-      if (typeof deviceConnection === 'object') {
+      // To be checked in LW-9970
+      if (connectedDevice !== WalletType.Trezor && typeof deviceConnection === 'object') {
         deviceConnection.transport.close();
       }
     }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -203,7 +203,7 @@ export const HardwareWalletFlow = ({
         await analytics.sendAliasEvent();
       }
 
-      // To be checked in LW-9970
+      // Check if app reloading workaround can be removed with this in LW-9970
       if (connectedDevice !== WalletType.Trezor && typeof deviceConnection === 'object') {
         deviceConnection.transport.close();
       }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/helpers.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/helpers.ts
@@ -37,9 +37,14 @@ export const getHWPersonProperties = async (
   connectedDevice: Wallet.HardwareWallets,
   deviceConnection: Wallet.DeviceConnection
 ): Promise<PostHogProperties> => {
+  // TODO: Remove these hardcoded specs once we have a logic that will prevent additional interaction with 3rd party Trezor Connect popup
+  const trezorSpecificationsHC: HardwareWalletPersonProperties = {
+    // We are only accepting Model T for now
+    model: `${WalletType.Trezor} model T`
+  };
   const HWSpecifications =
     connectedDevice === WalletType.Trezor
-      ? await getTrezorSpecifications()
+      ? trezorSpecificationsHC
       : await getLedgerSpecifications(deviceConnection as HardwareLedger.LedgerKeyAgent['deviceConnection']);
   return {
     $set_once: {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/helpers.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/helpers.ts
@@ -40,7 +40,7 @@ export const getHWPersonProperties = async (
   // TODO: Remove these hardcoded specs once we have a logic that will prevent additional interaction with 3rd party Trezor Connect popup
   const trezorSpecificationsHC: HardwareWalletPersonProperties = {
     // We are only accepting Model T for now
-    model: `${WalletType.Trezor} model T`
+    model: 'Trezor model T'
   };
   const HWSpecifications =
     connectedDevice === WalletType.Trezor

--- a/packages/cardano/src/wallet/lib/hardware-wallet.ts
+++ b/packages/cardano/src/wallet/lib/hardware-wallet.ts
@@ -24,17 +24,11 @@ const connectDevices: Record<HardwareWallets, () => Promise<DeviceConnection>> =
   [WalletType.Ledger]: async () =>
     await HardwareLedger.LedgerKeyAgent.checkDeviceConnection(DEFAULT_COMMUNICATION_TYPE),
   ...(AVAILABLE_WALLETS.includes(WalletType.Trezor) && {
-    [WalletType.Trezor]: async () => {
-      const isTrezorInitialized = await HardwareTrezor.TrezorKeyAgent.initializeTrezorTransport({
+    [WalletType.Trezor]: async () =>
+      await HardwareTrezor.TrezorKeyAgent.initializeTrezorTransport({
         manifest,
         communicationType: DEFAULT_COMMUNICATION_TYPE
-      });
-
-      // initializeTrezorTransport would still succeed even when device is not connected
-      await HardwareTrezor.TrezorKeyAgent.checkDeviceConnection(DEFAULT_COMMUNICATION_TYPE);
-
-      return isTrezorInitialized;
-    }
+      })
   })
 };
 


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-9969

---

## Proposed solution
In the scope of this task, we are reducing the number of interactions with 3rd party Trezor Connect popup

## Testing

1. Set feature flag `USE_TREZOR_HW=true`
2. Restore your wallet using a Trezor device ( onboarding flow )