### PR TITLE
fix(extension): incorrect action button width in dapp connector LW-10232

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/ConfirmTransaction.module.scss
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/ConfirmTransaction.module.scss
@@ -6,7 +6,7 @@
   padding-top: size_unit(0);
 }
 
-.transactionContainer { 
+.transactionContainer {
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -15,13 +15,13 @@
 
 .actions {
   @extend %flex-column;
-  height: size_unit(17.12);
   justify-content: space-between;
-  padding: size_unit(2) size_unit(3) size_unit(2) size_unit(3);
+  padding: size_unit(3) 0;
   border-top: 1px solid var(--light-mode-light-grey-plus, var(--dark-mode-mid-grey));
   position: sticky;
   bottom: 0;
   z-index: 10;
+  gap: size_unit(1);
   background-color: var(--light-mode-body, var(--dark-mode-bg-black));
   .actionBtn {
     width: 100%;


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-10232
- [x] Screenshots added.

---

## Proposed solution

Fixes the width of the Dapp connector action buttons

## Screenshots

before:
![image](https://github.com/input-output-hk/lace/assets/172414/b2cf4ed3-3269-4159-ae3a-f8b5baf3e089)

after:
![Bildschirmfoto 2024-04-10 um 13 33 25](https://github.com/input-output-hk/lace/assets/172414/d534431a-d1fc-403c-aad2-2ae78ae1d33e)

