### PR TITLE
fix(extension): disable cmd click for expand button

### DIFF
--- a/apps/browser-extension-wallet/src/components/ExpandButton/ExpandButton.tsx
+++ b/apps/browser-extension-wallet/src/components/ExpandButton/ExpandButton.tsx
@@ -16,9 +16,8 @@ const RenderTooltipIfMultiWallet = ({ children, label }: { children: ReactNode; 
 
 export const ExpandButton = ({ label, onClick }: { label: string; onClick: () => void }): React.ReactElement => (
   <RenderTooltipIfMultiWallet label={label}>
-    <a
+    <span
       onClick={onClick}
-      href="#"
       className={classnames(styles.button, {
         [styles.multiWallet]: process.env.USE_MULTI_WALLET === 'true'
       })}
@@ -26,6 +25,6 @@ export const ExpandButton = ({ label, onClick }: { label: string; onClick: () =>
     >
       <ExpandIcon className={styles.icon} />
       {process.env.USE_MULTI_WALLET !== 'true' && <span className={styles.text}>{label}</span>}
-    </a>
+    </span>
   </RenderTooltipIfMultiWallet>
 );


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-10092](https://input-output.atlassian.net/browse/LW-10092)
- [ ] ~~Proper tests implemented~~
- [ ] ~~Screenshots added.~~

---

## Proposed solution

Expand button is developed as `a` tag that has a default in browser behaviour to open a new tab on `cmd + click`.
Changing it to `span` solves an issue.

## Testing

Follow steps described in ticket.

## Screenshots

~~Attach screenshots here if implementation involves some UI changes~~
