### PR TITLE
fix(ui,core): [LW-10671] add z-index for account select in HW setup flow

### DIFF
--- a/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupSelectAccountsStepRevamp.module.scss
+++ b/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupSelectAccountsStepRevamp.module.scss
@@ -14,7 +14,3 @@
 .label {
   z-index: 0 !important;
 }
-
-.selectOptions {
-  z-index: 1000;
-}

--- a/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupSelectAccountsStepRevamp.tsx
+++ b/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupSelectAccountsStepRevamp.tsx
@@ -81,6 +81,7 @@ export const WalletSetupSelectAccountsStepRevamp = ({
               onSelectedAccountChange?.();
             }}
             showArrow
+            zIndex={1000}
           >
             {options.map(({ value, label }) => (
               <Select.Item key={value} value={value} title={label} />

--- a/packages/ui/src/design-system/select/select-root.component.tsx
+++ b/packages/ui/src/design-system/select/select-root.component.tsx
@@ -25,6 +25,7 @@ export type SelectRootProps = Pick<
   variant?: SelectVariant;
   portalContainer?: HTMLElement;
   triggerTestId?: string;
+  zIndex?: number;
 };
 
 const isValidSelectRootChild = (
@@ -54,6 +55,7 @@ const isValidSelectRootChild = (
  * @param value See: https://www.radix-ui.com/primitives/docs/components/select#root
  * @param variant The style variant.
  * @param triggerTestId The `data-testid` attribute, passed to the input trigger / root element.
+ * @param zIndex The `z-index` applied to the `<Select.Content />`.
  */
 export const Root = ({
   align = 'selected',
@@ -70,6 +72,7 @@ export const Root = ({
   value,
   variant = 'plain',
   triggerTestId,
+  zIndex,
 }: Readonly<SelectRootProps>): JSX.Element => {
   const [isOpen, setIsOpen] = React.useState(defaultOpen);
 
@@ -97,6 +100,7 @@ export const Root = ({
       </Select.Trigger>
       <Select.Portal container={portalContainer}>
         <Select.Content
+          style={{ zIndex }}
           className={cx.content[variant]}
           position={align === 'selected' ? 'item-aligned' : 'popper'}
         >


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-10671)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution
1. Add new `zIndex` prop to the Select component
2. Use `zIndex` in `WalletSetupSelectAccountsStepRevamp` (Select)

## Testing
1. Open Lace.
3. Open user menu.
4. Click on Add new wallet button.
5. Connect HW wallet via USB cable, unlock it and run Cardano app (Ledger).
6. Click on Connect button.
7. Select your device from HID window and click Connect button.
8. Reveal accounts list.

## Screenshots
<img width="864" alt="image" src="https://github.com/input-output-hk/lace/assets/17825044/7b0486a8-8876-42c0-93f0-8d174050828a">