### PR TITLE
fix(extension): do not render BrowsePoolsPreferencesCard for hardware wallets [LW-10202]

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingContainer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingContainer.tsx
@@ -134,7 +134,9 @@ export const StakingContainer = (): React.ReactElement => {
           isMultidelegationSupportedByDevice
         }}
       >
-        <StakingSkeleton>{multiDelegationEnabled ? <MultiDelegationStaking /> : <Staking />}</StakingSkeleton>
+        <StakingSkeleton multiDelegationEnabled={multiDelegationEnabled}>
+          {multiDelegationEnabled ? <MultiDelegationStaking /> : <Staking />}
+        </StakingSkeleton>
       </OutsideHandlesProvider>
     </Layout>
   );

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingSkeleton.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingSkeleton.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-statements */
 /* eslint-disable complexity */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { PropsWithChildren, useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import isNumber from 'lodash/isNumber';
 import { Skeleton } from 'antd';
 import { useTranslation } from 'react-i18next';
@@ -14,8 +14,13 @@ import LightBulb from '@src/assets/icons/light.svg';
 import { BrowsePoolsPreferencesCard } from '@lace/staking';
 import { Flex } from '@lace/ui';
 
+type StakingSkeletonProps = {
+  children: ReactNode;
+  multiDelegationEnabled: boolean;
+};
+
 // eslint-disable-next-line @typescript-eslint/ban-types
-export const StakingSkeleton = ({ children }: PropsWithChildren<object>): React.ReactElement => {
+export const StakingSkeleton = ({ children, multiDelegationEnabled }: StakingSkeletonProps): React.ReactElement => {
   const { t } = useTranslation();
   const { networkInfo, fetchNetworkInfo } = useWalletStore(stakingInfoSelector);
   const { priceResult } = useFetchCoinPrice();
@@ -72,7 +77,7 @@ export const StakingSkeleton = ({ children }: PropsWithChildren<object>): React.
 
   const sidePanel = (
     <Flex flexDirection="column" alignItems="stretch" gap="$32" mb="$112">
-      <BrowsePoolsPreferencesCard />
+      {multiDelegationEnabled && <BrowsePoolsPreferencesCard />}
       <Skeleton loading={!networkInfo}>
         <NetworkInfo {...networkInfo} translations={translations} />
       </Skeleton>


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-10202)

---

## Proposed solution
Do not render `BrowsePoolsPreferencesCard` for hardware wallets (unless multi-delegation staking is enabled for the HW wallet).

## Testing
`BrowsePoolsPreferencesCard` should not be visible when using HW (unless a feature flag for multi-delegation with HW is enabled).