### PR TITLE
feat: handle back from next step in wallet setup step

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -70,7 +70,7 @@ export const WalletSetupWizard = ({
   const [mnemonic, setMnemonic] = useState<string[]>([]);
   const [resetMnemonicStage, setResetMnemonicStage] = useState<MnemonicStage | ''>('');
   const [isResetMnemonicModalOpen, setIsResetMnemonicModalOpen] = useState(false);
-  const [isBackFromPasswordStep, setIsBackFromPasswordStep] = useState(false);
+  const [isBackFromNextStep, setIsBackFromNextStep] = useState(false);
   const walletName = getWalletFromStorage()?.name;
   const { createWallet } = useWalletManager();
   const analytics = useAnalyticsContext();
@@ -243,7 +243,7 @@ export const WalletSetupWizard = ({
         onReset={(resetStage) => {
           setResetMnemonicStage(resetStage);
           resetStage === 'input' ? setIsResetMnemonicModalOpen(true) : onCancel();
-          resetStage === 'input' && setIsBackFromPasswordStep(false);
+          resetStage === 'input' && setIsBackFromNextStep(false);
         }}
         renderVideoPopupContent={({ onClose }) => (
           <MnemonicVideoPopupContent
@@ -269,7 +269,7 @@ export const WalletSetupWizard = ({
         onPasteFromClipboard={() =>
           sendAnalytics(postHogOnboardingActions.create.RECOVERY_PHRASE_PASTE_FROM_CLIPBOARD_CLICK)
         }
-        isBackFromNextStep={isBackFromPasswordStep}
+        isBackFromNextStep={isBackFromNextStep}
       />
     );
   };
@@ -287,7 +287,7 @@ export const WalletSetupWizard = ({
       {currentStep === WalletSetupSteps.Register && (
         <WalletSetupNamePasswordStepRevamp
           onBack={() => {
-            setIsBackFromPasswordStep(true);
+            setIsBackFromNextStep(true);
             moveBack();
           }}
           onNext={handleSubmit}

--- a/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupMnemonicStepRevamp/WalletSetupMnemonicStepRevamp.tsx
+++ b/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupMnemonicStepRevamp/WalletSetupMnemonicStepRevamp.tsx
@@ -6,7 +6,7 @@ import { WalletSetupStepLayoutRevamp } from '../WalletSetupStepLayoutRevamp';
 import styles from '../../WalletSetup/WalletSetupOption.module.scss';
 import './WalletSetupMnemonicRevampCommon.module.scss';
 import { TranslationsFor } from '@ui/utils/types';
-import { hasEmptyString } from '@ui/components/WalletSetup/WalletSetupMnemonicVerificationStep';
+import { hasEmptyString } from './WalletSetupMnemonicVerificationStepRevamp';
 import { Dialog } from '@lace/ui';
 import { MnemonicWordsConfirmInputRevamp } from './MnemonicWordsConfirmInputRevamp';
 import { Wallet } from '@lace/cardano';
@@ -19,7 +19,7 @@ export interface WalletSetupMnemonicStepProps {
   onReset: (mnemonicStage?: MnemonicStage) => void;
   onNext: () => void;
   onStepNext?: (currentStage: MnemonicStage) => void;
-  mnemonicWordsInStep?: number;
+  isBackFromNextStep?: boolean;
   translations: TranslationsFor<
     | 'writePassphraseTitle'
     | 'enterPassphraseDescription'
@@ -48,7 +48,8 @@ export const WalletSetupMnemonicStepRevamp = ({
   renderVideoPopupContent,
   onWatchVideoClick,
   onCopyToClipboard,
-  onPasteFromClipboard
+  onPasteFromClipboard,
+  isBackFromNextStep = false
 }: WalletSetupMnemonicStepProps): React.ReactElement => {
   const initialMnemonicWordsConfirm = useMemo(() => mnemonic.map(() => ''), [mnemonic]);
   const [mnemonicStage, setMnemonicStage] = useState<MnemonicStage>('writedown');
@@ -57,9 +58,9 @@ export const WalletSetupMnemonicStepRevamp = ({
 
   // reset the state on mnemonic change
   useEffect(() => {
-    setMnemonicStage('writedown');
-    setMnemonicWordsConfirm(initialMnemonicWordsConfirm);
-  }, [initialMnemonicWordsConfirm, mnemonic]);
+    setMnemonicStage(isBackFromNextStep ? 'input' : 'writedown');
+    setMnemonicWordsConfirm(isBackFromNextStep ? mnemonic : initialMnemonicWordsConfirm);
+  }, [initialMnemonicWordsConfirm, isBackFromNextStep, mnemonic]);
 
   const pasteRecoveryPhrase = async (offset = 0) => {
     const copiedWords = await readMnemonicFromClipboard(mnemonic.length);


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-10089
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

On the registration screen, pressing back should take you to the input screen during create wallet

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes
