### PR TITLE
chore: improve post integration action

### DIFF
--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -34,7 +34,7 @@
     "prepare": "ts-patch install -s",
     "prettier": "run -T prettier --write .",
     "test": "run -T jest --config test/jest.config.js",
-    "test:coverage": "run -T test --coverage",
+    "test:coverage": "NODE_OPTIONS=\"--max-old-space-size=8192\" run -T test --coverage --silent",
     "test:e2e": "yarn exec echo \"No e2e tests on this app yet!\"",
     "watch": "NODE_OPTIONS='--openssl-legacy-provider' rm -rf dist & run -T webpack --config webpack.sw.dev.js --progress --watch & run -T webpack --config webpack.app.dev.js --progress --watch"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -20,7 +20,9 @@
     "build:babel": "babel --extensions .tsx ./tmp --out-dir dist/ --config-file ./babel.config.js",
     "build:cleanup": "rm -rf ./tmp",
     "build:svgr": "svgr ./raw --out-dir ./tmp --typescript",
-    "build:tsc": "tsc --project tsconfig.json"
+    "build:tsc": "tsc --project tsconfig.json",
+    "test": "echo \"@lace/icons: no test specified\"",
+    "test:coverage": "echo \"@lace/icons: no test specified\""
   },
   "devDependencies": {
     "@babel/cli": "^7.22.10",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,10 +22,10 @@
     "format": "yarn prettier --write '**/*.tsx'",
     "lint": "eslint .",
     "storybook": "NODE_OPTIONS=--openssl-legacy-provider; start-storybook -p 6006",
-    "test": "echo \"Error: no test specified\"",
+    "test": "echo \"@lace/ui: no test specified\"",
     "test-storybook": "test-storybook",
     "test-storybook:ci": "NODE_OPTIONS=--openssl-legacy-provider; export STORYBOOK_TEST=1; concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"yarn build-storybook && http-server storybook-static --port 6006\" \"wait-on http://127.0.0.1:6006/ && yarn test-storybook\"",
-    "test:coverage": "yarn test --coverage --silent",
+    "test:coverage": "echo \"@lace/ui: no test specified\"",
     "typecheck": "tsc --noEmit",
     "watch": "yarn build --watch"
   },


### PR DESCRIPTION
Improve post integration action to get rid of test run Fatal Error:

```
<--- Last few GCs --->

[5519:0x5766980]   289914 ms: Scavenge (reduce) 3913.7 (4142.6) -> 3913.2 (4142.6) MB, 6.6 / 0.0 ms  (average mu = 0.207, current mu = 0.220) allocation failure; 
[5519:0x5766980]   289929 ms: Scavenge (reduce) 3913.9 (4142.6) -> 3913.4 (4142.8) MB, 6.5 / 0.0 ms  (average mu = 0.207, current mu = 0.220) allocation failure; 
[5519:0x5766980]   289943 ms: Scavenge (reduce) 3914.2 (4142.8) -> 3913.7 (4143.1) MB, 6.4 / 0.0 ms  (average mu = 0.207, current mu = 0.220) allocation failure; 


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 1: 0xb6e500 node::Abort() [/opt/hostedtoolcache/node/18.12.1/x64/bin/node]
 2: 0xa7e632  [/opt/hostedtoolcache/node/18.12.1/x64/bin/node]
 3: 0xd47f20 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/opt/hostedtoolcache/node/18.12.1/x64/bin/node]
FAIL src/features/nfts/context/__test__/context.test.tsx
  ● Test suite failed to run

    A jest worker process (pid=5519) was terminated by another process: signal=SIGTERM, exitCode=null. Operating system logs may contain more information on why this occurred.

      at ChildProcessWorker._onExit (../../node_modules/jest-runner/node_modules/jest-worker/build/workers/ChildProcessWorker.js:3[70](https://github.com/input-output-hk/lace/actions/runs/8420025827/job/23053879871#step:5:71):23)


<--- Last few GCs --->

[5518:0x62df9[80](https://github.com/input-output-hk/lace/actions/runs/8420025827/job/23053879871#step:5:81)]   299414 ms: Scavenge (reduce) 3[91](https://github.com/input-output-hk/lace/actions/runs/8420025827/job/23053879871#step:5:92)3.5 (4140.5) -> 3913.3 (4140.7) MB, 6.5 / 0.0 ms  (average mu = 0.213, current mu = 0.199) allocation failure; 
[5518:0x62df980]   299422 ms: Scavenge (reduce) 3914.3 (4141.1) -> 3913.9 (4141.1) MB, 7.0 / 0.0 ms  (average mu = 0.213, current mu = 0.199) allocation failure; 
[5518:0x62df980]   29[94](https://github.com/input-output-hk/lace/actions/runs/8420025827/job/23053879871#step:5:95)32 ms: Scavenge (reduce) 3915.1 (4141.6) -> 3914.9 (4141.6) MB, 7.8 / 0.0 ms  (average mu = 0.213, current mu = 0.199) allocation failure;
```

and clean-up a bit output logs