### PR TITLE
feat(ui): Flag addresses as own or foreign [LW-10061]

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/DappTransactionContainer.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/DappTransactionContainer.tsx
@@ -5,7 +5,7 @@ import { Flex } from '@lace/ui';
 import { useViewsFlowContext } from '@providers/ViewFlowProvider';
 
 import { Wallet } from '@lace/cardano';
-import { withAddressBookContext } from '@src/features/address-book/context';
+import { useAddressBookContext, withAddressBookContext } from '@src/features/address-book/context';
 import { useWalletStore } from '@stores';
 import { useFetchCoinPrice, useChainHistoryProvider } from '@hooks';
 import {
@@ -23,6 +23,7 @@ import { useCurrencyStore, useAppSettingsContext } from '@providers';
 import { logger } from '@lib/wallet-api-ui';
 import { useComputeTxCollateral } from '@hooks/useComputeTxCollateral';
 import { utxoAndBackendChainHistoryResolver } from '@src/utils/utxo-chain-history-resolver';
+import { AddressBookSchema, useDbStateValue } from '@lib/storage';
 
 interface DappTransactionContainerProps {
   errorMessage?: string;
@@ -42,6 +43,10 @@ export const DappTransactionContainer = withAddressBookContext(
       walletUI: { cardanoCoin },
       walletState
     } = useWalletStore();
+
+    const ownAddresses = useObservable(inMemoryWallet.addresses$)?.map((a) => a.address);
+    const { list: addressBook } = useAddressBookContext() as useDbStateValue<AddressBookSchema>;
+    const addressToNameMap = new Map(addressBook?.map((entry) => [entry.address as string, entry.name]));
 
     const { fiatCurrency } = useCurrencyStore();
     const { priceResult } = useFetchCoinPrice();
@@ -146,6 +151,8 @@ export const DappTransactionContainer = withAddressBookContext(
             errorMessage={errorMessage}
             toAddress={toAddressTokens}
             collateral={txCollateral}
+            ownAddresses={ownAddresses}
+            addressToNameMap={addressToNameMap}
           />
         ) : (
           <Skeleton loading />

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/DappTransactionContainer.test.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/DappTransactionContainer.test.tsx
@@ -30,12 +30,13 @@ import { DappTransactionContainer } from '../DappTransactionContainer';
 import '@testing-library/jest-dom';
 import { BehaviorSubject } from 'rxjs';
 import { act } from 'react-dom/test-utils';
-import { buildMockTx } from '@src/utils/mocks/tx';
+import { buildMockTx, sendingAddress } from '@src/utils/mocks/tx';
 import { Wallet } from '@lace/cardano';
 import { SignTxData } from '../types';
 import { getWrapper } from '../testing.utils';
 import { TransactionWitnessRequest } from '@cardano-sdk/web-extension';
 import { cardanoCoin } from '@src/utils/constants';
+import { AddressBookSchema } from '@lib/storage';
 
 const { Cardano, Crypto } = Wallet;
 
@@ -51,6 +52,7 @@ const mockedAssetsInfo = new Map([['id', 'data']]);
 const assetInfo$ = new BehaviorSubject(mockedAssetsInfo);
 const available$ = new BehaviorSubject([]);
 const signed$ = new BehaviorSubject([]);
+const addresses$ = new BehaviorSubject([sendingAddress]);
 const rewardAccounts$ = new BehaviorSubject([
   {
     // eslint-disable-next-line unicorn/consistent-destructuring
@@ -65,6 +67,7 @@ const protocolParameters$ = new BehaviorSubject({
 });
 
 const inMemoryWallet = {
+  addresses$,
   assetInfo$,
   balance: {
     utxo: {
@@ -133,12 +136,12 @@ jest.mock('react-i18next', () => {
   };
 });
 
-const addressList = ['addressList'];
+const addressBook: AddressBookSchema[] = [];
 jest.mock('@src/features/address-book/context', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ...jest.requireActual<any>('@src/features/address-book/context'),
   withAddressBookContext: mockWithAddressBookContext,
-  useAddressBookContext: () => ({ list: addressList })
+  useAddressBookContext: () => ({ list: addressBook })
 }));
 
 jest.mock('antd', () => {
@@ -332,7 +335,9 @@ describe('Testing DappTransactionContainer component', () => {
         errorMessage,
         coinSymbol: 'ADA',
         collateral: BigInt(1_000_000),
-        txInspectionDetails
+        txInspectionDetails,
+        ownAddresses: [sendingAddress.address],
+        addressToNameMap: new Map()
       },
       {}
     );

--- a/apps/browser-extension-wallet/src/lib/translations/en.json
+++ b/apps/browser-extension-wallet/src/lib/translations/en.json
@@ -1368,6 +1368,8 @@
   "core.receive.usedAddresses.copy": "Copy Address",
   "core.receive.usedAddresses.addressCopied": "Address copied",
   "core.receive.showUsedAddresses": "Show used addresses",
+  "core.addressTags.own": "own",
+  "core.addressTags.foreign": "foreign",
   "addressesDiscovery.overlay.title": "Your wallet is syncing, this might take a few minutes",
   "addressesDiscovery.toast.errorText": "Wallet failed to sync",
   "addressesDiscovery.toast.successText": "Wallet synced successfully",

--- a/apps/browser-extension-wallet/src/utils/mocks/tx.ts
+++ b/apps/browser-extension-wallet/src/utils/mocks/tx.ts
@@ -1,11 +1,13 @@
 /* eslint-disable no-magic-numbers */
 import { Wallet } from '@lace/cardano';
 
-const sendingAddress = Wallet.Cardano.PaymentAddress(
-  'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
-);
+export const sendingAddress = {
+  address: Wallet.Cardano.PaymentAddress(
+    'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+  )
+} as Wallet.KeyManagement.GroupedAddress;
 
-const receivingAddress = Wallet.Cardano.PaymentAddress(
+export const receivingAddress = Wallet.Cardano.PaymentAddress(
   'addr_test1qpfhhfy2qgls50r9u4yh0l7z67xpg0a5rrhkmvzcuqrd0znuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q9gw0lz'
 );
 
@@ -34,7 +36,7 @@ export const buildMockTx = (
       ]),
       inputs: args.inputs ?? [
         {
-          address: sendingAddress,
+          address: sendingAddress.address,
           index: 0,
           txId: Wallet.Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
         }
@@ -64,7 +66,7 @@ export const buildMockTx = (
           }
         },
         {
-          address: sendingAddress,
+          address: sendingAddress.address,
           value: {
             assets: new Map([
               [Wallet.Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'), BigInt(1)]

--- a/packages/core/src/ui/components/ActivityDetail/TransactionDetails.module.scss
+++ b/packages/core/src/ui/components/ActivityDetail/TransactionDetails.module.scss
@@ -102,29 +102,14 @@ $border-bottom: 1px solid var(--light-mode-light-grey-plus, var(--dark-mode-mid-
         font-weight: 500;
         line-height: 17px;
       }
+
+      &.addressTag {
+        gap: size_unit(1);
+      }
     }
 
     .timestamp {
       flex: 0 0 35%;
-    }
-
-    .amount {
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-      align-items: flex-end;
-
-      .ada {
-        color: var(--text-color-primary, #ffffff);
-      }
-
-      .fiat {
-        color: var(--text-color-secondary, #878e9e);
-      }
-
-      .addrName {
-        margin-bottom: size_unit(1);
-      }
     }
 
     .addressDetail {

--- a/packages/core/src/ui/components/ActivityDetail/TransactionDetails.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/TransactionDetails.tsx
@@ -2,10 +2,13 @@
 /* eslint-disable no-magic-numbers */
 import React from 'react';
 import cn from 'classnames';
-import { TransactionDetailAsset, TransactionMetadataProps, TxOutputInput, TxSummary } from './TransactionDetailAsset';
+
 import { Ellipsis, toast } from '@lace/common';
 import { Box } from '@lace/ui';
-import { useTranslate } from '@src/ui/hooks';
+import { useTranslate } from '@ui/hooks';
+import { getAddressTagTranslations, renderAddressTag } from '@ui/utils';
+
+import { TransactionDetailAsset, TransactionMetadataProps, TxOutputInput, TxSummary } from './TransactionDetailAsset';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { ActivityStatus } from '../Activity';
 import styles from './TransactionDetails.module.scss';
@@ -76,6 +79,7 @@ export interface TransactionDetailsProps {
   txSummary?: TxSummary[];
   coinSymbol: string;
   tooltipContent?: string;
+  ownAddresses: string[];
   addressToNameMap: Map<string, string>;
   isPopupView?: boolean;
   openExternalLink?: (url: string) => void;
@@ -122,6 +126,7 @@ export const TransactionDetails = ({
   txSummary = [],
   coinSymbol,
   pools,
+  ownAddresses,
   addressToNameMap,
   isPopupView,
   openExternalLink,
@@ -353,22 +358,19 @@ export const TransactionDetails = ({
                     </div>
                   )}
                   {(summary.addr as string[]).map((addr) => {
-                    const addrName = addressToNameMap?.get(addr);
                     const address = isPopupView ? (
                       <Ellipsis className={cn(styles.addr, styles.fiat)} text={addr} ellipsisInTheMiddle />
                     ) : (
                       <span className={cn(styles.addr, styles.fiat)}>{addr}</span>
                     );
                     return (
-                      <div key={addr} data-testid="tx-to-detail" className={cn(styles.addr, styles.detail)}>
-                        {addrName ? (
-                          <div className={styles.amount}>
-                            <span className={cn(styles.ada, styles.addrName)}>{addrName}</span>
-                            {address}
-                          </div>
-                        ) : (
-                          address
-                        )}
+                      <div
+                        key={addr}
+                        data-testid="tx-to-detail"
+                        className={cn([styles.detail, styles.addr, styles.addressTag])}
+                      >
+                        {address}
+                        {renderAddressTag(addr, getAddressTagTranslations(t), ownAddresses, addressToNameMap)}
                       </div>
                     );
                   })}
@@ -590,6 +592,8 @@ export const TransactionDetails = ({
             coinSymbol={coinSymbol}
             withSeparatorLine
             sendAnalytics={sendAnalyticsInputs}
+            ownAddresses={ownAddresses}
+            addressToNameMap={addressToNameMap}
           />
         )}
         {addrOutputs?.length > 0 && (
@@ -604,6 +608,8 @@ export const TransactionDetails = ({
             }}
             coinSymbol={coinSymbol}
             sendAnalytics={sendAnalyticsOutputs}
+            ownAddresses={ownAddresses}
+            addressToNameMap={addressToNameMap}
           />
         )}
         {metadata?.length > 0 && (

--- a/packages/core/src/ui/components/ActivityDetail/TransactionInputOutput.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/TransactionInputOutput.tsx
@@ -2,14 +2,18 @@
 import React, { useState } from 'react';
 import { Tooltip } from 'antd';
 import cn from 'classnames';
-import { addEllipsis, Button } from '@lace/common';
 
 import { InfoCircleOutlined, DownOutlined } from '@ant-design/icons';
+import { addEllipsis, Button } from '@lace/common';
+
 import { TxOutputInput } from './TransactionDetailAsset';
 import { TranslationsFor } from '../../utils/types';
 
 import { ReactComponent as BracketDown } from '../../assets/icons/bracket-down.component.svg';
 import styles from './TransactionInputOutput.module.scss';
+import { Flex } from '@lace/ui';
+import { getAddressTagTranslations, renderAddressTag } from '@ui/utils';
+import { useTranslate } from '@ui/hooks';
 
 const rotateOpen: React.CSSProperties = {
   transform: 'rotate(180deg)',
@@ -30,6 +34,8 @@ export interface TransactionInputOutputProps {
   translations: TranslationsFor<'address' | 'sent'>;
   coinSymbol: string;
   withSeparatorLine?: boolean;
+  ownAddresses: string[];
+  addressToNameMap: Map<string, string>;
   sendAnalytics?: () => void;
 }
 
@@ -42,9 +48,12 @@ export const TransactionInputOutput = ({
   translations,
   coinSymbol,
   withSeparatorLine,
+  ownAddresses,
+  addressToNameMap,
   sendAnalytics
 }: TransactionInputOutputProps): React.ReactElement => {
   const [isVisible, setIsVisible] = useState<boolean>();
+  const { t } = useTranslate();
 
   const animation = isVisible ? rotateOpen : rotateClose;
   const Icon = BracketDown ? <BracketDown className={styles.bracket} style={{ ...animation }} /> : <DownOutlined />;
@@ -79,9 +88,12 @@ export const TransactionInputOutput = ({
             <div className={styles.addressContainer} key={`${inputAddress}-${idx}`}>
               <div className={styles.row}>
                 <div className={styles.label}>{translations.address}</div>
-                <div data-testid="tx-address" className={cn(styles.addressDetail, styles.content)}>
-                  <Tooltip title={inputAddress}>{addEllipsis(inputAddress, 8, 8)}</Tooltip>
-                </div>
+                <Flex flexDirection="column" alignItems="flex-end" gap="$8">
+                  <div data-testid="tx-address" className={cn(styles.addressDetail, styles.content)}>
+                    <Tooltip title={inputAddress}>{addEllipsis(inputAddress, 8, 8)}</Tooltip>
+                  </div>
+                  {renderAddressTag(inputAddress, getAddressTagTranslations(t), ownAddresses, addressToNameMap)}
+                </Flex>
               </div>
 
               <div className={styles.row}>

--- a/packages/core/src/ui/components/ActivityDetail/__tests__/TransactionDetails.test.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/__tests__/TransactionDetails.test.tsx
@@ -35,6 +35,7 @@ describe('Testing ActivityDetailsBrowser component', () => {
     ],
     amountTransformer: (amount) => `${amount} $`,
     coinSymbol: 'ADA',
+    ownAddresses: [],
     addressToNameMap: new Map()
   };
 
@@ -82,5 +83,23 @@ describe('Testing ActivityDetailsBrowser component', () => {
   test('should not display transaction metadata if not available', async () => {
     const { queryByTestId: query } = render(<TransactionDetails {...addrListProps} />);
     expect(query('tx-metadata')).not.toBeInTheDocument();
+  });
+
+  test('should show address tag for inputs', async () => {
+    // use empty addrOutputs (so we get only one toggle button for inputs)
+    const { findByTestId } = render(<TransactionDetails {...addrListProps} addrOutputs={[]} />);
+    const inputsSectionToggle = await findByTestId('tx-addr-list_toggle');
+    fireEvent.click(inputsSectionToggle);
+
+    expect(await findByTestId('address-tag')).toBeVisible();
+  });
+
+  test('should show address tag for outputs', async () => {
+    // use empty addrOutputs (so we get only one toggle button for outputs)
+    const { findByTestId } = render(<TransactionDetails {...addrListProps} addrOutputs={[]} />);
+    const outputsSectionToggle = await findByTestId('tx-addr-list_toggle');
+    fireEvent.click(outputsSectionToggle);
+
+    expect(await findByTestId('address-tag')).toBeVisible();
   });
 });

--- a/packages/core/src/ui/components/DappAddressSections/DappAddressSections.tsx
+++ b/packages/core/src/ui/components/DappAddressSections/DappAddressSections.tsx
@@ -8,8 +8,9 @@ import { Typography } from 'antd';
 import styles from './DappAddressSections.module.scss';
 import { useTranslate } from '@src/ui/hooks';
 
-import { TransactionAssets, SummaryExpander, DappTransactionSummary, Tooltip } from '@lace/ui';
+import { Flex, TransactionAssets, SummaryExpander, DappTransactionSummary, Tooltip } from '@lace/ui';
 import classNames from 'classnames';
+import { getAddressTagTranslations, renderAddressTag } from '@ui/utils/render-address-tag';
 
 interface GroupedAddressAssets {
   nfts: Array<AssetInfoWithAmount>;
@@ -23,6 +24,8 @@ export interface DappAddressSectionProps {
   isToAddressesEnabled: boolean;
   isFromAddressesEnabled: boolean;
   coinSymbol: string;
+  ownAddresses: string[];
+  addressToNameMap?: Map<string, string>;
 }
 
 const tryDecodeAsUtf8 = (
@@ -101,7 +104,9 @@ export const DappAddressSections = ({
   groupedToAddresses,
   isToAddressesEnabled,
   isFromAddressesEnabled,
-  coinSymbol
+  coinSymbol,
+  ownAddresses,
+  addressToNameMap
 }: DappAddressSectionProps): React.ReactElement => {
   const { t } = useTranslate();
 
@@ -121,11 +126,14 @@ export const DappAddressSections = ({
                 <Text className={styles.label} data-testid="dapp-transaction-address-title">
                   {t('core.dappTransaction.address')}
                 </Text>
-                <Text className={styles.value} data-testid="dapp-transaction-address">
-                  <Tooltip label={address}>
-                    <span>{addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}</span>
-                  </Tooltip>
-                </Text>
+                <Flex flexDirection="column" alignItems="flex-end" gap="$8">
+                  <Text className={styles.value} data-testid="dapp-transaction-address">
+                    <Tooltip label={address}>
+                      <span>{addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}</span>
+                    </Tooltip>
+                  </Text>
+                  {renderAddressTag(address, getAddressTagTranslations(t), ownAddresses, addressToNameMap)}
+                </Flex>
               </div>
               {(addressData.tokens.length > 0 || addressData.coins.length > 0) && (
                 <>
@@ -179,11 +187,14 @@ export const DappAddressSections = ({
                 <Text className={styles.label} data-testid="dapp-transaction-address-title">
                   {t('core.dappTransaction.address')}
                 </Text>
-                <Text className={styles.value} data-testid="dapp-transaction-address">
-                  <Tooltip label={address}>
-                    <span>{addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}</span>
-                  </Tooltip>
-                </Text>
+                <Flex flexDirection="column" alignItems="flex-end" gap="$8">
+                  <Text className={styles.value} data-testid="dapp-transaction-address">
+                    <Tooltip label={address}>
+                      <span>{addEllipsis(address, charBeforeEllipsisName, charAfterEllipsisName)}</span>
+                    </Tooltip>
+                  </Text>
+                  {renderAddressTag(address, getAddressTagTranslations(t), ownAddresses, addressToNameMap)}
+                </Flex>
               </div>
               {(addressData.tokens.length > 0 || addressData.coins.length > 0) && (
                 <>

--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.stories.tsx
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { DappTransaction } from './DappTransaction';
 import { ComponentProps } from 'react';
 import { Wallet } from '@lace/cardano';
+import { AssetInfoWithAmount, TokenTransferValue } from '@cardano-sdk/core';
 
 const meta: Meta<typeof DappTransaction> = {
   title: 'DappTransaction',
@@ -15,14 +16,60 @@ const meta: Meta<typeof DappTransaction> = {
 export default meta;
 type Story = StoryObj<typeof DappTransaction>;
 
+const fromAddress = Wallet.Cardano.PaymentAddress(
+  'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+);
+
+const toAddress = Wallet.Cardano.PaymentAddress(
+  'addr_test1qpfhhfy2qgls50r9u4yh0l7z67xpg0a5rrhkmvzcuqrd0znuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q9gw0lz'
+);
+
+const toAddressBookAddress = Wallet.Cardano.PaymentAddress(
+  'addr_test1qzqgfww9svrzelxrnlml0nmdq4yevwke7ck7ae27u5ptmq5dwuq25p4hr0yxhg4pce0d6t7v4c0msy3vr3xppygn9ktqe77950'
+);
+
+const PXLAssetId = Wallet.Cardano.AssetId('1ec85dcee27f2d90ec1f9a1e4ce74a667dc9be8b184463223f9c960150584c');
+const PXLPolicyId = Wallet.Cardano.AssetId.getPolicyId(PXLAssetId);
+const PXLAssetName = Wallet.Cardano.AssetId.getAssetName(PXLAssetId);
+const PXLAssetInfo: AssetInfoWithAmount = {
+  // eslint-disable-next-line no-magic-numbers
+  amount: BigInt(100_000),
+  assetInfo: {
+    assetId: PXLAssetId,
+    name: PXLAssetName,
+    policyId: PXLPolicyId,
+    fingerprint: Wallet.Cardano.AssetFingerprint.fromParts(PXLPolicyId, PXLAssetName),
+    // eslint-disable-next-line no-magic-numbers
+    supply: BigInt(11_242_452_000),
+    quantity: BigInt(1)
+  }
+};
+
+const fromAddressTokens: TokenTransferValue = {
+  // eslint-disable-next-line no-magic-numbers
+  coins: BigInt(-100_000),
+  assets: new Map([[PXLAssetId, { ...PXLAssetInfo, amount: -PXLAssetInfo.amount }]])
+};
+
+const toAddressTokens: TokenTransferValue = {
+  // eslint-disable-next-line no-magic-numbers
+  coins: BigInt(100_000),
+  assets: new Map([[PXLAssetId, PXLAssetInfo]])
+};
+
 const data: ComponentProps<typeof DappTransaction> = {
   dappInfo: {
     name: 'Mint'
   },
   coinSymbol: 'tAda',
   fiatCurrencyCode: 'usd',
-  fromAddress: new Map(),
-  toAddress: new Map(),
+  ownAddresses: [fromAddress],
+  addressToNameMap: new Map([[toAddressBookAddress, 'test']]),
+  fromAddress: new Map([[fromAddress, fromAddressTokens]]),
+  toAddress: new Map([
+    [toAddress, toAddressTokens],
+    [toAddressBookAddress, toAddressTokens]
+  ]),
   // eslint-disable-next-line no-magic-numbers
   collateral: 150_000 as unknown as bigint,
   txInspectionDetails: {

--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
@@ -30,6 +30,8 @@ export interface DappTransactionProps {
   /** tokens send to being sent to or from the user */
   fromAddress: Map<Cardano.PaymentAddress, TokenTransferValue>;
   toAddress: Map<Cardano.PaymentAddress, TokenTransferValue>;
+  ownAddresses?: string[];
+  addressToNameMap?: Map<string, string>;
   collateral?: bigint;
 }
 
@@ -57,6 +59,7 @@ const groupAddresses = (addresses: Map<Cardano.PaymentAddress, TokenTransferValu
 
     const addressAssets = value.assets;
     for (const [, asset] of addressAssets) {
+      // NFTs are unique, so there is only a supply of 1
       if (asset.assetInfo.supply === BigInt(1)) {
         group.nfts.push(asset);
       } else {
@@ -110,7 +113,9 @@ export const DappTransaction = ({
   fiatCurrencyCode,
   fiatCurrencyPrice,
   coinSymbol,
-  dappInfo
+  dappInfo,
+  ownAddresses = [],
+  addressToNameMap = new Map()
 }: DappTransactionProps): React.ReactElement => {
   const { t } = useTranslate();
 
@@ -205,6 +210,8 @@ export const DappTransaction = ({
           groupedFromAddresses={groupedFromAddresses}
           groupedToAddresses={groupedToAddresses}
           coinSymbol={coinSymbol}
+          ownAddresses={ownAddresses}
+          addressToNameMap={addressToNameMap}
         />
       </div>
     </div>

--- a/packages/core/src/ui/hooks/useTranslate.tsx
+++ b/packages/core/src/ui/hooks/useTranslate.tsx
@@ -6,7 +6,7 @@ import fallbackInstance from '../lib/i18n';
 // If no i18n instance found in context then use the local one
 setI18n(fallbackInstance);
 
-interface UseTranslate {
+export interface UseTranslate {
   t: (key: string | string[], defaultValue?: string, options?: TOptions<StringMap>) => string;
   Trans: typeof Trans;
   i18n: typeof i18n;

--- a/packages/core/src/ui/utils/__tests__/render-address-tag.test.ts
+++ b/packages/core/src/ui/utils/__tests__/render-address-tag.test.ts
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Wallet } from '@lace/cardano';
+import { AddressTagTranslations, renderAddressTag } from '@ui/utils';
+
+const address = Wallet.Cardano.PaymentAddress(
+  'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+);
+
+const translations: AddressTagTranslations = {
+  own: 'own',
+  foreign: 'foreign'
+};
+
+describe('rendering correct tags for addresses', () => {
+  test('should tag own addresses', async () => {
+    const ownAddresses = [address];
+    const { findByTestId } = render(renderAddressTag(address, translations, ownAddresses));
+    expect(await findByTestId('address-tag')).toContainHTML(translations.own);
+  });
+
+  test('should tag foreign addresses', async () => {
+    const { findByTestId } = render(renderAddressTag(address, translations));
+    expect(await findByTestId('address-tag')).toContainHTML(translations.foreign);
+  });
+
+  test('should tag address book addresses', async () => {
+    const addressName = 'test';
+    const addressToNameMap = new Map<string, string>([[address, addressName]]);
+    const { findByTestId } = render(renderAddressTag(address, translations, [], addressToNameMap));
+    expect(await findByTestId('address-tag')).toContainHTML(`${translations.foreign}/${addressName}`);
+  });
+});

--- a/packages/core/src/ui/utils/index.ts
+++ b/packages/core/src/ui/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './sanitize-number';
 export * from './handle';
 export * from './address-form';
+export * from './render-address-tag';

--- a/packages/core/src/ui/utils/render-address-tag.tsx
+++ b/packages/core/src/ui/utils/render-address-tag.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { AddressTag, AddressTagVariants } from '@lace/ui';
+import { UseTranslate } from '@ui/hooks';
+
+export type AddressTagTranslations = { own: string; foreign: string };
+
+export const getAddressTagTranslations = (t: UseTranslate['t']): AddressTagTranslations => ({
+  own: t('core.addressTags.own'),
+  foreign: t('core.addressTags.foreign')
+});
+
+export const renderAddressTag = (
+  address: string,
+  translations: AddressTagTranslations,
+  ownAddresses: string[] = [],
+  addressToNameMap: Map<string, string> = new Map() // address, name
+): JSX.Element => {
+  const matchingAddressName = addressToNameMap.get(address);
+  return ownAddresses.includes(address) ? (
+    <AddressTag variant={AddressTagVariants.Own}>{translations.own}</AddressTag>
+  ) : (
+    <AddressTag variant={AddressTagVariants.Foreign}>
+      {translations.foreign}
+      {matchingAddressName ? `/${matchingAddressName}` : ''}
+    </AddressTag>
+  );
+};

--- a/packages/core/wallaby.js
+++ b/packages/core/wallaby.js
@@ -1,0 +1,7 @@
+module.exports = () => {
+  return {
+    testFramework: {
+      configFile: 'test/jest.config.js'
+    }
+  };
+};

--- a/packages/ui/src/design-system/address-tags/address-tag.component.tsx
+++ b/packages/ui/src/design-system/address-tags/address-tag.component.tsx
@@ -1,0 +1,31 @@
+import type { PropsWithChildren, HTMLAttributes } from 'react';
+import React from 'react';
+
+import cs from 'classnames';
+
+import * as cx from './address-tag.css';
+
+import type { AddressTagVariants } from './types';
+
+export type AddressBaseTageProps = PropsWithChildren<
+  HTMLAttributes<HTMLDivElement> & {
+    variant: AddressTagVariants;
+    testId?: string;
+  }
+>;
+
+export const AddressTag = ({
+  children,
+  className,
+  variant,
+  testId = 'address-tag',
+  ...restProps
+}: Readonly<AddressBaseTageProps>): JSX.Element => (
+  <div
+    {...restProps}
+    data-testid={testId}
+    className={cs(className, cx.addressTag({ scheme: variant }))}
+  >
+    {children}
+  </div>
+);

--- a/packages/ui/src/design-system/address-tags/address-tag.css.ts
+++ b/packages/ui/src/design-system/address-tags/address-tag.css.ts
@@ -1,0 +1,33 @@
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '../../design-tokens';
+
+import { AddressTagVariants } from './types';
+
+export const addressTag = recipe({
+  base: {
+    fontSize: vars.fontSizes.$12,
+    fontWeight: vars.fontWeights.$medium,
+    borderRadius: vars.radius.$medium,
+    padding: `0 ${vars.spacing.$8}`,
+    display: 'flex',
+    alignItems: 'center',
+    height: vars.spacing.$24,
+  },
+  variants: {
+    scheme: {
+      [AddressTagVariants.Own]: {
+        color: vars.colors.$address_tag_own_color,
+        backgroundColor: vars.colors.$address_tag_own_bgColor,
+      },
+      [AddressTagVariants.Handle]: {
+        color: vars.colors.$address_tag_handle_color,
+        backgroundColor: vars.colors.$address_tag_handle_bgColor,
+      },
+      [AddressTagVariants.Foreign]: {
+        color: vars.colors.$address_tag_foreign_color,
+        backgroundColor: vars.colors.$address_tag_foreign_bgColor,
+      },
+    },
+  },
+});

--- a/packages/ui/src/design-system/address-tags/address-tags.stories.tsx
+++ b/packages/ui/src/design-system/address-tags/address-tags.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import type { Meta } from '@storybook/react';
+
+import { ThemeColorScheme, LocalThemeProvider } from '../../design-tokens';
+import { page, Section, Variants } from '../decorators';
+import { Cell, Grid } from '../grid';
+
+import { AddressTag } from './address-tag.component';
+import { AddressTagVariants } from './types';
+
+export default {
+  title: 'AddressTag',
+  decorators: [
+    page({
+      title: 'Address Tag',
+      subtitle: 'Simple component to flag addresses as own, handle or foreign.',
+    }),
+  ],
+} as Meta;
+
+export const Overview = (): JSX.Element => {
+  const variantsData = [
+    {
+      Component: AddressTag,
+      variant: AddressTagVariants.Own,
+    },
+    {
+      Component: AddressTag,
+      variant: AddressTagVariants.Handle,
+    },
+    {
+      Component: AddressTag,
+      variant: AddressTagVariants.Foreign,
+    },
+  ];
+  const renderTable = (showHeader = false): JSX.Element => (
+    <Variants.Table
+      headers={showHeader ? variantsData.map(v => v.variant) : []}
+    >
+      <Variants.Row>
+        {variantsData.map(({ Component, variant }) => (
+          <Variants.Cell key={variant}>
+            <Component variant={variant}>{variant}</Component>
+          </Variants.Cell>
+        ))}
+      </Variants.Row>
+    </Variants.Table>
+  );
+
+  return (
+    <Grid columns="$1">
+      <Cell>
+        <Section title="Main components">
+          <>
+            {renderTable(true)}
+            <LocalThemeProvider colorScheme={ThemeColorScheme.Dark}>
+              <div style={{ color: 'white' }}>{renderTable()}</div>
+            </LocalThemeProvider>
+          </>
+        </Section>
+      </Cell>
+    </Grid>
+  );
+};

--- a/packages/ui/src/design-system/address-tags/index.ts
+++ b/packages/ui/src/design-system/address-tags/index.ts
@@ -1,0 +1,2 @@
+export { AddressTag } from './address-tag.component';
+export { AddressTagVariants } from './types';

--- a/packages/ui/src/design-system/address-tags/types.ts
+++ b/packages/ui/src/design-system/address-tags/types.ts
@@ -1,0 +1,5 @@
+export enum AddressTagVariants {
+  Own = 'Own',
+  Handle = 'Handle',
+  Foreign = 'Foreign',
+}

--- a/packages/ui/src/design-system/index.ts
+++ b/packages/ui/src/design-system/index.ts
@@ -53,3 +53,4 @@ export { SummaryExpander } from './summary-expander';
 export * from './auto-suggest-box';
 export * from './table';
 export { InfoBar } from './info-bar';
+export * from './address-tags';

--- a/packages/ui/src/design-tokens/colors.data.ts
+++ b/packages/ui/src/design-tokens/colors.data.ts
@@ -308,6 +308,13 @@ export const colors = {
   $info_bar_container_bgColor: '',
   $info_bar_message_color: '',
   $info_bar_icon_color: '',
+
+  $address_tag_own_color: '',
+  $address_tag_own_bgColor: '',
+  $address_tag_handle_color: '',
+  $address_tag_handle_bgColor: '',
+  $address_tag_foreign_color: '',
+  $address_tag_foreign_bgColor: '',
 };
 
 export type Colors = typeof colors;

--- a/packages/ui/src/design-tokens/theme/dark-theme.css.ts
+++ b/packages/ui/src/design-tokens/theme/dark-theme.css.ts
@@ -409,6 +409,16 @@ const colors: Colors = {
   $info_bar_container_bgColor: darkColorScheme.$primary_dark_grey_plus,
   $info_bar_icon_color: darkColorScheme.$secondary_data_pink,
   $info_bar_message_color: darkColorScheme.$primary_light_grey,
+
+  $address_tag_own_color: darkColorScheme.$secondary_data_pink,
+  $address_tag_own_bgColor: rgba(darkColorScheme.$secondary_data_pink, 0.1),
+  $address_tag_handle_color: darkColorScheme.$primary_accent_purple,
+  $address_tag_handle_bgColor: rgba(
+    darkColorScheme.$primary_accent_purple,
+    0.1,
+  ),
+  $address_tag_foreign_color: darkColorScheme.$primary_dark_grey,
+  $address_tag_foreign_bgColor: darkColorScheme.$primary_light_grey,
 };
 
 const elevation: Elevation = {

--- a/packages/ui/src/design-tokens/theme/light-theme.css.ts
+++ b/packages/ui/src/design-tokens/theme/light-theme.css.ts
@@ -437,6 +437,16 @@ const colors: Colors = {
   $info_bar_container_bgColor: lightColorScheme.$secondary_cream,
   $info_bar_icon_color: lightColorScheme.$secondary_data_pink,
   $info_bar_message_color: lightColorScheme.$primary_black,
+
+  $address_tag_own_color: lightColorScheme.$secondary_data_pink,
+  $address_tag_own_bgColor: rgba(lightColorScheme.$secondary_data_pink, 0.1),
+  $address_tag_handle_color: lightColorScheme.$primary_accent_purple,
+  $address_tag_handle_bgColor: rgba(
+    lightColorScheme.$primary_accent_purple,
+    0.1,
+  ),
+  $address_tag_foreign_color: lightColorScheme.$primary_dark_grey,
+  $address_tag_foreign_bgColor: lightColorScheme.$primary_light_grey,
 };
 
 export const elevation: Elevation = {


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-9035
- [x] Tests added
- [x] Screenshots added.

---

## Proposed solution

adds a new `AddressTag` component to the `@lace/ui` toolkit with variants:
- tagging _own_ addresses of the active wallet
- tagging _address book_ contacts (by address) with the contact name
- tagging all other addresses as _foreign_

Integrates the logic + address tag component in DApp tx summary (from/to section) and activity feed details

## Screenshots

DApp tx summary:
![image](https://github.com/input-output-hk/lace/assets/172414/a0cf62f9-4ff8-4de0-8a40-0d6b059141a5)

Tx Activity details:
![Bildschirmfoto 2024-04-03 um 14 35 41](https://github.com/input-output-hk/lace/assets/172414/c64d1e7b-1163-4d16-a6db-2ce9229b0b62)
