### PR TITLE
Fix/lw 10502 fix for multiple stake pools requests

### DIFF
--- a/packages/staking/src/features/BrowsePools/StakePoolCard/constants.ts
+++ b/packages/staking/src/features/BrowsePools/StakePoolCard/constants.ts
@@ -1,1 +1,2 @@
 export const STAKE_POOL_CARD_HEIGHT = 84;
+export const STAKE_POOL_GRID_ROW_GAP = 12;

--- a/packages/staking/src/features/BrowsePools/StakePoolCard/index.ts
+++ b/packages/staking/src/features/BrowsePools/StakePoolCard/index.ts
@@ -1,4 +1,4 @@
 export { StakePoolCard } from './StakePoolCard';
 export { StakePoolCardProgressBar } from './SkatePoolCardProgressBar';
 export { StakePoolCardSkeleton } from './StakePoolCardSkeleton';
-export { STAKE_POOL_CARD_HEIGHT } from './constants';
+export { STAKE_POOL_CARD_HEIGHT, STAKE_POOL_GRID_ROW_GAP } from './constants';

--- a/packages/staking/src/features/BrowsePools/StakePoolsGrid/Grid.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsGrid/Grid.tsx
@@ -69,18 +69,16 @@ export const Grid = <T extends Record<string, unknown> | undefined>({
 
   return (
     <Flex h="$fill" ref={tableReference} data-testid="stake-pool-list-scroll-wrapper">
-      {items.length > 0 && scrollableTargetReference.current && (
-        <VirtuosoGrid<T>
-          overscan={overscan}
-          listClassName={cx.grid}
-          data={items}
-          customScrollParent={scrollableTargetReference.current}
-          totalCount={items.length}
-          className={cx.body}
-          rangeChanged={loadMoreData}
-          itemContent={itemContent}
-        />
-      )}
+      <VirtuosoGrid<T>
+        overscan={overscan}
+        listClassName={cx.grid}
+        data={items}
+        customScrollParent={scrollableTargetReference.current}
+        totalCount={items.length}
+        className={cx.body}
+        rangeChanged={loadMoreData}
+        itemContent={itemContent}
+      />
     </Flex>
   );
 };

--- a/packages/staking/src/features/BrowsePools/StakePoolsGrid/Grid.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsGrid/Grid.tsx
@@ -1,35 +1,26 @@
-/* eslint-disable react/no-multi-comp */
-import { Flex, useVisibleItemsCount } from '@lace/ui';
-import debounce from 'lodash/debounce';
-import { RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Flex } from '@lace/ui';
+import { useLayoutEffect, useRef } from 'react';
 import { ListRange, VirtuosoGrid, VirtuosoGridProps } from 'react-virtuoso';
-import useResizeObserver from 'use-resize-observer';
 import * as cx from './StakePoolsGrid.css';
 
 export type GridProps<T> = VirtuosoGridProps<T, null> & {
   items: T[];
   loadMoreData: (range: Readonly<ListRange>) => void;
   itemContent: (index: number, item: T) => React.ReactElement;
-  rowHeight: number;
   numberOfItemsPerRow?: number;
   scrollableTargetId?: string;
-  parentRef: RefObject<HTMLDivElement>;
+  tableReference?: React.Ref<HTMLDivElement>;
 };
-
-const DEFAULT_DEBOUNCE = 200;
 
 export const Grid = <T extends Record<string, unknown> | undefined>({
   itemContent,
   items,
   loadMoreData,
-  rowHeight,
-  numberOfItemsPerRow,
   scrollableTargetId = '',
-  parentRef,
+  tableReference,
+  ...props
 }: GridProps<T>) => {
-  const tableReference = useRef<HTMLDivElement | null>(null);
   const scrollableTargetReference = useRef<VirtuosoGridProps<T, undefined>['customScrollParent']>();
-  const [overscan, setOverscan] = useState({ main: 0, reverse: 0 });
 
   useLayoutEffect(() => {
     if (scrollableTargetId) {
@@ -37,40 +28,9 @@ export const Grid = <T extends Record<string, unknown> | undefined>({
     }
   }, [scrollableTargetId]);
 
-  const initialRowsCount = useVisibleItemsCount({
-    containerRef: tableReference,
-    rowHeight,
-  });
-
-  useEffect(() => {
-    if (tableReference && initialRowsCount !== undefined && numberOfItemsPerRow !== undefined) {
-      loadMoreData({ endIndex: Math.max(initialRowsCount, 1) * numberOfItemsPerRow, startIndex: 0 });
-    }
-  }, [initialRowsCount, loadMoreData, numberOfItemsPerRow, rowHeight]);
-
-  const updateGridOverscan = useCallback(() => {
-    if (!tableReference?.current || !parentRef?.current) return;
-    // VirtuosoGrid won't render more items in case it's top position (visible items count) changes, force it manually via overscan value
-    const tableVsParentHeightDiff =
-      parentRef.current.getBoundingClientRect().height - tableReference.current.getBoundingClientRect().height;
-    setOverscan({ main: tableVsParentHeightDiff, reverse: 0 });
-  }, [parentRef]);
-
-  useLayoutEffect(() => {
-    updateGridOverscan();
-  }, [updateGridOverscan]);
-
-  const onResize = useMemo(
-    () => debounce(updateGridOverscan, DEFAULT_DEBOUNCE, { leading: true }),
-    [updateGridOverscan]
-  );
-
-  useResizeObserver<HTMLElement>({ onResize, ref: parentRef });
-
   return (
     <Flex h="$fill" ref={tableReference} data-testid="stake-pool-list-scroll-wrapper">
       <VirtuosoGrid<T>
-        overscan={overscan}
         listClassName={cx.grid}
         data={items}
         customScrollParent={scrollableTargetReference.current}
@@ -78,6 +38,7 @@ export const Grid = <T extends Record<string, unknown> | undefined>({
         className={cx.body}
         rangeChanged={loadMoreData}
         itemContent={itemContent}
+        {...props}
       />
     </Flex>
   );

--- a/packages/staking/src/features/BrowsePools/StakePoolsGrid/StakePoolsGrid.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsGrid/StakePoolsGrid.tsx
@@ -84,6 +84,12 @@ export const StakePoolsGrid = ({
 
   useResizeObserver<HTMLDivElement>({ onResize, ref });
 
+  const itemContent = useCallback(
+    (index: number, data: StakePoolDetails | undefined): React.ReactElement =>
+      data ? <StakePoolsGridItem {...data} /> : <StakePoolCardSkeleton fadeScale={columnCount} index={index} />,
+    [columnCount]
+  );
+
   return (
     <div ref={ref} data-testid="stake-pools-grid-container">
       {selectedPools?.length > 0 && (
@@ -110,13 +116,7 @@ export const StakePoolsGrid = ({
           scrollableTargetId={scrollableTargetId}
           loadMoreData={loadMoreData}
           items={pools}
-          itemContent={(index, data) =>
-            data ? (
-              <StakePoolsGridItem sortField={sortField} {...data} />
-            ) : (
-              <StakePoolCardSkeleton fadeScale={columnCount} index={index} />
-            )
-          }
+          itemContent={itemContent}
         />
       )}
     </div>

--- a/packages/staking/src/features/BrowsePools/StakePoolsGrid/StakePoolsGridItem.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsGrid/StakePoolsGridItem.tsx
@@ -3,6 +3,7 @@ import { StakePoolCard } from 'features/BrowsePools/StakePoolCard';
 import React from 'react';
 import { useOutsideHandles } from '../../outside-handles-provider';
 import { MAX_POOLS_COUNT, StakePoolDetails, isPoolSelectedSelector, useDelegationPortfolioStore } from '../../store';
+import { DEFAULT_SORT_OPTIONS } from '../constants';
 import { getFormattedStakePoolProp } from '../formatters';
 import { useQueryStakePools } from '../hooks';
 import { SortField } from '../types';
@@ -15,7 +16,7 @@ export const StakePoolsGridItem = ({ stakePool, hexId, id, ...data }: StakePools
   const { analytics } = useOutsideHandles();
   const { sort } = useQueryStakePools();
 
-  const sortField = sort?.field || 'ticker';
+  const sortField = sort?.field || DEFAULT_SORT_OPTIONS.field;
 
   const { portfolioMutators, poolAlreadySelected } = useDelegationPortfolioStore((store) => ({
     poolAlreadySelected: isPoolSelectedSelector(hexId)(store),

--- a/packages/staking/src/features/BrowsePools/StakePoolsGrid/StakePoolsGridItem.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsGrid/StakePoolsGridItem.tsx
@@ -4,20 +4,18 @@ import React from 'react';
 import { useOutsideHandles } from '../../outside-handles-provider';
 import { MAX_POOLS_COUNT, StakePoolDetails, isPoolSelectedSelector, useDelegationPortfolioStore } from '../../store';
 import { getFormattedStakePoolProp } from '../formatters';
+import { useQueryStakePools } from '../hooks';
 import { SortField } from '../types';
 
 type StakePoolsGridItemProps = StakePoolDetails & {
   sortField?: SortField;
 };
 
-export const StakePoolsGridItem = ({
-  stakePool,
-  hexId,
-  id,
-  sortField = 'ticker',
-  ...data
-}: StakePoolsGridItemProps): React.ReactElement => {
+export const StakePoolsGridItem = ({ stakePool, hexId, id, ...data }: StakePoolsGridItemProps): React.ReactElement => {
   const { analytics } = useOutsideHandles();
+  const { sort } = useQueryStakePools();
+
+  const sortField = sort?.field || 'ticker';
 
   const { portfolioMutators, poolAlreadySelected } = useDelegationPortfolioStore((store) => ({
     poolAlreadySelected: isPoolSelectedSelector(hexId)(store),

--- a/packages/staking/src/features/BrowsePools/StakePoolsList/StakePoolsList.css.ts
+++ b/packages/staking/src/features/BrowsePools/StakePoolsList/StakePoolsList.css.ts
@@ -5,6 +5,10 @@ export const selectedTitle = sx({
   color: '$titleColor',
 });
 
+export const box = style({
+  position: 'relative',
+});
+
 export const selectedPools = style([
   sx({
     borderBottomColor: '$selectedPoolsSectionBorderColor',

--- a/packages/staking/src/features/BrowsePools/StakePoolsSearchEmpty.css.ts
+++ b/packages/staking/src/features/BrowsePools/StakePoolsSearchEmpty.css.ts
@@ -15,3 +15,8 @@ export const text = style([
     textAlign: 'center',
   },
 ]);
+
+export const wrapper = style({
+  minHeight: '144px',
+  position: 'absolute',
+});

--- a/packages/staking/src/features/BrowsePools/StakePoolsSearchEmpty.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsSearchEmpty.tsx
@@ -16,6 +16,7 @@ export const StakePoolsSearchEmpty = (): React.ReactElement => {
       h="$fill"
       w="$fill"
       data-testid="stake-pool-table-empty"
+      className={styles.wrapper}
     >
       <Empty data-testid="stake-pool-table-empty-image" className={styles.icon} />
       <Text.Body.Small className={styles.text} weight="$medium" data-testid="stake-pool-table-empty-message">

--- a/packages/ui/src/design-system/table/table-body.component.tsx
+++ b/packages/ui/src/design-system/table/table-body.component.tsx
@@ -1,33 +1,29 @@
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 
 import { Virtuoso } from 'react-virtuoso';
 
 import { Flex } from '../flex';
 
-import { useVisibleItemsCount } from './hooks';
 import * as cx from './table.css';
 
 import type { ListRange, VirtuosoProps } from 'react-virtuoso';
 
-const DEFAULT_ROW_HIGHT = 44;
-
 export type BodyProps<T> = VirtuosoProps<T, null> & {
-  items: T[];
+  items: T[] | undefined;
   loadMoreData: (range: Readonly<ListRange>) => void;
   itemContent: (index: number, item: T) => React.ReactElement;
-  rowHeight?: number;
   scrollableTargetId?: string;
+  tableReference?: React.Ref<HTMLDivElement>;
 };
 
 export const Body = <T extends object | undefined>({
   itemContent,
   items,
   loadMoreData,
-  rowHeight = DEFAULT_ROW_HIGHT,
   scrollableTargetId = '',
+  tableReference,
   ...props
 }: Readonly<BodyProps<T>>): React.ReactElement => {
-  const tableReference = useRef<HTMLDivElement | null>(null);
   const scrollableTargetReference =
     useRef<VirtuosoProps<T, undefined>['customScrollParent']>();
 
@@ -40,17 +36,6 @@ export const Body = <T extends object | undefined>({
     }
   }, [scrollableTargetId]);
 
-  const initialItemsLimit = useVisibleItemsCount({
-    rowHeight,
-    containerRef: tableReference,
-  });
-
-  useEffect(() => {
-    if (initialItemsLimit !== undefined) {
-      loadMoreData({ endIndex: Math.max(initialItemsLimit, 1), startIndex: 0 });
-    }
-  }, [initialItemsLimit, loadMoreData]);
-
   return (
     <Flex
       h="$fill"
@@ -59,7 +44,6 @@ export const Body = <T extends object | undefined>({
     >
       <Virtuoso
         customScrollParent={scrollableTargetReference.current}
-        totalCount={items.length}
         data={items}
         rangeChanged={loadMoreData}
         className={cx.body}


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-10502](https://input-output.atlassian.net/browse/LW-10502)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

- [x] memoize all props of virtuoso related components to avoid additional re-rendering;
- [x] do not unmount virtuoso grid and table component (is not done for grid comp yet);
- [x] remove as match as possible conditional rendering from layout, eg: `EmptyTable` component or `Table Header` is a good example, removing them from the DOM, would cause `Virtuoso components` to change their `height` (**trigger `rangeChange` cb -> `load more data` as a result**)
- [x] in case the next chunk of requested data is smaller then previous one (eg: search query is more specific), Virtuoso component would trigger `rangeChange` cb (obviously, because the range has just changed) in addition to the one we've just fired manual (due to search query change).  **Seems like an expected behaviour for me**?

## Testing

- there should be no that on request for single user input*

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-10502]: https://input-output.atlassian.net/browse/LW-10502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ