### PR TITLE
Fix post integration unit test run

### DIFF
--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -21,4 +21,8 @@ jobs:
           name: lightwallet
           path: apps/browser-extension-wallet/dist
       - name: Run unit tests
+        env:
+          AVAILABLE_CHAINS: 'Preprod,Preview,Mainnet'
+          DEFAULT_CHAIN: 'Preprod'
+          NODE_OPTIONS: '--max_old_space_size=8192'
         run: yarn test --maxWorkers=2 --silent


### PR DESCRIPTION
Post integration workflow is misconfigured. I aligned config to the same we have in [ci.yml](https://github.com/input-output-hk/lace/blob/main/.github/workflows/ci.yml#L32).

Those two configs will be improved in close future. The common subsets of workflows are going to be extracted to actions and reused.