### PR TITLE
fix(extension): [LW-10446] remove handle from getExistingAddress check 

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/AddressInput.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/AddressInput.tsx
@@ -297,7 +297,7 @@ export const AddressInput = ({ row, currentNetwork, isPopupView }: AddressInputP
         empty={!address}
         valid={isAddressInputValueValid}
         validationObject={validationObject}
-        exists={!!getExistingAddress(handle || address)}
+        exists={!!getExistingAddress(address)}
         className={styles.input}
         style={{ width: '100%' }}
         open

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/AddressInput.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/AddressInput.tsx
@@ -286,6 +286,18 @@ export const AddressInput = ({ row, currentNetwork, isPopupView }: AddressInputP
     (isAddressInputValueHandle || isAddressInputInvalidHandle) &&
     handleVerificationState === HandleVerificationState.INVALID;
 
+  const exists = () => {
+    if (handleVerificationState === HandleVerificationState.VALID) {
+      return Boolean(getExistingAddress(handle));
+    }
+
+    if (address.startsWith('$')) {
+      return false;
+    }
+
+    return Boolean(getExistingAddress(address));
+  };
+
   return (
     <span className={styles.container}>
       <DestinationAddressInput
@@ -297,7 +309,7 @@ export const AddressInput = ({ row, currentNetwork, isPopupView }: AddressInputP
         empty={!address}
         valid={isAddressInputValueValid}
         validationObject={validationObject}
-        exists={!!getExistingAddress(address)}
+        exists={exists()}
         className={styles.input}
         style={{ width: '100%' }}
         open


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-10446](https://input-output.atlassian.net/browse/LW-10446)

---

## Proposed solution

The `exists` property gets updated whenever the user is typing, thus, blocking the input field when the handle matches any existing address. The `DestinationAddressInput` component has an internal logic to disable the input when `handle === HandleVerificationState.VERIFYING`

[LW-10446]: https://input-output.atlassian.net/browse/LW-10446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ