### PR TITLE
chore: LW-9786 enable single pool delegation in multi-delegation view

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/helpers.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/helpers.ts
@@ -29,6 +29,12 @@ export const isMultidelegationSupportedByDevice = async (
       );
     }
     case WalletType.Trezor: {
+      // To allow checks once the app is refreshed. It won't affect the user flow
+      // TODO: Smarter Trezor initialization logic after onboarding revamp LW-9808
+      await HardwareTrezor.TrezorKeyAgent.initializeTrezorTransport({
+        manifest: Wallet.manifest,
+        communicationType: Wallet.KeyManagement.CommunicationType.Web
+      });
       const trezorInfo = await HardwareTrezor.TrezorKeyAgent.checkDeviceConnection(
         Wallet.KeyManagement.CommunicationType.Web
       );

--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/HardwareWalletFlow.tsx
@@ -133,11 +133,6 @@ export const HardwareWalletFlow = ({
       if (enhancedAnalyticsStatus === EnhancedAnalyticsOptInStatus.OptedIn) {
         await analytics.sendAliasEvent();
       }
-
-      // Check if app reloading workaround can be removed with this in LW-9970
-      if (connectedDevice !== WalletType.Trezor && typeof deviceConnection === 'object') {
-        deviceConnection.transport.close();
-      }
     }
   };
 

--- a/packages/staking/src/features/Drawer/confirmation/StakePoolConfirmationFooter.tsx
+++ b/packages/staking/src/features/Drawer/confirmation/StakePoolConfirmationFooter.tsx
@@ -25,6 +25,7 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
     submittingState: { setIsRestaking },
     delegationStoreDelegationTxBuilder: delegationTxBuilder,
     isMultidelegationSupportedByDevice,
+    walletManagerExecuteWithPassword,
   } = useOutsideHandles();
   const { isBuildingTx, stakingError } = useStakingStore();
   const [isConfirmingTx, setIsConfirmingTx] = useState(false);
@@ -63,7 +64,7 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
     // HW-WALLET
     setIsConfirmingTx(true);
     try {
-      await signAndSubmitTransaction();
+      await walletManagerExecuteWithPassword(signAndSubmitTransaction);
       setIsRestaking(currentPortfolio.length > 0);
       portfolioMutators.executeCommand({ type: 'HwSkipToSuccess' });
     } catch (error: any) {

--- a/packages/staking/src/features/Drawer/confirmation/StakePoolConfirmationFooter.tsx
+++ b/packages/staking/src/features/Drawer/confirmation/StakePoolConfirmationFooter.tsx
@@ -42,7 +42,8 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
   const signAndSubmitTransaction = useCallback(async () => {
     if (!delegationTxBuilder) throw new Error('Unable to submit transaction. The delegationTxBuilder not available');
 
-    if (!isInMemory) {
+    const isMultidelegation = draftPortfolio && draftPortfolio.length > 1;
+    if (!isInMemory && isMultidelegation) {
       const isSupported = await isMultidelegationSupportedByDevice(walletType);
       if (!isSupported) {
         throw new Error('MULTIDELEGATION_NOT_SUPPORTED');
@@ -50,7 +51,7 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
     }
     const signedTx = await delegationTxBuilder.build().sign();
     await inMemoryWallet.submitTx(signedTx);
-  }, [delegationTxBuilder, inMemoryWallet, isInMemory, isMultidelegationSupportedByDevice, walletType]);
+  }, [delegationTxBuilder, inMemoryWallet, isInMemory, isMultidelegationSupportedByDevice, walletType, draftPortfolio]);
 
   const handleSubmission = useCallback(async () => {
     setOpenPoolsManagementConfirmationModal(null);
@@ -73,7 +74,14 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
     } finally {
       setIsConfirmingTx(false);
     }
-  }, [currentPortfolio, isInMemory, portfolioMutators, setIsRestaking, signAndSubmitTransaction]);
+  }, [
+    currentPortfolio,
+    isInMemory,
+    portfolioMutators,
+    setIsRestaking,
+    signAndSubmitTransaction,
+    walletManagerExecuteWithPassword,
+  ]);
 
   const onClick = useCallback(async () => {
     analytics.sendEventToPostHog(PostHogAction.StakingManageDelegationStakePoolConfirmationNextClick);


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-9786

---

## Proposed solution

This PR introduces an additional check where we enabled single pool delegation in multi-delegation view. This check will allow users with older Ledger Cardano App and Trezor Firmware ( multi-delegation not supported ) to delegate in a single pool even in multi-delegation view.
Also, this PR fixes HW multi-delegation tx signing.


## Testing
-  Check if single and multi delegation works when you are using devices with the latest Ledger Cardano App and Trezor Firmware
-  Check if single pool delegation works when you are using devices with older Ledger Cardano App and Trezor Firmware
