### PR TITLE
fix: improve mnemonic check on create flow

### DIFF
--- a/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupMnemonicStepRevamp/WalletSetupMnemonicStepRevamp.tsx
+++ b/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupMnemonicStepRevamp/WalletSetupMnemonicStepRevamp.tsx
@@ -11,6 +11,7 @@ import { Dialog } from '@lace/ui';
 import { MnemonicWordsConfirmInputRevamp } from './MnemonicWordsConfirmInputRevamp';
 import { Wallet } from '@lace/cardano';
 import { readMnemonicFromClipboard, writeMnemonicToClipboard } from './wallet-utils';
+import isEqual from 'lodash/isEqual';
 
 export type MnemonicStage = 'writedown' | 'input';
 
@@ -118,7 +119,8 @@ export const WalletSetupMnemonicStepRevamp = ({
 
   const isSubmitEnabled =
     mnemonicStage === 'writedown' ||
-    Wallet.KeyManagement.util.validateMnemonic(Wallet.KeyManagement.util.joinMnemonicWords(mnemonicConfirm));
+    (Wallet.KeyManagement.util.validateMnemonic(Wallet.KeyManagement.util.joinMnemonicWords(mnemonicConfirm)) &&
+      isEqual(mnemonic, mnemonicConfirm));
 
   return (
     <>


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-10151
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Check that the entered password matches the created password in the create wallet onboarding flow

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes
