### PR TITLE
[LW 9606] Add dark mode to stories

### DIFF
--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -1,0 +1,49 @@
+@import './theme.scss';
+
+:global(.ant-radio:hover .ant-radio-inner) {
+  border-color: var(--light-mode-dark-grey, var(--dark-mode-light-grey)) !important;
+  background: var(--color-white, var(--dark-mode-grey));
+}
+:global(.ant-tooltip) {
+  color: var(--light-mode-dark-grey, var(--dark-mode-light-grey)) !important;
+  font-weight: 400 !important;
+  font-size: var(--bodySmall) !important;
+}
+:global(.ant-tooltip-inner) {
+  background-color: var(--dark-mode-mid-grey, #ffffff) !important;
+  border-radius: 11px !important;
+  color: var(--dark-mode-light-grey, --light-mode-dark-grey) !important;
+  padding: size_unit(1) size_unit(2) !important;
+}
+:global(.ant-tooltip-arrow-content) {
+  background-color: var(--dark-mode-mid-grey, #ffffff) !important;
+}
+
+:global(.ant-tooltip-arrow-content:before) {
+  background: var(--dark-mode-mid-grey, #ffffff) !important;
+}
+
+:global(.ant-modal-mask) {
+  background: var(--light-mode-black, var(--dark-mode-bg-black)) !important;
+  opacity: 0.9;
+}
+
+:global(.ant-drawer.ant-drawer-open .ant-drawer-mask) {
+  animation: none;
+}
+
+:global(.ant-drawer) {
+  transition: none;
+}
+
+:global {
+  .ant-checkbox-checked .ant-checkbox-inner {
+    background-color: var(--primary-default) !important;
+    border-color: var(--primary-default) !important;
+  }
+}
+
+body {
+  background-color: var(--bg-color-body, #ffffff) !important;
+  color: var(--text-color-primary, #3d3b39);
+}

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ThemeColorScheme, ThemeProvider, colorSchemaDecorator } from '@lace/ui';
 import 'antd/dist/antd.css';
 import 'normalize.css';
-import './theme.scss';
+import './index.scss';
 
 export const preview = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ThemeColorScheme, ThemeProvider } from '@lace/ui';
+import { ThemeColorScheme, ThemeProvider, colorSchemaDecorator } from '@lace/ui';
 import 'antd/dist/antd.css';
 import 'normalize.css';
 import './theme.scss';
@@ -19,9 +19,16 @@ export const preview = {
 };
 
 export const decorators = [
-  (Story) => (
-    <ThemeProvider colorScheme={ThemeColorScheme.Light}>
-      <Story />
-    </ThemeProvider>
-  )
+  (Story, args) => {
+    const { decorators: { colorSchema = true } = {} } = args.parameters;
+    return colorSchema ? colorSchemaDecorator(Story, args) : <Story />;
+  },
+  (Story, args) => {
+    const { decorators: { theme } = {} } = args.parameters;
+    return (
+      <ThemeProvider colorScheme={theme ?? ThemeColorScheme.Light}>
+        <Story />
+      </ThemeProvider>
+    );
+  }
 ];

--- a/packages/core/.storybook/theme.scss
+++ b/packages/core/.storybook/theme.scss
@@ -6,13 +6,14 @@
   /*
     in case the theme provider is not being used, this media query allows us to use the theme set on the user system
     */
-  @media (prefers-color-scheme: dark) {
+  @media (prefers-color-scheme: dark) and (data-theme: dark) {
     :root {
       @include theme-custom-properties($dark-theme);
     }
   }
 
-  html[data-theme='dark'] {
+  html[data-theme='dark'],
+  div[data-theme='dark'] {
     @include theme-custom-properties($dark-theme);
   }
 }
@@ -21,13 +22,14 @@
   /*
     in case the theme provider is not being used, this media query allows us to use the theme set on the user system
     */
-  @media (prefers-color-scheme: light) {
+  @media (prefers-color-scheme: light) and (data-theme: light) {
     :root {
       @include theme-custom-properties($light-theme);
     }
   }
 
-  html[data-theme='light'] {
+  html[data-theme='light'],
+  div[data-theme='light'] {
     @include theme-custom-properties($light-theme);
   }
 }

--- a/packages/core/src/ui/components/Account/DisableAccountConfirmation/DisableAccountConfirmation.stories.ts
+++ b/packages/core/src/ui/components/Account/DisableAccountConfirmation/DisableAccountConfirmation.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { DisableAccountConfirmation } from './DisableAccountConfirmation';
 import { ComponentProps } from 'react';
+import { ThemeColorScheme } from '@lace/ui';
 
 const meta: Meta<typeof DisableAccountConfirmation> = {
   title: 'Accounts/DisableAccountConfirmation',
@@ -29,5 +30,22 @@ const data: ComponentProps<typeof DisableAccountConfirmation> = {
 export const Overview: Story = {
   args: {
     ...data
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
+  }
+};
+
+export const WithDarkMode: Story = {
+  args: {
+    ...data
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false,
+      theme: ThemeColorScheme.Dark
+    }
   }
 };

--- a/packages/core/src/ui/components/Account/EditAccount/EditAccountDrawer.stories.ts
+++ b/packages/core/src/ui/components/Account/EditAccount/EditAccountDrawer.stories.ts
@@ -46,6 +46,7 @@ export const WithDarkMode: Story = {
   },
   parameters: {
     decorators: {
+      colorSchema: false,
       theme: ThemeColorScheme.Dark
     }
   }

--- a/packages/core/src/ui/components/Account/EditAccount/EditAccountDrawer.stories.ts
+++ b/packages/core/src/ui/components/Account/EditAccount/EditAccountDrawer.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { EditAccountDrawer } from './EditAccountDrawer';
 import { ComponentProps } from 'react';
+import { ThemeColorScheme } from '@lace/ui';
 
 const meta: Meta<typeof EditAccountDrawer> = {
   title: 'Accounts/EditAccountDrawer',
@@ -31,5 +32,21 @@ const data: ComponentProps<typeof EditAccountDrawer> = {
 export const Overview: Story = {
   args: {
     ...data
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
+  }
+};
+
+export const WithDarkMode: Story = {
+  args: {
+    ...data
+  },
+  parameters: {
+    decorators: {
+      theme: ThemeColorScheme.Dark
+    }
   }
 };

--- a/packages/core/src/ui/components/Account/EnableAccountConfirmWithHW/EnableAccountConfirmWithHW.stories.tsx
+++ b/packages/core/src/ui/components/Account/EnableAccountConfirmWithHW/EnableAccountConfirmWithHW.stories.tsx
@@ -74,6 +74,7 @@ export const WithDarkMode: Story = {
   args: data,
   parameters: {
     decorators: {
+      colorSchema: false,
       theme: ThemeColorScheme.Dark
     }
   }

--- a/packages/core/src/ui/components/Account/EnableAccountConfirmWithHW/EnableAccountConfirmWithHW.stories.tsx
+++ b/packages/core/src/ui/components/Account/EnableAccountConfirmWithHW/EnableAccountConfirmWithHW.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EnableAccountConfirmWithHW } from './EnableAccountConfirmWithHW';
+import { ThemeColorScheme } from '@lace/ui';
 
 const meta: Meta<typeof EnableAccountConfirmWithHW> = {
   title: 'Accounts/EnableAccountConfirmWithHW',
@@ -37,13 +38,23 @@ const data: ComponentProps<typeof EnableAccountConfirmWithHW> = {
 };
 
 export const Waiting: Story = {
-  args: data
+  args: data,
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
+  }
 };
 
 export const Signing: Story = {
   args: {
     ...data,
     state: 'signing'
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
   }
 };
 
@@ -51,5 +62,19 @@ export const ErrorCase: Story = {
   args: {
     ...data,
     state: 'error'
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
+  }
+};
+
+export const WithDarkMode: Story = {
+  args: data,
+  parameters: {
+    decorators: {
+      theme: ThemeColorScheme.Dark
+    }
   }
 };

--- a/packages/core/src/ui/components/Account/EnableAccountPasswordPrompt/EnableAccountPasswordPrompt.stories.ts
+++ b/packages/core/src/ui/components/Account/EnableAccountPasswordPrompt/EnableAccountPasswordPrompt.stories.ts
@@ -73,6 +73,7 @@ export const WithDarkMode: Story = {
   },
   parameters: {
     decorators: {
+      colorSchema: false,
       theme: ThemeColorScheme.Dark
     }
   }

--- a/packages/core/src/ui/components/Account/EnableAccountPasswordPrompt/EnableAccountPasswordPrompt.stories.ts
+++ b/packages/core/src/ui/components/Account/EnableAccountPasswordPrompt/EnableAccountPasswordPrompt.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { EnableAccountPasswordPrompt } from './EnableAccountPasswordPrompt';
 import { ComponentProps } from 'react';
+import { ThemeColorScheme } from '@lace/ui';
 
 const meta: Meta<typeof EnableAccountPasswordPrompt> = {
   title: 'Accounts/EnableAccountPasswordPrompt',
@@ -34,6 +35,11 @@ const data: ComponentProps<typeof EnableAccountPasswordPrompt> = {
 export const Overview: Story = {
   args: {
     ...data
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
   }
 };
 
@@ -41,6 +47,11 @@ export const PopUp: Story = {
   args: {
     ...data,
     isPopup: true
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
   }
 };
 
@@ -48,5 +59,21 @@ export const IncorrectPassword: Story = {
   args: {
     ...data,
     wasPasswordIncorrect: true
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
+  }
+};
+
+export const WithDarkMode: Story = {
+  args: {
+    ...data
+  },
+  parameters: {
+    decorators: {
+      theme: ThemeColorScheme.Dark
+    }
   }
 };

--- a/packages/core/src/ui/components/ConfirmDRepRegistration/ConfirmDRepRegistration.stories.tsx
+++ b/packages/core/src/ui/components/ConfirmDRepRegistration/ConfirmDRepRegistration.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ConfirmDRepRetirement/ConfirmDRepRetirement.stories.tsx
+++ b/packages/core/src/ui/components/ConfirmDRepRetirement/ConfirmDRepRetirement.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ConfirmDRepUpdate/ConfirmDRepUpdate.stories.tsx
+++ b/packages/core/src/ui/components/ConfirmDRepUpdate/ConfirmDRepUpdate.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ConfirmStakeRegistrationDelegation/ConfirmStakeRegistrationDelegation.stories.tsx
+++ b/packages/core/src/ui/components/ConfirmStakeRegistrationDelegation/ConfirmStakeRegistrationDelegation.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ConfirmStakeVoteDelegation/ConfirmStakeVoteDelegation.stories.tsx
+++ b/packages/core/src/ui/components/ConfirmStakeVoteDelegation/ConfirmStakeVoteDelegation.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ConfirmStakeVoteRegistrationDelegation/ConfirmStakeVoteRegistrationDelegation.stories.tsx
+++ b/packages/core/src/ui/components/ConfirmStakeVoteRegistrationDelegation/ConfirmStakeVoteRegistrationDelegation.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ConfirmVoteDelegation/ConfirmVoteDelegation.stories.tsx
+++ b/packages/core/src/ui/components/ConfirmVoteDelegation/ConfirmVoteDelegation.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ConfirmVoteRegistrationDelegation/ConfirmVoteRegistrationDelegation.stories.tsx
+++ b/packages/core/src/ui/components/ConfirmVoteRegistrationDelegation/ConfirmVoteRegistrationDelegation.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ProposalProcedures/HardForkInitiationAction/HardForkInitiationAction.stories.tsx
+++ b/packages/core/src/ui/components/ProposalProcedures/HardForkInitiationAction/HardForkInitiationAction.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ProposalProcedures/InfoAction/InfoAction.stories.tsx
+++ b/packages/core/src/ui/components/ProposalProcedures/InfoAction/InfoAction.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ProposalProcedures/NewConstitutionAction/NewConstitutionAction.stories.tsx
+++ b/packages/core/src/ui/components/ProposalProcedures/NewConstitutionAction/NewConstitutionAction.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ProposalProcedures/NoConfidenceAction/NoConfidenceAction.stories.tsx
+++ b/packages/core/src/ui/components/ProposalProcedures/NoConfidenceAction/NoConfidenceAction.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ProposalProcedures/ParameterChangeAction/ParameterChangeAction.stories.tsx
+++ b/packages/core/src/ui/components/ProposalProcedures/ParameterChangeAction/ParameterChangeAction.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ProposalProcedures/TreasuryWithdrawalsAction/TreasuryWithdrawalsAction.stories.tsx
+++ b/packages/core/src/ui/components/ProposalProcedures/TreasuryWithdrawalsAction/TreasuryWithdrawalsAction.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/ProposalProcedures/UpdateCommitteeAction/UpdateCommitteeActionAction.stories.tsx
+++ b/packages/core/src/ui/components/ProposalProcedures/UpdateCommitteeAction/UpdateCommitteeActionAction.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/core/src/ui/components/SharedWallet/AddCoSigners/AddCoSigners.stories.tsx
+++ b/packages/core/src/ui/components/SharedWallet/AddCoSigners/AddCoSigners.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { Meta } from '@storybook/react';
 
 import { AddCoSigners } from './AddCoSigners';
-import { Flex } from '@lace/ui';
 import { ValidateAddress } from './type';
 import { Wallet } from '@lace/cardano';
 
@@ -64,22 +63,20 @@ const validateAddress: ValidateAddress = async (address) => {
 };
 
 export const Overview = (): JSX.Element => (
-  <Flex alignItems="center" justifyContent="center" w="$480" h="$480">
-    <AddCoSigners
-      validateAddress={validateAddress}
-      translations={{
-        title: 'Add your Co-signers',
-        subtitle: 'Add up to 20 wallet addresses to your shared wallet',
-        inputLabel: "Recipient's address or $handle",
-        inputError: 'Invalid address',
-        addButton: 'Add Co-signer',
-        removeButton: 'Remove',
-        backButton: 'Back',
-        nextButton: 'Next'
-      }}
-      onBack={() => void 0}
-      onNext={() => void 0}
-      addressBook={addressBook}
-    />
-  </Flex>
+  <AddCoSigners
+    validateAddress={validateAddress}
+    translations={{
+      title: 'Add your Co-signers',
+      subtitle: 'Add up to 20 wallet addresses to your shared wallet',
+      inputLabel: "Recipient's address or $handle",
+      inputError: 'Invalid address',
+      addButton: 'Add Co-signer',
+      removeButton: 'Remove',
+      backButton: 'Back',
+      nextButton: 'Next'
+    }}
+    onBack={() => void 0}
+    onNext={() => void 0}
+    addressBook={addressBook}
+  />
 );

--- a/packages/core/src/ui/components/SharedWallet/ImportantInfo/ImportantInfo.stories.tsx
+++ b/packages/core/src/ui/components/SharedWallet/ImportantInfo/ImportantInfo.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { Meta } from '@storybook/react';
 
 import { ImportantInfo } from './ImportantInfo';
-import { Flex } from '@lace/ui';
 
 const meta: Meta<typeof ImportantInfo> = {
   title: 'Shared Wallets/ImportantInfo',
@@ -15,18 +14,16 @@ const meta: Meta<typeof ImportantInfo> = {
 export default meta;
 
 export const Overview = (): JSX.Element => (
-  <Flex alignItems="center" justifyContent="center" w="$480" h="$420">
-    <ImportantInfo
-      translations={{
-        title: 'Important information about shared wallets',
-        subtitle:
-          'Once you create your shared wallet, information contained will be fixed. You will not be able to edit after proceeding',
-        checkBoxLabel: 'I understand that I will not be able to make changes after creating the shared wallet',
-        backButton: 'Back',
-        nextButton: 'Next'
-      }}
-      onBack={() => void 0}
-      onNext={() => void 0}
-    />
-  </Flex>
+  <ImportantInfo
+    translations={{
+      title: 'Important information about shared wallets',
+      subtitle:
+        'Once you create your shared wallet, information contained will be fixed. You will not be able to edit after proceeding',
+      checkBoxLabel: 'I understand that I will not be able to make changes after creating the shared wallet',
+      backButton: 'Back',
+      nextButton: 'Next'
+    }}
+    onBack={() => void 0}
+    onNext={() => void 0}
+  />
 );

--- a/packages/core/src/ui/components/SharedWallet/NoSharedWalletFoundDialog/NoSharedWalletFoundDialog.stories.ts
+++ b/packages/core/src/ui/components/SharedWallet/NoSharedWalletFoundDialog/NoSharedWalletFoundDialog.stories.ts
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { NoSharedWalletFoundDialog } from './NoSharedWalletFoundDialog';
+import { ThemeColorScheme } from '@lace/ui';
+import { ComponentProps } from 'react';
 
 const meta: Meta<typeof NoSharedWalletFoundDialog> = {
   title: 'Shared Wallets/NoSharedWalletFoundDialog',
@@ -14,18 +16,38 @@ type Story = StoryObj<typeof NoSharedWalletFoundDialog>;
 
 const noop = (): void => void 0;
 
+const data: ComponentProps<typeof NoSharedWalletFoundDialog> = {
+  open: true,
+  translations: {
+    title: 'No shared wallet found',
+    description: 'Please try again',
+    confirm: 'Proceed'
+  },
+  events: {
+    handleOnConfirm: noop,
+    onOpenChanged: noop
+  }
+};
+
 export const Overview: Story = {
   args: {
-    open: true,
-    translations: {
-      title: 'No shared wallet found',
-      description: 'Please try again',
-      confirm: 'Proceed'
-    },
-    events: {
-      onCancel: noop,
-      onConfirm: noop,
-      onOpenChanged: noop
+    ...data
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
+  }
+};
+
+export const WithDarkMode: Story = {
+  args: {
+    ...data
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false,
+      theme: ThemeColorScheme.Dark
     }
   }
 };

--- a/packages/core/src/ui/components/SharedWallet/StartOverDialog/StartOverDialog.stories.tsx
+++ b/packages/core/src/ui/components/SharedWallet/StartOverDialog/StartOverDialog.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { StartOverDialog } from './StartOverDialog';
+import { ComponentProps } from 'react';
+import { ThemeColorScheme } from '@lace/ui';
 
 const meta: Meta<typeof StartOverDialog> = {
   title: 'Shared Wallets/StartOverAgainDialog',
@@ -14,19 +16,40 @@ type Story = StoryObj<typeof StartOverDialog>;
 
 const noop = (): void => void 0;
 
+const data: ComponentProps<typeof StartOverDialog> = {
+  open: true,
+  translations: {
+    title: 'Are you sure you want to cancel adding a shared wallet?',
+    description: 'You’ll have to start over.',
+    cancel: 'Go Back',
+    confirm: 'Proceed'
+  },
+  events: {
+    onCancel: noop,
+    onConfirm: noop,
+    onOpenChanged: noop
+  }
+};
+
 export const Overview: Story = {
   args: {
-    open: true,
-    translations: {
-      title: 'Are you sure you want to cancel adding a shared wallet?',
-      description: 'You’ll have to start over.',
-      cancel: 'Go Back',
-      confirm: 'Proceed'
-    },
-    events: {
-      onCancel: noop,
-      onConfirm: noop,
-      onOpenChanged: noop
+    ...data
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false
+    }
+  }
+};
+
+export const WithDarkMode: Story = {
+  args: {
+    ...data
+  },
+  parameters: {
+    decorators: {
+      colorSchema: false,
+      theme: ThemeColorScheme.Dark
     }
   }
 };

--- a/packages/core/src/ui/components/VotingProcedures/VotingProcedures.stories.tsx
+++ b/packages/core/src/ui/components/VotingProcedures/VotingProcedures.stories.tsx
@@ -7,7 +7,7 @@ const customViewports = {
   popup: {
     name: 'Popup',
     styles: {
-      width: '360px',
+      width: '720px',
       height: '600'
     }
   }

--- a/packages/ui/src/design-system/decorators/color-schema/color-schema-table.component.tsx
+++ b/packages/ui/src/design-system/decorators/color-schema/color-schema-table.component.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { ThemeColorScheme, LocalThemeProvider } from '../../design-tokens';
-import * as Variants from '../decorators/variants-table';
+import { ThemeColorScheme, LocalThemeProvider } from '../../../design-tokens';
+import * as Variants from '../variants-table';
 
 interface Props {
   children: React.ReactNode;
-  headers?: string[] | undefined;
+  headers?: string[];
 }
 
 export const ColorSchemaTable = ({

--- a/packages/ui/src/design-system/decorators/color-schema/color-schema.css.ts
+++ b/packages/ui/src/design-system/decorators/color-schema/color-schema.css.ts
@@ -1,0 +1,19 @@
+import { style, sx } from '../../../design-tokens';
+
+export const storyContainer = style([
+  sx({
+    p: '$10',
+    background: '$variants_table_bgColor',
+    w: '$fill',
+    h: '$fill',
+    minHeight: '$fill',
+  }),
+  { flex: 1, overflowY: 'auto' },
+]);
+
+export const root = style([
+  sx({
+    minHeight: '$fill',
+    h: '$fill',
+  }),
+]);

--- a/packages/ui/src/design-system/decorators/color-schema/color-schema.decorator.tsx
+++ b/packages/ui/src/design-system/decorators/color-schema/color-schema.decorator.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import type { DecoratorFunction } from '@storybook/csf/dist/story';
+import type { ReactFramework } from '@storybook/react';
+
+import { ThemeColorScheme, LocalThemeProvider } from '../../../design-tokens';
+import { Box } from '../../box';
+import { Flex } from '../../flex';
+
+import * as styles from './color-schema.css';
+
+export const colorSchemaDecorator: DecoratorFunction<
+  ReactFramework
+> = Story => (
+  <Flex className={styles.root} flexDirection="row">
+    <Box className={styles.storyContainer}>{<Story />}</Box>
+    <LocalThemeProvider
+      colorScheme={ThemeColorScheme.Dark}
+      className={styles.storyContainer}
+    >
+      <Story />
+    </LocalThemeProvider>
+  </Flex>
+);

--- a/packages/ui/src/design-system/decorators/color-schema/color-schema.decorator.tsx
+++ b/packages/ui/src/design-system/decorators/color-schema/color-schema.decorator.tsx
@@ -4,7 +4,6 @@ import type { DecoratorFunction } from '@storybook/csf/dist/story';
 import type { ReactFramework } from '@storybook/react';
 
 import { ThemeColorScheme, LocalThemeProvider } from '../../../design-tokens';
-import { Box } from '../../box';
 import { Flex } from '../../flex';
 
 import * as styles from './color-schema.css';
@@ -13,7 +12,12 @@ export const colorSchemaDecorator: DecoratorFunction<
   ReactFramework
 > = Story => (
   <Flex className={styles.root} flexDirection="row">
-    <Box className={styles.storyContainer}>{<Story />}</Box>
+    <LocalThemeProvider
+      colorScheme={ThemeColorScheme.Light}
+      className={styles.storyContainer}
+    >
+      <Story />
+    </LocalThemeProvider>
     <LocalThemeProvider
       colorScheme={ThemeColorScheme.Dark}
       className={styles.storyContainer}

--- a/packages/ui/src/design-system/decorators/index.ts
+++ b/packages/ui/src/design-system/decorators/index.ts
@@ -3,4 +3,5 @@ export * as Variants from './variants-table';
 export { Section } from './page-section.component';
 export { usePortalContainer } from './page.hooks';
 export { UIStateTable } from './ui-state-table.component';
-export { ColorSchemaTable } from './color-schema-table.component';
+export { ColorSchemaTable } from './color-schema/color-schema-table.component';
+export { colorSchemaDecorator } from './color-schema/color-schema.decorator';

--- a/packages/ui/src/design-system/index.ts
+++ b/packages/ui/src/design-system/index.ts
@@ -28,7 +28,7 @@ export { PasswordBox } from './password-box';
 export { TextLink } from './text-link';
 export * as ProfileDropdown from './profile-dropdown';
 export { TextBox } from './text-box';
-export { Variants, Section } from './decorators';
+export { Variants, Section, colorSchemaDecorator } from './decorators';
 export * as EducationalCard from './educational-card';
 export { FileUpload } from './file-upload';
 export { Checkbox } from './checkbox';

--- a/packages/ui/src/design-tokens/theme/local-theme-provider.component.tsx
+++ b/packages/ui/src/design-tokens/theme/local-theme-provider.component.tsx
@@ -32,6 +32,7 @@ export const LocalThemeProvider = ({
   return (
     <ThemeContext.Provider value={value}>
       <div
+        data-theme={colorScheme}
         className={cs(cx.root, className, {
           [darkTheme]: colorScheme === ThemeColorScheme.Dark,
           [lightTheme]: colorScheme === ThemeColorScheme.Light,


### PR DESCRIPTION
# Checklist

- [x] JIRA - https://input-output.atlassian.net/browse/LW-9606
- [ ] ~~Proper tests implemented~~
- [ ] ~~Screenshots added.~~

---

## Proposed solution

Create a decorator to add dark mode to stories and add it as default to global decorators
Add flag to disable global theme decorator to cover dialog/modal stories, as those need separated dark mode story

## Testing

Check: https://659e90c5edb661a3f34725d8-pmombxtshr.chromatic.com/


