### PR TITLE
Remove build lace artifact with all features enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,19 +45,3 @@ jobs:
           github-token: ${{ secrets.COVERALLS_REPO_TOKEN  }}
           allow-empty: true
           compare-ref: main
-      - name: Rebuild a version of Lace with feature flags enabled
-        shell: bash
-        env:
-          LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY  }}
-          POSTHOG_PRODUCTION_TOKEN_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_MAINNET || '' }}
-          POSTHOG_PRODUCTION_TOKEN_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREPROD || '' }}
-          POSTHOG_PRODUCTION_TOKEN_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREVIEW || '' }}
-          PRODUCTION_MODE_TRACKING: ${{ startsWith(github.ref, 'refs/heads/release') && 'true' || 'false' }}
-        run: |
-          eval "set -x ; $(cat apps/browser-extension-wallet/.env.* | grep ^USE_ | sed -r 's/false/true/' | sort --unique | sed -r 's/^/export /' | tr '\n' ';') set +x"
-          yarn browser build
-      - name: Upload build
-        uses: actions/upload-artifact@v4
-        with:
-          name: lace--all-feature-flags
-          path: apps/browser-extension-wallet/dist


### PR DESCRIPTION
Remove step from CI which builds lace artifact with all features enabled which is not used anywhere.

With this change we can save 5 minutes per each CI run.