### PR TITLE
chore: use actions variables to pass Cardano Services urls

### DIFF
--- a/.github/shared/build/action.yml
+++ b/.github/shared/build/action.yml
@@ -5,6 +5,15 @@ inputs:
     description: 'Build developer preview of Lace'
     required: false
     default: 'false'
+  CARDANO_SERVICES_URL_MAINNET:
+    description: 'Cardano services mainnet url'
+    required: true
+  CARDANO_SERVICES_URL_PREPROD:
+    description: 'Cardano services preprod url'
+    required: true
+  CARDANO_SERVICES_URL_PREVIEW:
+    description: 'Cardano services preview url'
+    required: true
   LACE_EXTENSION_KEY:
     description: 'Public extended manifest key'
     required: true
@@ -32,6 +41,7 @@ runs:
       with:
         node-version-file: '.nvmrc'
         cache: 'yarn'
+
     - name: Node modules cache
       uses: actions/cache@v4
       with:
@@ -39,13 +49,18 @@ runs:
           node_modules
           **/node_modules
         key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
     - name: Install dependencies
       shell: bash
       run: yarn install --immutable --inline-builds
+
     - name: Build dist version
       shell: bash
       env:
         BUILD_DEV_PREVIEW: ${{ inputs.BUILD_DEV_PREVIEW }}
+        CARDANO_SERVICES_URL_MAINNET: ${{ inputs.CARDANO_SERVIICES_URL_MAINNET }}
+        CARDANO_SERVICES_URL_PREPROD: ${{ inputs.CARDANO_SERVIICES_URL_PREPROD }}
+        CARDANO_SERVICES_URL_PREVIEW: ${{ inputs.CARDANO_SERVIICES_URL_PREVIEW }}
         LACE_EXTENSION_KEY: ${{ inputs.LACE_EXTENSION_KEY }}
         POSTHOG_PRODUCTION_TOKEN_MAINNET: ${{ inputs.POSTHOG_PRODUCTION_TOKEN_MAINNET }}
         POSTHOG_PRODUCTION_TOKEN_PREPROD: ${{ inputs.POSTHOG_PRODUCTION_TOKEN_PREPROD }}

--- a/.github/workflows/build-dev-preview.yml
+++ b/.github/workflows/build-dev-preview.yml
@@ -18,6 +18,9 @@ jobs:
         uses: ./.github/shared/build
         with:
           BUILD_DEV_PREVIEW: 'true'
+          CARDANO_SERVICES_URL_MAINNET: ${{ vars.CARDANO_SERVICES_URL_DEV_MAINNET }}
+          CARDANO_SERVICES_URL_PREPROD: ${{ vars.CARDANO_SERVICES_URL_DEV_PREPROD }}
+          CARDANO_SERVICES_URL_PREVIEW: ${{ vars.CARDANO_SERVICES_URL_DEV_PREVIEW }}
           LACE_EXTENSION_KEY: ${{ secrets.DEV_PREVIEW_MANIFEST_PUBLIC_KEY  }}
           PRODUCTION_MODE_TRACKING: 'false'
       - name: Check for linter issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,32 +13,41 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Decrypt test data
         working-directory: ./packages/e2e-tests
         run: ./decrypt_secret.sh
         env:
           WALLET_1_PASSWORD: ${{ secrets.WALLET_PASSWORD_TESTNET }}
+
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:
+          CARDANO_SERVICES_URL_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_MAINNET || vars.CARDANO_SERVICES_URL_DEV_MAINNET }}
+          CARDANO_SERVICES_URL_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREPROD || vars.CARDANO_SERVICES_URL_DEV_PREPROD }}
+          CARDANO_SERVICES_URL_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREVIEW || vars.CARDANO_SERVICES_URL_DEV_PREVIEW }}
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY  }}
           POSTHOG_PRODUCTION_TOKEN_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_MAINNET || '' }}
           POSTHOG_PRODUCTION_TOKEN_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREPROD || '' }}
           POSTHOG_PRODUCTION_TOKEN_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREVIEW || '' }}
           PRODUCTION_MODE_TRACKING: ${{ startsWith(github.ref, 'refs/heads/release') && 'true' || 'false' }}
+
       - name: Check for linter issues
         run: yarn lint
+
       - name: Run unit tests, generate test coverage report
         env:
           AVAILABLE_CHAINS: 'Preprod,Preview,Mainnet'
           DEFAULT_CHAIN: 'Preprod'
           NODE_OPTIONS: '--max_old_space_size=8192'
         run: yarn test:coverage --maxWorkers=2 --silent
+
       - name: Upload build
         uses: actions/upload-artifact@v4
         with:
           name: lace
           path: apps/browser-extension-wallet/dist
+
       - name: Upload Coveralls report
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,16 @@ jobs:
         env:
           WALLET_1_PASSWORD: ${{ secrets.WALLET_PASSWORD_TESTNET }}
 
+      - name: Log vars context
+        run: echo '${{ toJSON(vars) }}'
+
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:
           CARDANO_SERVICES_URL_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_MAINNET || vars.CARDANO_SERVICES_URL_DEV_MAINNET }}
           CARDANO_SERVICES_URL_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREPROD || vars.CARDANO_SERVICES_URL_DEV_PREPROD }}
           CARDANO_SERVICES_URL_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREVIEW || vars.CARDANO_SERVICES_URL_DEV_PREVIEW }}
-          LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY  }}
+          LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY }}
           POSTHOG_PRODUCTION_TOKEN_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_MAINNET || '' }}
           POSTHOG_PRODUCTION_TOKEN_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREPROD || '' }}
           POSTHOG_PRODUCTION_TOKEN_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && secrets.POSTHOG_PRODUCTION_TOKEN_PREVIEW || '' }}
@@ -51,6 +54,6 @@ jobs:
       - name: Upload Coveralls report
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.COVERALLS_REPO_TOKEN  }}
+          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
           allow-empty: true
           compare-ref: main

--- a/.github/workflows/e2e-tests-linux.yml
+++ b/.github/workflows/e2e-tests-linux.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:
+          CARDANO_SERVICES_URL_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_MAINNET || vars.CARDANO_SERVICES_URL_DEV_MAINNET }}
+          CARDANO_SERVICES_URL_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREPROD || vars.CARDANO_SERVICES_URL_DEV_PREPROD }}
+          CARDANO_SERVICES_URL_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREVIEW || vars.CARDANO_SERVICES_URL_DEV_PREVIEW }}
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY }}
       - name: Start XVFB
         run: |

--- a/.github/workflows/e2e-tests-win.yml
+++ b/.github/workflows/e2e-tests-win.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:
+          CARDANO_SERVICES_URL_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_MAINNET || vars.CARDANO_SERVICES_URL_DEV_MAINNET }}
+          CARDANO_SERVICES_URL_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREPROD || vars.CARDANO_SERVICES_URL_DEV_PREPROD }}
+          CARDANO_SERVICES_URL_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREVIEW || vars.CARDANO_SERVICES_URL_DEV_PREVIEW }}
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY }}
       - name: Save Lace extension build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:
+          CARDANO_SERVICES_URL_MAINNET: ${{ vars.CARDANO_SERVICES_URL_DEV_MAINNET }}
+          CARDANO_SERVICES_URL_PREPROD: ${{ vars.CARDANO_SERVICES_URL_DEV_PREPROD }}
+          CARDANO_SERVICES_URL_PREVIEW: ${{ vars.CARDANO_SERVICES_URL_DEV_PREVIEW }}
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY  }}
       - name: Upload build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build dist version of Lace
         uses: ./.github/shared/build
         with:
+          CARDANO_SERVICES_URL_MAINNET: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_MAINNET || vars.CARDANO_SERVICES_URL_DEV_MAINNET }}
+          CARDANO_SERVICES_URL_PREPROD: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREPROD || vars.CARDANO_SERVICES_URL_DEV_PREPROD }}
+          CARDANO_SERVICES_URL_PREVIEW: ${{ startsWith(github.ref, 'refs/heads/release') && vars.CARDANO_SERVICES_URL_LIVE_PREVIEW || vars.CARDANO_SERVICES_URL_DEV_PREVIEW }}
           LACE_EXTENSION_KEY: ${{ secrets.MANIFEST_PUBLIC_KEY }}
       - name: Start XVFB
         run: |

--- a/apps/browser-extension-wallet/webpack.app.dev.js
+++ b/apps/browser-extension-wallet/webpack.app.dev.js
@@ -8,4 +8,10 @@ require('dotenv-defaults').config({
   defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
 });
 
+console.log('WEBPACK Build App Dev');
+console.log('CARDANO SERVICES URL MAINNET: ', process.env.CARDANO_SERVICES_URL_MAINNET);
+console.log('CARDANO SERVICES URL PREPROD: ', process.env.CARDANO_SERVICES_URL_PREPROD);
+console.log('CARDANO SERVICES URL PREVIEW: ', process.env.CARDANO_SERVICES_URL_PREVIEW);
+console.log('CARDANO SERVICES URL SANCHONET: ', process.env.CARDANO_SERVICES_URL_SANCHONET);
+
 module.exports = (env) => merge(createDevConfig({ devServerPort: 3001 })(env), appConfig());

--- a/apps/browser-extension-wallet/webpack.app.prod.js
+++ b/apps/browser-extension-wallet/webpack.app.prod.js
@@ -5,7 +5,14 @@ const appConfig = require('./webpack.common.app');
 require('dotenv-defaults').config({
   path: './.env',
   encoding: 'utf8',
-  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
+  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults',
+  override: true
 });
+
+console.log('WEBPACK Build App Prod');
+console.log('CARDANO SERVICES URL MAINNET: ', process.env.CARDANO_SERVICES_URL_MAINNET);
+console.log('CARDANO SERVICES URL PREPROD: ', process.env.CARDANO_SERVICES_URL_PREPROD);
+console.log('CARDANO SERVICES URL PREVIEW: ', process.env.CARDANO_SERVICES_URL_PREVIEW);
+console.log('CARDANO SERVICES URL SANCHONET: ', process.env.CARDANO_SERVICES_URL_SANCHONET);
 
 module.exports = () => merge(prodConfig(), appConfig());

--- a/apps/browser-extension-wallet/webpack.common.app.js
+++ b/apps/browser-extension-wallet/webpack.common.app.js
@@ -4,11 +4,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin');
 const { merge } = require('webpack-merge');
 const commonConfig = require('./webpack.common');
-require('dotenv-defaults').config({
-  path: './.env',
-  encoding: 'utf8',
-  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
-});
 
 module.exports = () =>
   merge(commonConfig(), {

--- a/apps/browser-extension-wallet/webpack.common.dev.js
+++ b/apps/browser-extension-wallet/webpack.common.dev.js
@@ -40,11 +40,13 @@ module.exports =
         cache: { type: 'filesystem' },
         plugins: [
           new Dotenv({
-            path: '.env',
+            path: './.env',
             safe: false,
             silent: false,
+            defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? '.env.devpreview' : true,
             systemvars: true,
-            allowEmptyValues: true
+            allowEmptyValues: true,
+            override: true
           }),
           new CopyPlugin({
             patterns: [

--- a/apps/browser-extension-wallet/webpack.common.dev.js
+++ b/apps/browser-extension-wallet/webpack.common.dev.js
@@ -3,11 +3,6 @@ const { merge } = require('webpack-merge');
 const CopyPlugin = require('copy-webpack-plugin');
 const { transformManifest } = require('./webpack-utils');
 const Dotenv = require('dotenv-webpack');
-require('dotenv-defaults').config({
-  path: './.env',
-  encoding: 'utf8',
-  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
-});
 
 const serverConfig = (RUN_DEV_SERVER, port) =>
   RUN_DEV_SERVER
@@ -48,7 +43,6 @@ module.exports =
             path: '.env',
             safe: false,
             silent: false,
-            defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? '.env.devpreview' : true,
             systemvars: true,
             allowEmptyValues: true
           }),

--- a/apps/browser-extension-wallet/webpack.common.js
+++ b/apps/browser-extension-wallet/webpack.common.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const { NormalModuleReplacementPlugin, ProvidePlugin, IgnorePlugin, EnvironmentPlugin } = require('webpack');
-const Dotenv = require('dotenv-webpack');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
@@ -81,14 +80,6 @@ module.exports = () => {
         typescript: {
           configFile: 'src/tsconfig.json'
         }
-      }),
-      new Dotenv({
-        path: '.env',
-        safe: false,
-        silent: false,
-        defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? '.env.devpreview' : true,
-        systemvars: true,
-        allowEmptyValues: true
       }),
       new EnvironmentPlugin({
         APP_VERSION: app_version,

--- a/apps/browser-extension-wallet/webpack.common.prod.js
+++ b/apps/browser-extension-wallet/webpack.common.prod.js
@@ -2,11 +2,6 @@ const TerserPlugin = require('terser-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const { transformManifest } = require('./webpack-utils');
 const Dotenv = require('dotenv-webpack');
-require('dotenv-defaults').config({
-  path: './.env',
-  encoding: 'utf8',
-  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
-});
 
 module.exports = () => ({
   mode: 'production',
@@ -16,7 +11,6 @@ module.exports = () => ({
       path: '.env',
       safe: false,
       silent: false,
-      defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? '.env.devpreview' : true,
       systemvars: true,
       allowEmptyValues: true
     }),

--- a/apps/browser-extension-wallet/webpack.common.prod.js
+++ b/apps/browser-extension-wallet/webpack.common.prod.js
@@ -8,11 +8,13 @@ module.exports = () => ({
   devtool: false,
   plugins: [
     new Dotenv({
-      path: '.env',
+      path: './.env',
       safe: false,
       silent: false,
+      defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? '.env.devpreview' : true,
       systemvars: true,
-      allowEmptyValues: true
+      allowEmptyValues: true,
+      override: true
     }),
     new CopyPlugin({
       patterns: [

--- a/apps/browser-extension-wallet/webpack.common.sw.js
+++ b/apps/browser-extension-wallet/webpack.common.sw.js
@@ -1,11 +1,6 @@
 const path = require('path');
 const { merge } = require('webpack-merge');
 const commonConfig = require('./webpack.common');
-require('dotenv-defaults').config({
-  path: './.env',
-  encoding: 'utf8',
-  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
-});
 
 // service worker script (background.ts) needs a separate webpack config,
 // because it needs a different loader for WASM

--- a/apps/browser-extension-wallet/webpack.sw.dev.js
+++ b/apps/browser-extension-wallet/webpack.sw.dev.js
@@ -8,4 +8,10 @@ require('dotenv-defaults').config({
   defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
 });
 
+console.log('WEBPACK Build Sw Dev');
+console.log('CARDANO SERVICES URL MAINNET: ', process.env.CARDANO_SERVICES_URL_MAINNET);
+console.log('CARDANO SERVICES URL PREPROD: ', process.env.CARDANO_SERVICES_URL_PREPROD);
+console.log('CARDANO SERVICES URL PREVIEW: ', process.env.CARDANO_SERVICES_URL_PREVIEW);
+console.log('CARDANO SERVICES URL SANCHONET: ', process.env.CARDANO_SERVICES_URL_SANCHONET);
+
 module.exports = (env) => merge(createDevConfig({ devServerPort: 3000 })(env), swConfig());

--- a/apps/browser-extension-wallet/webpack.sw.prod.js
+++ b/apps/browser-extension-wallet/webpack.sw.prod.js
@@ -5,8 +5,15 @@ const swConfig = require('./webpack.common.sw');
 require('dotenv-defaults').config({
   path: './.env',
   encoding: 'utf8',
-  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
+  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults',
+  override: true
 });
+
+console.log('WEBPACK Build Sw Prod');
+console.log('CARDANO SERVICES URL MAINNET: ', process.env.CARDANO_SERVICES_URL_MAINNET);
+console.log('CARDANO SERVICES URL PREPROD: ', process.env.CARDANO_SERVICES_URL_PREPROD);
+console.log('CARDANO SERVICES URL PREVIEW: ', process.env.CARDANO_SERVICES_URL_PREVIEW);
+console.log('CARDANO SERVICES URL SANCHONET: ', process.env.CARDANO_SERVICES_URL_SANCHONET);
 
 module.exports = () =>
   merge(


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-10078](https://input-output.atlassian.net/browse/LW-10078)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

Use Cardano services urls for Mainnet, Preprod, and Preview from Github actions variables instead of hardcoded values in .env.defaults file

![image](https://github.com/input-output-hk/lace/assets/114646443/6d34c473-8f5f-46a2-9ee0-a25299b6e756)

Default Cardano Services values for CI jobs are **DEV** `CARDANO_SERVICES_URL_DEV_*`, whereas for the release branches we use **LIVE** `CARDANO_SERVICES_URL_LIVE_*`

[LW-10078]: https://input-output.atlassian.net/browse/LW-10078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ