### PR TITLE
fix(staking): [LW-10669] remove unnecessary wrapper class for empty placeholder

### DIFF
--- a/packages/staking/src/features/BrowsePools/StakePoolsSearchEmpty.css.ts
+++ b/packages/staking/src/features/BrowsePools/StakePoolsSearchEmpty.css.ts
@@ -15,8 +15,3 @@ export const text = style([
     textAlign: 'center',
   },
 ]);
-
-export const wrapper = style({
-  minHeight: '144px',
-  position: 'absolute',
-});

--- a/packages/staking/src/features/BrowsePools/StakePoolsSearchEmpty.tsx
+++ b/packages/staking/src/features/BrowsePools/StakePoolsSearchEmpty.tsx
@@ -16,7 +16,6 @@ export const StakePoolsSearchEmpty = (): React.ReactElement => {
       h="$fill"
       w="$fill"
       data-testid="stake-pool-table-empty"
-      className={styles.wrapper}
     >
       <Empty data-testid="stake-pool-table-empty-image" className={styles.icon} />
       <Text.Body.Small className={styles.text} weight="$medium" data-testid="stake-pool-table-empty-message">


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-10669)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution
Remove unnecessary class added to the empty placeholder wrapper during LW-10502.

## Testing
1. Open Lace.
2. Go to Staking page.
3. Switch to grid view.
4. Enter search query that does not return any results.

Verify page UI.

## Screenshots
<img width="1501" alt="image" src="https://github.com/input-output-hk/lace/assets/17825044/b2e5d3ab-0bb3-41e4-a135-dc41351dc328">