### PR TITLE
fix(extension): [LW-10672] fix broken try again button while enabling account

### DIFF
--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/WalletAccounts.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/WalletAccounts.tsx
@@ -134,18 +134,18 @@ export const WalletAccounts = ({ isPopup, onBack }: { isPopup: boolean; onBack: 
     [disableAccountConfirmation, accountsData]
   );
 
-  const showHWErrorState = useCallback(() => {
+  const showHWErrorState = (accountIndex: number) => {
     enableAccountHWSigningDialog.setData({
-      ...enableAccountHWSigningDialog.data,
+      accountIndex,
       state: 'error'
     });
-  }, [enableAccountHWSigningDialog]);
+  };
 
   const unlockHWAccount = useCallback(
     async (accountIndex: number) => {
       const name = defaultAccountName(accountIndex);
       try {
-        const timeout = setTimeout(showHWErrorState, HW_CONNECT_TIMEOUT_MS);
+        const timeout = setTimeout(() => showHWErrorState(accountIndex), HW_CONNECT_TIMEOUT_MS);
         if (wallet.type === WalletType.InMemory) return;
         await Wallet.connectDevice(wallet.type);
         await addAccount({
@@ -161,7 +161,7 @@ export const WalletAccounts = ({ isPopup, onBack }: { isPopup: boolean; onBack: 
         enableAccountHWSigningDialog.hide();
         closeDropdownAndShowAccountActivated(name);
       } catch {
-        showHWErrorState();
+        showHWErrorState(accountIndex);
       }
     },
     [

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/WalletAccounts.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/WalletAccounts.tsx
@@ -134,12 +134,12 @@ export const WalletAccounts = ({ isPopup, onBack }: { isPopup: boolean; onBack: 
     [disableAccountConfirmation, accountsData]
   );
 
-  const showHWErrorState = (accountIndex: number) => {
+  const showHWErrorState = useCallback((accountIndex: number) => {
     enableAccountHWSigningDialog.setData({
       accountIndex,
       state: 'error'
     });
-  };
+  }, []);
 
   const unlockHWAccount = useCallback(
     async (accountIndex: number) => {


### PR DESCRIPTION
# Checklist
[Jira Ticket]: https://input-output.atlassian.net/browse/LW-10672

This PR introduces a fix for the broken "Try Again" button while enabling an account with **_Ledger HW._**

---

## Proposed solution

While trying to enable an account when the dive is locked, the component loses the selected account index in an error state. This fix ensures that the index is passed to the error state so the user can click on "Try again" and re-try the procedure 

## Testing
Check the steps to reproduce described in the ticket https://input-output.atlassian.net/browse/LW-10672:

1. Open Lace with Ledger wallet restored and connected.
2. Open user menu.
3. Open account menu for connected wallet.
4. Lock Ledger device.
5. Click on Enable button for any of disabled accounts.
6. Select your device from HID window and click Connect button.
7. Unlock your Ledger device, make sure that Cardano app is active.
8. Click on Try again button.
9. Select your device from HID window and click Connect button.
10. Click on Try again button.