### PR TITLE
fix(extension): fix placeholder visibility in search pool input

### DIFF
--- a/packages/core/src/ui/components/ActivityDetail/ActivityTypeIcon.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/ActivityTypeIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React from 'react';
 import cn from 'classnames';
 import Icon, { QuestionOutlined } from '@ant-design/icons';

--- a/packages/core/src/ui/components/ActivityDetail/TransactionDetails.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/TransactionDetails.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable no-magic-numbers */
 import React from 'react';
 import cn from 'classnames';

--- a/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
+++ b/packages/core/src/ui/components/DappTransaction/DappTransaction.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React from 'react';
 import { ErrorPane, truncate } from '@lace/common';
 import { Wallet } from '@lace/cardano';

--- a/packages/staking/src/features/overview/StakePoolSearch/StakePoolSearch.tsx
+++ b/packages/staking/src/features/overview/StakePoolSearch/StakePoolSearch.tsx
@@ -184,7 +184,7 @@ export const StakePoolSearch = ({
       <Select
         ref={ref}
         showSearch
-        value={value || ''}
+        value={value}
         data-testid="search-input"
         placeholder={translations.searchPlaceholder}
         defaultActiveFirstOption={false}


### PR DESCRIPTION
# Checklist

- [x] JIRA -[LW-10237](https://input-output.atlassian.net/browse/LW-10237)
- [ ] ~~Proper tests implemented~~
- [ ] Screenshots added.

---

## Proposed solution

In order to have placeholder rendered value passed into the `search` component imported from `antd` lib should be either `undefined` or `null` 

## Testing

Connect your hw device and proceed to the staking page

## Screenshots

<img width="362" alt="Screenshot 2024-05-01 at 14 13 04" src="https://github.com/input-output-hk/lace/assets/7934077/5cf47471-7b62-4f9c-9343-d89185a9a407">



[LW-10237]: https://input-output.atlassian.net/browse/LW-10237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ