### PR TITLE
fix(extension): "From" instead of "To" label for Sending transaction [LW-9741]

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityDetail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityDetail.tsx
@@ -3,16 +3,16 @@ import uniq from 'lodash/uniq';
 import flatMap from 'lodash/flatMap';
 import { Skeleton } from 'antd';
 import { Wallet } from '@lace/cardano';
+import type { ActivityType } from '@lace/core';
 import {
-  AssetActivityListProps,
   ActivityStatus,
-  TxOutputInput,
-  TxSummary,
+  AssetActivityListProps,
+  DelegationActivityType,
   RewardsDetails,
   TransactionActivityType,
-  DelegationActivityType
+  TxOutputInput,
+  TxSummary
 } from '@lace/core';
-import type { ActivityType } from '@lace/core';
 import { PriceResult } from '@hooks';
 import { useWalletStore } from '@stores';
 import { ActivityDetail as ActivityDetailType } from '@src/types';
@@ -54,7 +54,8 @@ export const getTransactionData = ({
     return outputData.map((output) => ({
       ...output,
       // Show up to 5 addresses below multiple addresses (see LW-4040)
-      addr: addrs.slice(0, MAX_SUMMARY_ADDRESSES)
+      addr: addrs.slice(0, MAX_SUMMARY_ADDRESSES),
+      type: TransactionActivityType.incoming
     }));
   }
 
@@ -63,7 +64,8 @@ export const getTransactionData = ({
     .filter((output) => !walletAddresses.includes(output.addr))
     .map((output) => ({
       ...output,
-      ...(!Array.isArray(output.addr) && { addr: [output.addr] })
+      ...(!Array.isArray(output.addr) && { addr: [output.addr] }),
+      type: TransactionActivityType.outgoing
     }));
 };
 

--- a/packages/core/src/ui/components/ActivityDetail/TransactionDetailAsset.ts
+++ b/packages/core/src/ui/components/ActivityDetail/TransactionDetailAsset.ts
@@ -1,3 +1,5 @@
+import { TransactionActivityType } from '@ui/components/ActivityDetail/types';
+
 export interface TransactionDetailAsset {
   icon?: string;
   title: string;
@@ -22,6 +24,7 @@ export interface TxOutputInput {
 
 export interface TxSummary extends Omit<TxOutputInput, 'addr'> {
   addr: string[];
+  type: TransactionActivityType;
 }
 
 interface TxMetadata {

--- a/packages/core/src/ui/components/ActivityDetail/TransactionDetails.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/TransactionDetails.tsx
@@ -21,7 +21,8 @@ import {
   TxDetailsProposalProceduresTitles,
   TxDetailsCertificateTitles,
   TxDetails,
-  TxDetail
+  TxDetail,
+  TransactionActivityType
 } from './types';
 import { Collateral, CollateralStatus } from './Collateral';
 
@@ -346,7 +347,7 @@ export const TransactionDetails = ({
               </div>
               <div className={styles.details}>
                 <div className={styles.title}>
-                  {t(`core.activityDetails.${name.toLowerCase() === 'sent' ? 'to' : 'from'}`)}
+                  {t(`core.activityDetails.${summary.type === TransactionActivityType.outgoing ? 'to' : 'from'}`)}
                 </div>
                 <div>
                   {summary.addr.length > 1 && (


### PR DESCRIPTION
# Checklist

- [x] [JIRA ticket](https://input-output.atlassian.net/browse/LW-9741)

---

## Problem

The current code resulted in a bug due to just comparing a translated string to a
string literal 'sent' to determine if the transaction was going in or out which failed for the "sending" state (and wouldnt work for other languages anyway)

## Proposed solution

Pass the `TransactionActivityType` to the transaction details to determine the correct state of the transaction.

## Testing

Send a transaction and quickly switch to the activity tab while it is in "sending" state. Make sure that the summary says "to" instead of "from" for the target address.
