### PR TITLE
Github Actions workflow improvements

### DIFF
--- a/.github/shared/build/action.yml
+++ b/.github/shared/build/action.yml
@@ -28,12 +28,12 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
         cache: 'yarn'
     - name: Node modules cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           node_modules

--- a/.github/workflows/build-dev-preview.yml
+++ b/.github/workflows/build-dev-preview.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Decrypt test data
         working-directory: ./packages/e2e-tests
         run: ./decrypt_secret.sh
@@ -28,7 +28,7 @@ jobs:
           DEFAULT_CHAIN: 'Preprod'
         run: yarn test:coverage --maxWorkers=2 --silent
       - name: Upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Lace (Developer Preview)
           path: apps/browser-extension-wallet/dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Decrypt test data
         working-directory: ./packages/e2e-tests
         run: ./decrypt_secret.sh
@@ -35,7 +35,7 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=8192'
         run: yarn test:coverage --maxWorkers=2 --silent
       - name: Upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lace
           path: apps/browser-extension-wallet/dist
@@ -57,7 +57,7 @@ jobs:
           eval "set -x ; $(cat apps/browser-extension-wallet/.env.* | grep ^USE_ | sed -r 's/false/true/' | sort --unique | sed -r 's/^/export /' | tr '\n' ';') set +x"
           yarn browser build
       - name: Upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lace--all-feature-flags
           path: apps/browser-extension-wallet/dist

--- a/.github/workflows/core-chromatic.yml
+++ b/.github/workflows/core-chromatic.yml
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 🧰 Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
 
       - name: 📝 Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ~/.yarn/berry/cache

--- a/.github/workflows/e2e-tests-linux.yml
+++ b/.github/workflows/e2e-tests-linux.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Decrypt test data
         working-directory: ./packages/e2e-tests
         run: ./decrypt_secret.sh
@@ -93,7 +93,7 @@ jobs:
           copyLatest: true
           ignoreMissingResults: true
       - name: Publish artifacts (logs, reports, screenshots)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-artifacts

--- a/.github/workflows/e2e-tests-win.yml
+++ b/.github/workflows/e2e-tests-win.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Decrypt test data
         working-directory: ./packages/e2e-tests
         run: ./decrypt_secret.sh
@@ -50,12 +50,12 @@ jobs:
         with:
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY }}
       - name: Save Lace extension build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lace-build
           path: ./apps/browser-extension-wallet/dist
       - name: Save Core build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: core-build
           path: ./packages/core/dist
@@ -70,29 +70,29 @@ jobs:
         shell: pwsh
         run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Decrypt test data
         working-directory: ./packages/e2e-tests
         run: ./decrypt_secret.sh
         env:
           WALLET_1_PASSWORD: ${{ secrets.WALLET_PASSWORD_TESTNET }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Get built extension
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: lace-build
           path: ./apps/browser-extension-wallet/dist
       - name: Get Core build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: core-build
           path: ./packages/core/dist
       - name: Node modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./packages/e2e-tests/node_modules
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -126,7 +126,7 @@ jobs:
           platform=Windows
           " > environment.properties
       - name: Publish artifacts (logs, reports, screenshots)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-artifacts
@@ -144,9 +144,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-artifacts
           path: ./packages/e2e-tests

--- a/.github/workflows/git-checks.yml
+++ b/.github/workflows/git-checks.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Block Fixup Commit Merge
         uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,8 +9,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/labeler@v4
+      - uses: actions/checkout@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           sync-labels: true

--- a/.github/workflows/packages-staking.yml
+++ b/.github/workflows/packages-staking.yml
@@ -21,16 +21,16 @@ jobs:
       - name: Setup Build Essential
         run: apt-get update && apt-get install build-essential -y
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
       - name: Node modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -45,7 +45,7 @@ jobs:
       - name: Run tests
         run: yarn workspace @lace/staking test:unit --coverage
       - name: Upload test coverage artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: staking-coverage
           path: packages/staking/coverage
@@ -55,7 +55,7 @@ jobs:
 #      - name: Build Ladle
 #        run: yarn workspace @lace/staking story:build
 #      - name: Upload Ladle artifacts
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: staking-ladle
 #          path: packages/staking/build
@@ -63,7 +63,7 @@ jobs:
 #        continue-on-error: true
 #        run: yarn workspace @lace/staking test:vr
 #      - name: Upload visual regression
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: staking-visual-regression
 #          path: packages/staking/.lostpixel

--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY  }}
       - name: Upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lightwallet
           path: apps/browser-extension-wallet/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
 

--- a/.github/workflows/safari-ci.yml
+++ b/.github/workflows/safari-ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download Lace dist artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: lace
           path: apps/browser-extension-wallet/dist
@@ -28,7 +28,7 @@ jobs:
         run: packages/e2e-tests/tools/convertChromeExtToSafari.sh
         shell: bash
       - name: Upload unsigned Safari build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lace-safari
           path: packages/e2e-tests/wallet-extension-safari-build/Lace/wallet-extension-safari-build/extension-build/Build/Products/Release

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Decrypt test data
         working-directory: ./packages/e2e-tests
         run: ./decrypt_secret.sh
@@ -62,7 +62,7 @@ jobs:
           updatePr: comment
           baseUrl: 'https://${{ secrets.E2E_REPORTS_USER }}:${{ secrets.E2E_REPORTS_PASSWORD }}@${{ secrets.E2E_REPORTS_URL }}'
       - name: Publish artifacts (logs, reports, screenshots)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-artifacts

--- a/.github/workflows/staking-chromatic.yml
+++ b/.github/workflows/staking-chromatic.yml
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 🧰 Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
 
       - name: 📝 Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ~/.yarn/berry/cache

--- a/.github/workflows/ui-toolkit-chromatic.yml
+++ b/.github/workflows/ui-toolkit-chromatic.yml
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 🧰 Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
 
       - name: 📝 Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ~/.yarn/berry/cache

--- a/apps/browser-extension-wallet/test/jest.config.js
+++ b/apps/browser-extension-wallet/test/jest.config.js
@@ -47,13 +47,5 @@ module.exports = createJestConfig({
     '!src/utils/test-utils.ts',
     '!src/utils/fake-api-request.ts'
   ],
-  setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock'],
-  transform: {
-    '^.+\\.tsx?$': [
-      'ts-jest',
-      {
-        tsconfig: './src/tsconfig.json'
-      }
-    ]
-  }
+  setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock']
 });

--- a/packages/cardano/test/jest.config.js
+++ b/packages/cardano/test/jest.config.js
@@ -22,20 +22,31 @@ module.exports = createJestConfig({
   testTimeout: 60000,
   testEnvironment: 'jsdom',
   collectCoverageFrom: [
-    'src/ui/components/**/*.{ts,tsx}',
-    'src/ui/hooks/**/*.{ts,tsx}',
-    'src/ui/util/**/*.{ts,tsx}',
-    'src/wallet/**/*.{ts,tsx}',
-    '!src/wallet/**/mock.ts'
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.stories.tsx',
+    '!src/**/*.test.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/types.ts',
+    '!src/**/index.{ts,tsx}',
+    '!src/wallet/test/mocks/*',
+    // files bellow fails to collect coverage as they are not imported in the tests
+    '!src/wallet/lib/config.ts',
+    '!src/wallet/util/calculate-deposit-reclaim.ts',
+    '!src/wallet/lib/get-total-minimum-coins.ts',
+    '!src/wallet/lib/build-transaction-props.ts',
+    '!src/wallet/util/observable.ts',
+    '!src/wallet/lib/providers.ts',
+    '!src/wallet/lib/set-missing-coins.ts',
+    '!src/ui/components/Voting/CatalystRegisterStep.tsx',
+    '!src/wallet/lib/hardware-wallet.ts',
+    '!src/ui/components/Voting/CurrentCatalystFund.tsx',
+    '!src/ui/components/Voting/DownloadCatalystStep.tsx',
+    '!src/ui/components/Voting/VotingParticipation.tsx',
+    '!src/ui/components/Voting/CatalystScanStep.tsx',
+    '!src/ui/components/Voting/CatalystPinStep.tsx',
+    '!src/ui/components/Voting/WaitForNextFundCard.tsx',
+    '!src/ui/components/Voting/CatalystConfirmationStep.tsx'
   ],
   setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock'],
-  transform: {
-    '^.+\\.tsx?$': [
-      'ts-jest',
-      {
-        tsconfig: './src/tsconfig.json'
-      }
-    ]
-  },
   workerThreads: true
 });

--- a/packages/common/src/.eslintrc.js
+++ b/packages/common/src/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  "extends": ["../../../.eslintrc.js"],
-  "parserOptions": {
-    "project": "./tsconfig.json",
-    "tsconfigRootDir": __dirname
+  extends: ['../../../.eslintrc.js'],
+  parserOptions: {
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname
   }
-}
+};

--- a/packages/common/test/jest.config.js
+++ b/packages/common/test/jest.config.js
@@ -19,13 +19,5 @@ module.exports = createJestConfig({
     'src/ui/hooks/**/*.{ts,tsx}',
     'src/ui/utils/**/*.{ts,tsx}'
   ],
-  setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock'],
-  transform: {
-    '^.+\\.tsx?$': [
-      'ts-jest',
-      {
-        tsconfig: './src/tsconfig.json'
-      }
-    ]
-  }
+  setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock']
 });

--- a/packages/core/src/.eslintrc.js
+++ b/packages/core/src/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  "extends": ["../../../.eslintrc.js"],
-  "parserOptions": {
-    "project": "./tsconfig.json",
-    "tsconfigRootDir": __dirname
+  extends: ['../../../.eslintrc.js'],
+  parserOptions: {
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname
   }
-}
+};

--- a/packages/core/test/jest.config.js
+++ b/packages/core/test/jest.config.js
@@ -20,13 +20,5 @@ module.exports = createJestConfig({
     'src/ui/utils/**/*.{ts,tsx}',
     'src/wallet/**/*.{ts,tsx}'
   ],
-  setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock'],
-  transform: {
-    '^.+\\.tsx?$': [
-      'ts-jest',
-      {
-        tsconfig: './src/tsconfig.json'
-      }
-    ]
-  }
+  setupFilesAfterEnv: ['./test/jest.setup.js', 'jest-canvas-mock']
 });

--- a/test/createJestConfig.js
+++ b/test/createJestConfig.js
@@ -31,7 +31,11 @@ const createJestConfig = (jestConfig) => {
     transform: {
       ...jestConfig.transform,
       ...esmExceptions.transform,
-      '^.+\\.(ts|tsx)$': 'ts-jest'
+      '^.+\\.(ts|tsx)$': [
+        'ts-jest', {
+          tsconfig: `${rootDir}/src/tsconfig.json`
+        }
+     ]
     },
     transformIgnorePatterns: [...transformIgnorePatterns, ...esmExceptions.transformIgnorePatterns]
   };


### PR DESCRIPTION
Improve code coverage and clean-up output log for cardano package.

With this change we eliminate from outpu errors like this one :point_down:
```
Failed to collect coverage from /Users/piotrczeglik/Work/PROJECTS/LACE/lace/packages/cardano/src/wallet/util/calculate-deposit-reclaim.ts
ERROR: Invalid file coverage object, missing keys, found:data
STACK: Error: Invalid file coverage object, missing keys, found:data
    at assertValidObject (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/istanbul-lib-coverage/lib/file-coverage.js:36:15)
    at new FileCoverage (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/istanbul-lib-coverage/lib/file-coverage.js:78:9)
    at CoverageMap.addFileCoverage (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/istanbul-lib-coverage/lib/coverage-map.js:109:21)
    at /Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/@jest/reporters/build/CoverageReporter.js:279:33
    at async Promise.all (index 4)
    at CoverageReporter._addUntestedFiles (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/@jest/reporters/build/CoverageReporter.js:296:7)
    at CoverageReporter.onRunComplete (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/@jest/reporters/build/CoverageReporter.js:171:5)
    at ReporterDispatcher.onRunComplete (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/@jest/core/build/ReporterDispatcher.js:71:9)
    at TestScheduler.scheduleTests (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/@jest/core/build/TestScheduler.js:306:5)
    at runJest (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/@jest/core/build/runJest.js:367:19)
    at _run10000 (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/@jest/core/build/cli/index.js:343:7)
    at runCLI (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/@jest/core/build/cli/index.js:198:3)
    at Object.run (/Users/piotrczeglik/Work/PROJECTS/LACE/lace/node_modules/jest-cli/build/run.js:130:37)
```

as we have a bunch of files which are not imported in tests nor have a test: 
```
    'src/wallet/lib/config.ts',
    'src/wallet/util/calculate-deposit-reclaim.ts',
    'src/wallet/lib/get-total-minimum-coins.ts',
    'src/wallet/lib/build-transaction-props.ts',
    'src/wallet/util/observable.ts',
    'src/wallet/lib/providers.ts',
    'src/wallet/lib/set-missing-coins.ts',
    'src/ui/components/Voting/CatalystRegisterStep.tsx',
    'src/wallet/lib/hardware-wallet.ts',
    'src/ui/components/Voting/CurrentCatalystFund.tsx',
    'src/ui/components/Voting/DownloadCatalystStep.tsx',
    'src/ui/components/Voting/VotingParticipation.tsx',
    'src/ui/components/Voting/CatalystScanStep.tsx',
    'src/ui/components/Voting/CatalystPinStep.tsx',
    'src/ui/components/Voting/WaitForNextFundCard.tsx',
    'src/ui/components/Voting/CatalystConfirmationStep.tsx'
```

This is what coveralls shows currently on [main](https://coveralls.io/github/input-output-hk/lace):

![image](https://github.com/input-output-hk/lace/assets/114646443/b4682e26-9dd9-46cc-8f50-5a51b7d73a9b)


This is what coveralls shows after [this change](https://coveralls.io/builds/66473504):

![image](https://github.com/input-output-hk/lace/assets/114646443/92855429-5e60-47dd-aad7-6faa7a887a5b)
