### PR TITLE
chore: update ts-jest

### DIFF
--- a/.github/workflows/build-dev-preview.yml
+++ b/.github/workflows/build-dev-preview.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           AVAILABLE_CHAINS: 'Preprod,Preview,Mainnet'
           DEFAULT_CHAIN: 'Preprod'
-        run: yarn test:coverage --maxWorkers=2
+        run: yarn test:coverage --maxWorkers=2 --silent
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           AVAILABLE_CHAINS: 'Preprod,Preview,Mainnet'
           DEFAULT_CHAIN: 'Preprod'
           NODE_OPTIONS: '--max_old_space_size=8192'
-        run: yarn test:coverage --maxWorkers=2
+        run: yarn test:coverage --maxWorkers=2 --silent
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -21,7 +21,7 @@ jobs:
           name: lightwallet
           path: apps/browser-extension-wallet/dist
       - name: Run unit tests, generate test coverage report
-        run: yarn test:coverage --maxWorkers=2
+        run: yarn test:coverage --maxWorkers=2 --silent
       - name: Upload Coveralls report
         uses: coverallsapp/github-action@v2
         with:

--- a/apps/browser-extension-wallet/test/jest.config.js
+++ b/apps/browser-extension-wallet/test/jest.config.js
@@ -48,9 +48,12 @@ module.exports = createJestConfig({
     '!src/utils/fake-api-request.ts'
   ],
   setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock'],
-  globals: {
-    'ts-jest': {
-      tsconfig: './src/tsconfig.json'
-    }
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: './src/tsconfig.json'
+      }
+    ]
   }
 });

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "stylelint-order": "^6.0.3",
     "swc-loader": "0.2.3",
     "terser-webpack-plugin": "5.3.6",
-    "ts-jest": "28.0.7",
+    "ts-jest": "29.1.2",
     "ts-patch": "^2.0.1",
     "typedoc": "^0.21.5",
     "typescript": "^4.3.5",

--- a/packages/cardano/package.json
+++ b/packages/cardano/package.json
@@ -33,7 +33,7 @@
     "prepare": "ts-patch install -s",
     "prestart": "yarn build",
     "start": "node dist/index.js",
-    "test": "NODE_ENV=test jest -c ./test/jest.config.js",
+    "test": "NODE_ENV=test run -T jest -c ./test/jest.config.js",
     "test:coverage": "yarn test --coverage --silent",
     "tsc:declarationOnly": "tsc --project ./src/tsconfig.declarationOnly.json",
     "watch": "yarn build --watch"

--- a/packages/cardano/package.json
+++ b/packages/cardano/package.json
@@ -34,7 +34,7 @@
     "prestart": "yarn build",
     "start": "node dist/index.js",
     "test": "NODE_ENV=test jest -c ./test/jest.config.js",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "yarn test --coverage --silent",
     "tsc:declarationOnly": "tsc --project ./src/tsconfig.declarationOnly.json",
     "watch": "yarn build --watch"
   },

--- a/packages/cardano/test/jest.config.js
+++ b/packages/cardano/test/jest.config.js
@@ -29,10 +29,13 @@ module.exports = createJestConfig({
     '!src/wallet/**/mock.ts'
   ],
   setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock'],
-  globals: {
-    'ts-jest': {
-      tsconfig: './src/tsconfig.json'
-    }
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: './src/tsconfig.json'
+      }
+    ]
   },
   workerThreads: true
 });

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -34,7 +34,7 @@
     "prestart": "yarn build",
     "start": "node dist/index.js",
     "test": "NODE_ENV=test run -T jest -c ./test/jest.config.js",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "yarn test --coverage --silent",
     "watch": "yarn build --watch"
   },
   "dependencies": {

--- a/packages/common/test/jest.config.js
+++ b/packages/common/test/jest.config.js
@@ -20,9 +20,12 @@ module.exports = createJestConfig({
     'src/ui/utils/**/*.{ts,tsx}'
   ],
   setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock'],
-  globals: {
-    'ts-jest': {
-      tsconfig: './src/tsconfig.json'
-    }
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: './src/tsconfig.json'
+      }
+    ]
   }
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "start": "node dist/index.js",
     "storybook": "NODE_OPTIONS=--openssl-legacy-provider; start-storybook -p 6006",
     "test": "NODE_ENV=test run -T jest -c ./test/jest.config.js",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "yarn test --coverage --silent",
     "typecheck": "tsc --noEmit",
     "watch": "yarn build --watch"
   },

--- a/packages/core/test/jest.config.js
+++ b/packages/core/test/jest.config.js
@@ -21,9 +21,12 @@ module.exports = createJestConfig({
     'src/wallet/**/*.{ts,tsx}'
   ],
   setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock'],
-  globals: {
-    'ts-jest': {
-      tsconfig: './src/tsconfig.json'
-    }
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: './src/tsconfig.json'
+      }
+    ]
   }
 });

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -43,8 +43,8 @@
     "prettier:check": "yarn run -T prettier --check '**/*.{js,ts,jsx,tsx,html,json,md}'",
     "prettier:fix": "yarn run -T prettier --write --loglevel warn '**/*.{js,ts,jsx,tsx,html,json,md}'",
     "test": "echo 'Staking package runs tests in its own CI'",
-    "test:all": "yarn test:unit --coverage && yarn test:vr",
-    "test:coverage": "yarn test --coverage",
+    "test:all": "yarn test:unit --coverage --silent && yarn test:vr",
+    "test:coverage": "yarn test --coverage --silent",
     "test:unit": "vitest run",
     "watch": "tsup --watch"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,7 @@
     "test": "echo \"Error: no test specified\"",
     "test-storybook": "test-storybook",
     "test-storybook:ci": "NODE_OPTIONS=--openssl-legacy-provider; export STORYBOOK_TEST=1; concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"yarn build-storybook && http-server storybook-static --port 6006\" \"wait-on http://127.0.0.1:6006/ && yarn test-storybook\"",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "yarn test --coverage --silent",
     "typecheck": "tsc --noEmit",
     "watch": "yarn build --watch"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -25072,17 +25072,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001248, caniuse-lite@npm:^1.0.30001251, caniuse-lite@npm:^1.0.30001280, caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001517":
-  version: 1.0.30001538
-  resolution: "caniuse-lite@npm:1.0.30001538"
-  checksum: 94c5d55757a339c7cc175f08a024671e2b4e7c04f130b1015793303d637061347efb6ad84447c3b8137333e742d150b8ad9672716bbf2482646c2e63a56f6c55
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001565":
-  version: 1.0.30001572
-  resolution: "caniuse-lite@npm:1.0.30001572"
-  checksum: 7d017a99a38e29ccee4ed3fc0ef1eb90cf082fcd3a7909c5c536c4ba1d55c5b26ecc1e4ad82c1caa6bfadce526764b354608710c9b61a75bdc7ce8ca15c5fcf2
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001248, caniuse-lite@npm:^1.0.30001251, caniuse-lite@npm:^1.0.30001280, caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001517, caniuse-lite@npm:^1.0.30001565":
+  version: 1.0.30001599
+  resolution: "caniuse-lite@npm:1.0.30001599"
+  checksum: d7e619e2e723547b7311ba0ca5134d9cd55df548e93dbedcf8a6e4ec74c7db91969c4272fb1ab2fd94cddeac6a8176ebf05853eb06689d5e76bb97d979a214b0
   languageName: node
   linkType: hard
 
@@ -36666,7 +36659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^28.0.0, jest-util@npm:^28.1.3":
+"jest-util@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-util@npm:28.1.3"
   dependencies:
@@ -36677,6 +36670,20 @@ __metadata:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: fd6459742c941f070223f25e38a2ac0719aad92561591e9fb2a50d602a5d19d754750b79b4074327a42b00055662b95da3b006542ceb8b54309da44d4a62e721
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-util@npm:29.7.0"
+  dependencies:
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  checksum: 042ab4980f4ccd4d50226e01e5c7376a8556b472442ca6091a8f102488c0f22e6e8b89ea874111d2328a2080083bf3225c86f3788c52af0bd0345a00eb57a3ca
   languageName: node
   linkType: hard
 
@@ -36705,20 +36712,6 @@ __metadata:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: fd9212950d34d2ecad8c990dda0d8ea59a8a554b0c188b53ea5d6c4a0829a64f2e1d49e6e85e812014933d17426d7136da4785f9cf76fff1799de51b88bc85d3
-  languageName: node
-  linkType: hard
-
-"jest-util@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-util@npm:29.7.0"
-  dependencies:
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    chalk: ^4.0.0
-    ci-info: ^3.2.0
-    graceful-fs: ^4.2.9
-    picomatch: ^2.2.3
-  checksum: 042ab4980f4ccd4d50226e01e5c7376a8556b472442ca6091a8f102488c0f22e6e8b89ea874111d2328a2080083bf3225c86f3788c52af0bd0345a00eb57a3ca
   languageName: node
   linkType: hard
 
@@ -37635,7 +37628,7 @@ __metadata:
     stylelint-order: ^6.0.3
     swc-loader: 0.2.3
     terser-webpack-plugin: 5.3.6
-    ts-jest: 28.0.7
+    ts-jest: 29.1.2
     ts-patch: ^2.0.1
     typedoc: ^0.21.5
     typescript: ^4.3.5
@@ -47079,7 +47072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.7, semver@npm:7.x, semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0":
+"semver@npm:7.3.7, semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0":
   version: 7.5.2
   resolution: "semver@npm:7.5.2"
   dependencies:
@@ -50143,24 +50136,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:28.0.7":
-  version: 28.0.7
-  resolution: "ts-jest@npm:28.0.7"
+"ts-jest@npm:29.1.2":
+  version: 29.1.2
+  resolution: "ts-jest@npm:29.1.2"
   dependencies:
     bs-logger: 0.x
     fast-json-stable-stringify: 2.x
-    jest-util: ^28.0.0
-    json5: ^2.2.1
+    jest-util: ^29.0.0
+    json5: ^2.2.3
     lodash.memoize: 4.x
     make-error: 1.x
-    semver: 7.x
+    semver: ^7.5.3
     yargs-parser: ^21.0.1
   peerDependencies:
     "@babel/core": ">=7.0.0-beta.0 <8"
-    "@jest/types": ^28.0.0
-    babel-jest: ^28.0.0
-    jest: ^28.0.0
-    typescript: ">=4.3"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3 <6"
   peerDependenciesMeta:
     "@babel/core":
       optional: true
@@ -50172,7 +50165,7 @@ __metadata:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: be6ad6382e3b2e7b0c45d06616a4a02aeb6815bad2026fe8eeb4e0941205faa50ac3f5930adb7ba2fda5fea6a5739bfa507e2eac8764d2c729ddc8010681707a
+  checksum: a0ce0affc1b716c78c9ab55837829c42cb04b753d174a5c796bb1ddf9f0379fc20647b76fbe30edb30d9b23181908138d6b4c51ef2ae5e187b66635c295cefd5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In this PR I'm improving unit test run by:

- updating `ts-jest` from v28.0.7 to v29.1.2
- updating browserslist's db
- fixing local test command for cardano package