### PR TITLE
[LW-10289] replace Koralabs handleProvider with SDK handleHttpProvider

### DIFF
--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -74,9 +74,9 @@ CEXPLORER_URL_PREPROD=https://preprod.cexplorer.io
 CEXPLORER_URL_SANCHONET=https://sancho.cexplorer.io
 
 # ADA Handle URLs
-ADA_HANDLE_URL_MAINNET=https://api.handle.me
-ADA_HANDLE_URL_PREVIEW=https://preview.api.handle.me
-ADA_HANDLE_URL_PREPROD=https://preprod.api.handle.me
+ADA_HANDLE_URL_MAINNET=https://dev-mainnet.lw.iog.io/
+ADA_HANDLE_URL_PREPROD=https://dev-preprod.lw.iog.io/
+ADA_HANDLE_URL_PREVIEW=https://dev-preview.lw.iog.io/
 ADA_HANDLE_URL_SANCHONET=
 
 # Manifest.json

--- a/apps/browser-extension-wallet/.env.developerpreview
+++ b/apps/browser-extension-wallet/.env.developerpreview
@@ -13,7 +13,7 @@ SAVED_PRICE_DURATION_IN_MINUTES=720
 # Feature Flags
 USE_PASSWORD_VERIFICATION=false
 USE_DAPP_CONNECTOR=true
-USE_TREZOR_HW=true
+USE_TREZOR_HW=false
 USE_TOKEN_PRICING=true
 USE_NFT_FOLDERS=true
 USE_MULTI_CURRENCY=true
@@ -74,9 +74,9 @@ CEXPLORER_URL_PREPROD=https://preprod.cexplorer.io
 CEXPLORER_URL_SANCHONET=https://sancho.cexplorer.io
 
 # ADA Handle URLs
-ADA_HANDLE_URL_MAINNET=https://api.handle.me
-ADA_HANDLE_URL_PREVIEW=https://preview.api.handle.me
-ADA_HANDLE_URL_PREPROD=https://preprod.api.handle.me
+ADA_HANDLE_URL_MAINNET=https://dev-mainnet.lw.iog.io
+ADA_HANDLE_URL_PREVIEW=https://dev-preview.lw.iog.io
+ADA_HANDLE_URL_PREPROD=https://dev-preprod.lw.iog.io
 ADA_HANDLE_URL_SANCHONET=
 
 # Manifest.json

--- a/apps/browser-extension-wallet/.env.example
+++ b/apps/browser-extension-wallet/.env.example
@@ -72,9 +72,9 @@ CEXPLORER_URL_PREPROD=https://preprod.cexplorer.io
 CEXPLORER_URL_SANCHONET=https://sancho.cexplorer.io
 
 # ADA Handle URLs
-ADA_HANDLE_URL_MAINNET=https://api.handle.me
-ADA_HANDLE_URL_PREVIEW=https://preview.api.handle.me
-ADA_HANDLE_URL_PREPROD=https://preprod.api.handle.me
+ADA_HANDLE_URL_MAINNET=https://dev-mainnet.lw.iog.io
+ADA_HANDLE_URL_PREVIEW=https://dev-preview.lw.iog.io
+ADA_HANDLE_URL_PREPROD=https://dev-preprod.lw.iog.io
 ADA_HANDLE_URL_SANCHONET=
 
 # Manifest.json

--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -48,7 +48,6 @@
     "@cardano-sdk/wallet": "0.37.3",
     "@cardano-sdk/web-extension": "0.27.3",
     "@emurgo/cip14-js": "~3.0.1",
-    "@koralabs/handles-public-api-interfaces": "^1.6.6",
     "@lace/cardano": "0.1.0",
     "@lace/common": "0.1.0",
     "@lace/core": "0.1.0",

--- a/apps/browser-extension-wallet/src/features/ada-handle/config.ts
+++ b/apps/browser-extension-wallet/src/features/ada-handle/config.ts
@@ -4,7 +4,7 @@ import { Wallet } from '@lace/cardano';
 export const ADA_HANDLE_POLICY_ID = Wallet.ADA_HANDLE_POLICY_ID;
 export const isAdaHandleEnabled = process.env.USE_ADA_HANDLE === 'true';
 export const HANDLE_SERVER_URLS: Record<Exclude<Cardano.NetworkMagics, Cardano.NetworkMagics.Sanchonet>, string> = {
-  [Cardano.NetworkMagics.Mainnet]: 'https://api.handle.me',
-  [Cardano.NetworkMagics.Preprod]: 'https://preprod.api.handle.me',
-  [Cardano.NetworkMagics.Preview]: 'https://preview.api.handle.me'
+  [Cardano.NetworkMagics.Mainnet]: process.env.ADA_HANDLE_URL_MAINNET,
+  [Cardano.NetworkMagics.Preprod]: process.env.ADA_HANDLE_URL_PREPROD,
+  [Cardano.NetworkMagics.Preview]: process.env.ADA_HANDLE_URL_PREVIEW
 };

--- a/apps/browser-extension-wallet/src/hooks/useHandleResolver.ts
+++ b/apps/browser-extension-wallet/src/hooks/useHandleResolver.ts
@@ -1,18 +1,20 @@
 import { useMemo } from 'react';
 import { useWalletStore } from '@src/stores';
-import { KoraLabsHandleProvider } from '@cardano-sdk/cardano-services-client';
-import { ADA_HANDLE_POLICY_ID, HANDLE_SERVER_URLS } from '@src/features/ada-handle/config';
+import { handleHttpProvider } from '@cardano-sdk/cardano-services-client';
+import { HandleProvider } from '@cardano-sdk/core';
+import { HANDLE_SERVER_URLS } from '@src/features/ada-handle/config';
+import { logger } from '@lib/wallet-api-ui';
 
-export const useHandleResolver = (): KoraLabsHandleProvider => {
+export const useHandleResolver = (): HandleProvider => {
   const {
     currentChain: { networkMagic }
   } = useWalletStore();
 
   return useMemo(() => {
     const serverUrl = HANDLE_SERVER_URLS[networkMagic as keyof typeof HANDLE_SERVER_URLS];
-    return new KoraLabsHandleProvider({
-      serverUrl,
-      policyId: ADA_HANDLE_POLICY_ID
+    return handleHttpProvider({
+      baseUrl: serverUrl,
+      logger
     });
   }, [networkMagic]);
 };

--- a/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
@@ -2,8 +2,7 @@ import { runtime, storage as webStorage } from 'webextension-polyfill';
 import { of, combineLatest, map, EMPTY } from 'rxjs';
 import { getProviders } from './config';
 import { DEFAULT_LOOK_AHEAD_SEARCH, HDSequentialDiscovery, createPersonalWallet, storage } from '@cardano-sdk/wallet';
-import { KoraLabsHandleProvider } from '@cardano-sdk/cardano-services-client';
-import axiosFetchAdapter from '@vespaiach/axios-fetch-adapter';
+import { handleHttpProvider } from '@cardano-sdk/cardano-services-client';
 import {
   AnyWallet,
   StoresFactory,
@@ -21,7 +20,7 @@ import {
   walletRepositoryProperties
 } from '@cardano-sdk/web-extension';
 import { Wallet } from '@lace/cardano';
-import { ADA_HANDLE_POLICY_ID, HANDLE_SERVER_URLS } from '@src/features/ada-handle/config';
+import { HANDLE_SERVER_URLS } from '@src/features/ada-handle/config';
 import { Cardano, NotImplementedError } from '@cardano-sdk/core';
 import { cacheActivatedWalletAddressSubscription } from './cache-wallets-address';
 
@@ -76,8 +75,8 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
         logger,
         ...providers,
         stores,
-        handleProvider: new KoraLabsHandleProvider({
-          serverUrl:
+        handleProvider: handleHttpProvider({
+          baseUrl:
             HANDLE_SERVER_URLS[
               // TODO: remove exclude to support sanchonet
               Cardano.ChainIds[chainName].networkMagic as Exclude<
@@ -85,8 +84,7 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
                 Cardano.NetworkMagics.Sanchonet
               >
             ],
-          adapter: axiosFetchAdapter,
-          policyId: ADA_HANDLE_POLICY_ID
+          logger
         }),
         addressDiscovery: new HDSequentialDiscovery(providers.chainHistoryProvider, DEFAULT_LOOK_AHEAD_SEARCH),
         witnesser,

--- a/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
@@ -23,6 +23,7 @@ import { Wallet } from '@lace/cardano';
 import { HANDLE_SERVER_URLS } from '@src/features/ada-handle/config';
 import { Cardano, NotImplementedError } from '@cardano-sdk/core';
 import { cacheActivatedWalletAddressSubscription } from './cache-wallets-address';
+import axiosFetchAdapter from '@vespaiach/axios-fetch-adapter';
 
 const logger = console;
 
@@ -76,6 +77,7 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
         ...providers,
         stores,
         handleProvider: handleHttpProvider({
+          adapter: axiosFetchAdapter,
           baseUrl:
             HANDLE_SERVER_URLS[
               // TODO: remove exclude to support sanchonet

--- a/apps/browser-extension-wallet/src/utils/validators/address-book.ts
+++ b/apps/browser-extension-wallet/src/utils/validators/address-book.ts
@@ -96,7 +96,7 @@ export const validateWalletHandle = async ({ value, handleResolver }: validateWa
 
   const response = await verifyHandle(value, handleResolver);
 
-  if (!response) {
+  if (!response.valid) {
     throw new Error(i18n.t('general.errors.incorrectHandle'));
   }
   return '';
@@ -116,21 +116,20 @@ export const ensureHandleOwnerHasntChanged = async ({
   }
 
   const { handle, cardanoAddress } = handleResolution;
-  const response = await handleResolver.resolveHandles({ handles: [handle] });
-  const newHandleResolution = response[0];
+  const resolvedHandle = await handleResolver.resolveHandles({ handles: [handle] });
 
-  if (!newHandleResolution) {
+  if (!resolvedHandle[0]) {
     throw new CustomError(i18n.t('general.errors.incorrectHandle'), false);
   }
 
-  if (!Cardano.util.addressesShareAnyKey(cardanoAddress, newHandleResolution.cardanoAddress)) {
+  if (!Cardano.util.addressesShareAnyKey(cardanoAddress, resolvedHandle[0].cardanoAddress)) {
     throw new CustomConflictError({
       message: `${i18n.t('general.errors.handleConflict', {
         receivedAddress: cardanoAddress,
-        actualAddress: newHandleResolution.cardanoAddress
+        actualAddress: resolvedHandle[0].cardanoAddress
       })}`,
       expectedAddress: cardanoAddress,
-      actualAddress: newHandleResolution.cardanoAddress
+      actualAddress: resolvedHandle[0].cardanoAddress
     });
   }
 };

--- a/apps/browser-extension-wallet/src/utils/validators/address-book.ts
+++ b/apps/browser-extension-wallet/src/utils/validators/address-book.ts
@@ -20,7 +20,7 @@ export const verifyHandle = async (
 ): Promise<ValidationResult & { handles?: HandleResolution[] }> => {
   try {
     const resolvedHandles = await handleResolver.resolveHandles({ handles: [value.slice(1).toLowerCase()] });
-    if (resolvedHandles.length === 0 || resolvedHandles === null) {
+    if (!resolvedHandles[0]) {
       return { valid: false };
     }
     return { valid: true, handles: resolvedHandles };
@@ -95,12 +95,10 @@ export const validateWalletHandle = async ({ value, handleResolver }: validateWa
   }
 
   const response = await verifyHandle(value, handleResolver);
-  const handles = response.handles;
 
-  if (!handles) {
+  if (!response) {
     throw new Error(i18n.t('general.errors.incorrectHandle'));
   }
-
   return '';
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10578,13 +10578,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@koralabs/handles-public-api-interfaces@npm:^1.6.6":
-  version: 1.6.6
-  resolution: "@koralabs/handles-public-api-interfaces@npm:1.6.6"
-  checksum: 10687928187ac935089781fc616a3c10596120aed2f5be2c28852cf2d8c1b14acbb72b90243f3228ff0bc9034c99230162d48d08f5aeb657c7d4decd6c6364e2
-  languageName: node
-  linkType: hard
-
 "@lace/browser-extension-wallet@workspace:apps/browser-extension-wallet":
   version: 0.0.0-use.local
   resolution: "@lace/browser-extension-wallet@workspace:apps/browser-extension-wallet"
@@ -10600,7 +10593,6 @@ __metadata:
     "@cardano-sdk/web-extension": 0.27.3
     "@emurgo/cardano-message-signing-asmjs": 1.0.1
     "@emurgo/cip14-js": ~3.0.1
-    "@koralabs/handles-public-api-interfaces": ^1.6.6
     "@lace/cardano": 0.1.0
     "@lace/common": 0.1.0
     "@lace/core": 0.1.0


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-10289
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution
We want to start using `handleHttpProvider` instead of Koralabs, therefore we replace all instances and clean up imports. 

## Testing
- Try to test handles, try to send to a handle, add a handle to address book, try to send to wrong handle and see it's not found. 
- Try to test subhandles as well in the same way. 

## Screenshots

![Screenshot 2024-04-30 at 11 19 12](https://github.com/input-output-hk/lace/assets/4052063/ab348c59-39a5-4607-8362-bff4821c6731)
![Screenshot 2024-04-30 at 11 19 07](https://github.com/input-output-hk/lace/assets/4052063/8a11e6dd-8937-4d47-908b-3ee8fd694309)
![Screenshot 2024-04-30 at 11 18 55](https://github.com/input-output-hk/lace/assets/4052063/7cb88dae-2a6e-4f94-a074-e17039c27de5)
![Screenshot 2024-04-30 at 11 18 48](https://github.com/input-output-hk/lace/assets/4052063/21936e9e-3908-4881-bc1d-769002b18332)
