### PR TITLE
Update Sonar Cloud workflow configuration

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -3,18 +3,13 @@ on:
   push:
     branches:
       - main
-      - release/**/*
-      - feat/*
-      - feat-*
-      - fix/*
-      - fix-*
-      - lw-*
+      - release/**
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
   sonarcloud:
     name: SonarCloud Code Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
In my past PR I used a wrong pattern for release branch name and after reviewing this workflow it looks it's not needed to track feat, fix, etc branches as the same information we get from PRs in SonarCloud.