### PR TITLE
Skip chromatic run for draft PRs

### DIFF
--- a/.github/workflows/core-chromatic.yml
+++ b/.github/workflows/core-chromatic.yml
@@ -2,6 +2,7 @@ name: Lace Core Chromatic
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - packages/core/**
   push:
@@ -12,6 +13,7 @@ on:
 
 jobs:
   chromatic-deployment:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/git-checks.yml
+++ b/.github/workflows/git-checks.yml
@@ -1,9 +1,12 @@
 name: Git Checks
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   block-fixup:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/staking-chromatic.yml
+++ b/.github/workflows/staking-chromatic.yml
@@ -2,6 +2,7 @@ name: Lace Staking Chromatic
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - packages/staking/**
   push:
@@ -12,6 +13,7 @@ on:
 
 jobs:
   chromatic-deployment:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ui-toolkit-chromatic.yml
+++ b/.github/workflows/ui-toolkit-chromatic.yml
@@ -2,6 +2,7 @@ name: Lace UI Toolkit
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - packages/ui/**
   push:
@@ -12,6 +13,7 @@ on:
 
 jobs:
   chromatic-deployment:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
In this PR I skip Chromatic and Github checks run for draft PRs.

Motivation for this change is to reduce a number of Chromatic runs in CI, which affects our Chromatic monthly limits and speed up pipeline check for drafts.

Credits to @przemyslaw-wlodek for an idea and participation