### PR TITLE
fix/unblock  analytics tests + move create_alias event to 'enter wallet' button click

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/MultiWallet.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/MultiWallet.tsx
@@ -30,6 +30,7 @@ export const MultiWallet = (): JSX.Element => {
               />
             </div>
             <WalletOnboardingFlows
+              mergeEventRequired
               postHogActions={postHogMultiWalletActions}
               renderHome={() => <Home />}
               setFormDirty={(dirty) => shouldShowDialog$.next(dirty)}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/WalletOnboardingFlows.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/WalletOnboardingFlows.tsx
@@ -9,6 +9,7 @@ import { WalletOnboardingProvider } from './walletOnboardingContext';
 
 type WalletOnboardingProps = {
   aliasEventRequired?: boolean;
+  mergeEventRequired?: boolean;
   flowsEnabled?: boolean;
   forgotPasswordFlowActive?: boolean;
   postHogActions: WalletOnboardingPostHogActions;
@@ -19,6 +20,7 @@ type WalletOnboardingProps = {
 
 export const WalletOnboardingFlows: VFC<WalletOnboardingProps> = ({
   aliasEventRequired = false,
+  mergeEventRequired = false,
   flowsEnabled = true,
   forgotPasswordFlowActive = false,
   postHogActions,
@@ -39,7 +41,9 @@ export const WalletOnboardingFlows: VFC<WalletOnboardingProps> = ({
 
   const { path } = useRouteMatch();
   return (
-    <WalletOnboardingProvider value={{ aliasEventRequired, forgotPasswordFlowActive, postHogActions, setFormDirty }}>
+    <WalletOnboardingProvider
+      value={{ aliasEventRequired, mergeEventRequired, forgotPasswordFlowActive, postHogActions, setFormDirty }}
+    >
       <Switch>
         <Route exact path={`${path}/`} render={renderHome} />
         {flowsEnabled && (

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
@@ -218,6 +218,7 @@ export const HardwareWalletProvider = ({ children }: HardwareWalletProviderProps
     }
   }, [
     aliasEventRequired,
+    mergeEventRequired,
     analytics,
     closeConnection,
     connection,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
@@ -211,11 +211,11 @@ export const HardwareWalletProvider = ({ children }: HardwareWalletProviderProps
       await analytics.sendMergeEvent(cardanoWallet.source.account.extendedAccountPublicKey);
     }
 
+    await saveHardwareWallet(cardanoWallet);
+
     if (await isHdWallet(cardanoWallet.wallet)) {
       await analytics.sendEventToPostHog(postHogActions.hardware.HD_WALLET);
     }
-
-    await saveHardwareWallet(cardanoWallet);
   }, [
     aliasEventRequired,
     mergeEventRequired,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
@@ -203,19 +203,19 @@ export const HardwareWalletProvider = ({ children }: HardwareWalletProviderProps
       /* eslint-enable camelcase */
     });
 
+    if (aliasEventRequired) {
+      await analytics.sendAliasEvent();
+    }
+
     if (mergeEventRequired) {
       await analytics.sendMergeEvent(cardanoWallet.source.account.extendedAccountPublicKey);
     }
-
-    await saveHardwareWallet(cardanoWallet);
 
     if (await isHdWallet(cardanoWallet.wallet)) {
       await analytics.sendEventToPostHog(postHogActions.hardware.HD_WALLET);
     }
 
-    if (aliasEventRequired) {
-      await analytics.sendAliasEvent();
-    }
+    await saveHardwareWallet(cardanoWallet);
   }, [
     aliasEventRequired,
     mergeEventRequired,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
@@ -48,7 +48,7 @@ export const useHardwareWallet = (): State => {
 export const HardwareWalletProvider = ({ children }: HardwareWalletProviderProps): React.ReactElement => {
   const analytics = useAnalyticsContext();
   const history = useHistory();
-  const { aliasEventRequired } = useWalletOnboarding();
+  const { aliasEventRequired, mergeEventRequired } = useWalletOnboarding();
   const { postHogActions, setFormDirty } = useWalletOnboarding();
   const { connectHardwareWalletRevamped, createHardwareWalletRevamped, saveHardwareWallet, walletRepository } =
     useWalletManager();
@@ -202,7 +202,10 @@ export const HardwareWalletProvider = ({ children }: HardwareWalletProviderProps
       $set: { wallet_accounts_quantity: await getWalletAccountsQtyString(walletRepository) }
       /* eslint-enable camelcase */
     });
-    await analytics.sendMergeEvent(cardanoWallet.source.account.extendedAccountPublicKey);
+
+    if (mergeEventRequired) {
+      await analytics.sendMergeEvent(cardanoWallet.source.account.extendedAccountPublicKey);
+    }
 
     await saveHardwareWallet(cardanoWallet);
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/useHotWalletCreation.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/useHotWalletCreation.ts
@@ -43,7 +43,6 @@ export const useHotWalletCreation = ({ initialMnemonic }: UseSoftwareWalletCreat
   const createWallet = () => walletManager.createWallet(createWalletData);
 
   const sendPostWalletAddAnalytics = async ({
-    extendedAccountPublicKey,
     postHogActionHdWallet,
     postHogActionWalletAdded,
     wallet
@@ -52,14 +51,13 @@ export const useHotWalletCreation = ({ initialMnemonic }: UseSoftwareWalletCreat
       // eslint-disable-next-line camelcase
       $set: { wallet_accounts_quantity: await getWalletAccountsQtyString(walletManager.walletRepository) }
     });
-    await analytics.sendMergeEvent(extendedAccountPublicKey);
-
-    if (postHogActionHdWallet && wallet && (await isHdWallet(wallet))) {
-      await analytics.sendEventToPostHog(postHogActionHdWallet);
-    }
 
     if (aliasEventRequired) {
       await analytics.sendAliasEvent();
+    }
+
+    if (postHogActionHdWallet && wallet && (await isHdWallet(wallet))) {
+      await analytics.sendEventToPostHog(postHogActionHdWallet);
     }
   };
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/useHotWalletCreation.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/useHotWalletCreation.ts
@@ -24,7 +24,7 @@ type SendPostWalletAddAnalyticsParams = {
 export const useHotWalletCreation = ({ initialMnemonic }: UseSoftwareWalletCreationParams) => {
   const analytics = useAnalyticsContext();
   const walletManager = useWalletManager();
-  const { aliasEventRequired } = useWalletOnboarding();
+  const { aliasEventRequired, mergeEventRequired } = useWalletOnboarding();
   const [createWalletData, setCreateWalletData] = useState<CreateWalletParams>({
     mnemonic: initialMnemonic,
     name: '',
@@ -43,6 +43,7 @@ export const useHotWalletCreation = ({ initialMnemonic }: UseSoftwareWalletCreat
   const createWallet = () => walletManager.createWallet(createWalletData);
 
   const sendPostWalletAddAnalytics = async ({
+    extendedAccountPublicKey,
     postHogActionHdWallet,
     postHogActionWalletAdded,
     wallet
@@ -54,6 +55,10 @@ export const useHotWalletCreation = ({ initialMnemonic }: UseSoftwareWalletCreat
 
     if (aliasEventRequired) {
       await analytics.sendAliasEvent();
+    }
+
+    if (mergeEventRequired) {
+      await analytics.sendMergeEvent(extendedAccountPublicKey);
     }
 
     if (postHogActionHdWallet && wallet && (await isHdWallet(wallet))) {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/walletOnboardingContext.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/walletOnboardingContext.tsx
@@ -3,6 +3,7 @@ import { SetFormDirty, WalletOnboardingPostHogActions } from './types';
 
 type ContextValue = {
   aliasEventRequired: boolean;
+  mergeEventRequired: boolean;
   forgotPasswordFlowActive: boolean;
   postHogActions: WalletOnboardingPostHogActions;
   setFormDirty: SetFormDirty;

--- a/packages/e2e-tests/src/features/analytics/AnalyticsOnboardingEvents.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsOnboardingEvents.feature
@@ -1,7 +1,7 @@
 @OnboardingCreateWallet @Analytics @Testnet
 Feature: Analytics - Posthog - Onboarding - Extended View
 
-  @LW-8311 @Pending @issue=LW-10488
+  @LW-8311
   Scenario Outline: Analytics - Posthog events are enabled or disabled based on decision <enable_analytics> on Analytics page
     Given "Get started" page is displayed
     When I enable showing Analytics consent banner
@@ -28,16 +28,17 @@ Feature: Analytics - Posthog - Onboarding - Extended View
     And I click "Enter wallet" button
     Then I validate latest analytics multiple events:
       | onboarding \| restore wallet revamp \| let's set up your new wallet \| enter wallet \| click |
+      | onboarding \| restore wallet revamp \| added                                                 |
       | $create_alias                                                                                |
     And I validate that alias event has assigned same user id "5b3ca1f1f7a14aad1e79f46213e2777d" in posthog
 
-  @LW-7365 @Pending @issue=LW-10488
+  @LW-7365
   Scenario: Analytics - Onboarding new wallet events
     Given "Get started" page is displayed
     When I enable showing Analytics consent banner
     And I set up request interception for posthog analytics request(s)
     And I accept analytics banner on "Get started" page
-    Then I validate latest analytics single event "wallet | onboarding | analytics banner | agree | click"
+    Then I validate latest analytics single event "onboarding | analytics banner | agree | click"
     When I click "Create" button on wallet setup page
     Then I validate latest analytics single event "onboarding | new wallet revamp | create | click"
     When I go to "Mnemonic verification" page from "Create" wallet flow
@@ -49,8 +50,9 @@ Feature: Analytics - Posthog - Onboarding - Extended View
     And I click "Enter wallet" button
     Then I validate latest analytics multiple events:
       | onboarding \| new wallet revamp \| let's set up your new wallet \| enter wallet \| click |
-      | $create_alias                                                                            |
-    And I validate that 6 analytics event(s) have been sent
+      | onboarding \| new wallet revamp \| added                                                 |
+      | $create_alias                                                                                |
+    And I validate that 7 analytics event(s) have been sent
 
   @LW-7364 @Pending
     # Disabled as user is opted out until he decision about tracking.


### PR DESCRIPTION
Unblock tests LW-8311,LW-7365 [here](https://input-output.atlassian.net/browse/LW-10488).
After discussion with @vhulchenko-iohk and @szymonmaslowski I moved create_event sending to 'enter wallet' button click
Also new bug popped up during this [LW-10635](https://input-output.atlassian.net/browse/LW-10635) and will be fixed here as well

[LW-10635]: https://input-output.atlassian.net/browse/LW-10635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ