### PR TITLE
fix: improve mnemonic reset warning popup modal

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/wallet-setup/components/WalletSetupWizard.tsx
@@ -215,6 +215,12 @@ export const WalletSetupWizard = ({
     moveForward();
   };
 
+  const handleCloseMnemonicResetModal = () => {
+    setIsResetMnemonicModalOpen(false);
+    setResetMnemonicStage('');
+    setIsBackFromNextStep(false);
+  };
+
   const renderedMnemonicStep = () => {
     if ([SetupType.RESTORE, SetupType.FORGOT_PASSWORD].includes(setupType)) {
       const isMnemonicSubmitEnabled = util.validateMnemonic(util.joinMnemonicWords(mnemonic));
@@ -242,7 +248,6 @@ export const WalletSetupWizard = ({
         onReset={(resetStage) => {
           setResetMnemonicStage(resetStage);
           resetStage === 'input' ? setIsResetMnemonicModalOpen(true) : onCancel();
-          resetStage === 'input' && setIsBackFromNextStep(false);
         }}
         renderVideoPopupContent={({ onClose }) => (
           <MnemonicVideoPopupContent
@@ -301,17 +306,13 @@ export const WalletSetupWizard = ({
           visible={isResetMnemonicModalOpen}
           cancelLabel={t('browserView.walletSetup.mnemonicResetModal.cancel')}
           confirmLabel={t('browserView.walletSetup.mnemonicResetModal.confirm')}
-          onCancel={() => {
-            setIsResetMnemonicModalOpen(false);
-            setResetMnemonicStage('');
-          }}
+          onCancel={handleCloseMnemonicResetModal}
           onConfirm={() => {
+            handleCloseMnemonicResetModal();
             setMnemonic(util.generateMnemonicWords());
-            setIsResetMnemonicModalOpen(false);
             if (resetMnemonicStage === 'writedown') {
               moveBack();
             }
-            setResetMnemonicStage('');
           }}
         />
       )}


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-10318
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

improve when mnemonic reset warning popup modal is shown when moving back from next step in create flow

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes
