### PR TITLE
feat(ui): show full address on hover in dapp bridge [LW-100056]

### DIFF
--- a/packages/core/src/ui/components/DappAddressSections/DappAddressSections.tsx
+++ b/packages/core/src/ui/components/DappAddressSections/DappAddressSections.tsx
@@ -8,7 +8,7 @@ import { Typography } from 'antd';
 import styles from './DappAddressSections.module.scss';
 import { useTranslate } from '@src/ui/hooks';
 
-import { TransactionAssets, SummaryExpander, DappTransactionSummary } from '@lace/ui';
+import { TransactionAssets, SummaryExpander, DappTransactionSummary, Tooltip } from '@lace/ui';
 import classNames from 'classnames';
 
 interface GroupedAddressAssets {
@@ -118,7 +118,9 @@ export const DappAddressSections = ({
                   {t('package.core.dappTransaction.address')}
                 </Text>
                 <Text className={styles.value} data-testid="dapp-transaction-from-address-address">
-                  {addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}
+                  <Tooltip label={address}>
+                    <span>{addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}</span>
+                  </Tooltip>
                 </Text>
               </div>
               {(addressData.tokens.length > 0 || addressData.coins.length > 0) && (
@@ -169,7 +171,9 @@ export const DappAddressSections = ({
                   {t('package.core.dappTransaction.address')}
                 </Text>
                 <Text className={styles.value} data-testid="dapp-transaction-to-address">
-                  {addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}
+                  <Tooltip label={address}>
+                    <span>{addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}</span>
+                  </Tooltip>
                 </Text>
               </div>
               {(addressData.tokens.length > 0 || addressData.coins.length > 0) && (


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-10056
- [x] Screenshots added.

---

As a user reviewing a Tx in the dapp bridge,
I want to be able to see and copy the full address of the recipients displayed in the screen,
So I can verify addresses are correct before signing

## Proposed solution

This PR adds a tooltip over shortened addresses in the from/to section which shows the full address which can be checked and copied.

## Screenshots

![Bildschirmfoto 2024-03-22 um 14 01 52](https://github.com/input-output-hk/lace/assets/172414/b944708c-c4fd-4bd9-ad94-d221324893f7)

![Bildschirmfoto 2024-03-22 um 14 02 01](https://github.com/input-output-hk/lace/assets/172414/dac87b07-6b8b-4c0f-95d0-a8d22c79b2bf)
