### PR TITLE
fix(staking): [LW-10659] oversaturated dot color in StakePoolsTable view

### DIFF
--- a/packages/staking/src/features/theme/colors.ts
+++ b/packages/staking/src/features/theme/colors.ts
@@ -90,7 +90,7 @@ export const lightThemeColors: typeof colorsContract = {
   $stakePoolGridSeparatorColor: lightColorScheme.$primary_light_grey_plus,
   $stakePoolListCellDotHighColor: lightColorScheme.$secondary_data_orange,
   $stakePoolListCellDotMediumColor: lightColorScheme.$secondary_data_green,
-  $stakePoolListCellDotVeryHighColor: lightColorScheme.$primary_grey,
+  $stakePoolListCellDotVeryHighColor: darkColorScheme.$secondary_data_pink,
   $stakePoolListPlaceholderCheckboxColor: lightColorScheme.$primary_grey,
   $titleColor: lightColorScheme.$primary_dark_grey,
   $tooltipBgColor: lightColorScheme.$primary_white,


### PR DESCRIPTION
# Checklist

- [x] JIRA - \<link>
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution
Replace incorrect color for the oversaturated state in the Stake Pools Table view.

## Testing
1. Open Lace (please use Mainnet due to better stake pools availability).
2. Go to Staking page.
3. Open Browse pools tab.
4. Switch to list view.
5. Click on Saturation column header.
6. Take a look at saturation indicators (saturation >= 95%).

## Screenshots
<img width="1778" alt="image" src="https://github.com/input-output-hk/lace/assets/17825044/f6db6776-7ea6-46e7-8e31-d9dc12dd67ee">