### PR TITLE
fix(extension): fix infinite scroll on PopupView

### DIFF
--- a/apps/browser-extension-wallet/src/components/Layout/MainLayout.module.scss
+++ b/apps/browser-extension-wallet/src/components/Layout/MainLayout.module.scss
@@ -21,7 +21,6 @@
       display: flex;
       min-height: 0;
       width: 100%;
-      flex-direction: column;
       > * {
         width: 100%;
       }


### PR DESCRIPTION
# Checklist

- [x] [LW-10211](https://input-output.atlassian.net/browse/LW-10211), [LW-10212](https://input-output.atlassian.net/browse/LW-10212)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution
I'm removing a CSS line, introduced by [PR 833](https://github.com/input-output-hk/lace/pull/883/files)
The issue was that InfiniteScroll doesn't detect scroll event.

## Testing
I'm not sure if this will break any other screen, so some regression testing is needed.

## Screenshots
<img width="1713" alt="Screenshot 2024-04-05 at 18 52 34" src="https://github.com/input-output-hk/lace/assets/143514860/a6ee0a7c-7342-4bb5-ab7e-dc24599bce20">


[LW-10211]: https://input-output.atlassian.net/browse/LW-10211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LW-10212]: https://input-output.atlassian.net/browse/LW-10212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ