### PR TITLE
fix(extension): [lw-10782] add proper mappers for missed conway era certs

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useWalletActivities.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletActivities.ts
@@ -22,6 +22,7 @@ export const useWalletActivities = ({
 
   const fetchWalletActivities = useCallback(async () => {
     fiatCurrency &&
+      cardanoFiatPrice &&
       getWalletActivities({
         fiatCurrency,
         cardanoFiatPrice,

--- a/apps/browser-extension-wallet/src/utils/tx-inspection.ts
+++ b/apps/browser-extension-wallet/src/utils/tx-inspection.ts
@@ -9,6 +9,7 @@ import {
   sentInspector,
   totalAddressOutputsValueInspector
 } from '@cardano-sdk/core';
+import { certificateInspectorFactory } from '@src/features/dapp/components/confirm-transaction/utils';
 import { Wallet } from '@lace/cardano';
 import {
   ActivityType,
@@ -54,10 +55,6 @@ const governanceCertificateInspection = (
   // Assumes single certificate only, should update
 
   switch (true) {
-    case signedCertificateTypenames.includes(CertificateType.Registration):
-      return ConwayEraCertificatesTypes.Registration;
-    case signedCertificateTypenames.includes(CertificateType.Unregistration):
-      return ConwayEraCertificatesTypes.Unregistration;
     case signedCertificateTypenames.includes(CertificateType.RegisterDelegateRepresentative):
       return ConwayEraCertificatesTypes.RegisterDelegateRepresentative;
     case signedCertificateTypenames.includes(CertificateType.UnregisterDelegateRepresentative):
@@ -112,7 +109,7 @@ const getWalletAccounts = (walletAddresses: Wallet.KeyManagement.GroupedAddress[
     { paymentAddresses: [], rewardAccounts: [] }
   );
 
-const txIncludesConwayCertificates = (certificates?: Wallet.Cardano.Certificate[]) =>
+export const txIncludesConwayCertificates = (certificates?: Wallet.Cardano.Certificate[]): boolean =>
   certificates?.length > 0
     ? certificates.some((certificate) =>
         Object.values(ConwayEraCertificatesTypes).includes(
@@ -162,11 +159,16 @@ export const inspectTxType = async ({
     delegation: delegationInspector,
     stakeKeyRegistration: stakeKeyRegistrationInspector,
     stakeKeyDeregistration: stakeKeyDeregistrationInspector,
+    conwayEraStakeKeyRegistration: certificateInspectorFactory(CertificateType.Registration),
+    conwayEraStakeKeyDeregistration: certificateInspectorFactory(CertificateType.Unregistration),
     selfTransaction: selfTxInspector(paymentAddresses)
   })(tx);
 
   if (txIncludesConwayCertificates(tx.body.certificates)) {
-    return governanceCertificateInspection(tx.body.certificates);
+    const inspection = governanceCertificateInspection(tx.body.certificates);
+    if (inspection) {
+      return inspection;
+    }
   }
 
   const withRewardsWithdrawal = isTxWithRewardsWithdrawal(
@@ -183,6 +185,10 @@ export const inspectTxType = async ({
         return DelegationActivityType.delegationRegistration;
       case inspectionProperties.stakeKeyDeregistration.length > 0:
         return DelegationActivityType.delegationDeregistration;
+      case !!inspectionProperties.conwayEraStakeKeyRegistration:
+        return ConwayEraCertificatesTypes.Registration;
+      case !!inspectionProperties.conwayEraStakeKeyDeregistration:
+        return ConwayEraCertificatesTypes.Unregistration;
       // Voting procedures take priority over proposals
       // TODO: use proper inspector when available on sdk side (LW-9569)
       case tx.body.votingProcedures?.length > 0:

--- a/apps/browser-extension-wallet/src/utils/tx-inspection.ts
+++ b/apps/browser-extension-wallet/src/utils/tx-inspection.ts
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 /* eslint-disable consistent-return */
 import {
   createTxInspector,
@@ -53,8 +54,11 @@ const governanceCertificateInspection = (
   // Assumes single certificate only, should update
 
   switch (true) {
+    case signedCertificateTypenames.includes(CertificateType.Registration):
+      return ConwayEraCertificatesTypes.Registration;
+    case signedCertificateTypenames.includes(CertificateType.Unregistration):
+      return ConwayEraCertificatesTypes.Unregistration;
     case signedCertificateTypenames.includes(CertificateType.RegisterDelegateRepresentative):
-      // TODO: can we map to Cip30TxType instead?
       return ConwayEraCertificatesTypes.RegisterDelegateRepresentative;
     case signedCertificateTypenames.includes(CertificateType.UnregisterDelegateRepresentative):
       return ConwayEraCertificatesTypes.UnregisterDelegateRepresentative;

--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityDetail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityDetail.tsx
@@ -3,8 +3,9 @@ import uniq from 'lodash/uniq';
 import flatMap from 'lodash/flatMap';
 import { Skeleton } from 'antd';
 import { Wallet } from '@lace/cardano';
-import type { ActivityType } from '@lace/core';
 import {
+  ActivityType,
+  ConwayEraCertificatesTypes,
   ActivityStatus,
   AssetActivityListProps,
   DelegationActivityType,
@@ -83,8 +84,10 @@ interface ActivityDetailProps {
 }
 
 const getTypeLabel = (type: ActivityType): TranslationKey => {
-  if (type === DelegationActivityType.delegationRegistration) return 'core.activityDetails.registration';
-  if (type === DelegationActivityType.delegationDeregistration) return 'core.activityDetails.deregistration';
+  if (type === DelegationActivityType.delegationRegistration || type === ConwayEraCertificatesTypes.Registration)
+    return 'core.activityDetails.registration';
+  if (type === DelegationActivityType.delegationDeregistration || type === ConwayEraCertificatesTypes.Unregistration)
+    return 'core.activityDetails.deregistration';
   if (type === TransactionActivityType.incoming) return 'core.activityDetails.received';
   if (type === TransactionActivityType.outgoing) return 'core.activityDetails.sent';
   return `core.activityDetails.${type}`;

--- a/packages/core/src/ui/components/Activity/AssetActivityItem.tsx
+++ b/packages/core/src/ui/components/Activity/AssetActivityItem.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 /* eslint-disable unicorn/consistent-function-scoping */
 /* eslint-disable react/no-multi-comp */
 import React, { useMemo, useRef, useEffect, useCallback } from 'react';
@@ -10,7 +11,7 @@ import { ReactComponent as PendingIcon } from '../../assets/icons/pending.compon
 import { ReactComponent as ErrorIcon } from '../../assets/icons/error.component.svg';
 import pluralize from 'pluralize';
 import { txIconSize } from '@src/ui/utils/icon-size';
-import { DelegationActivityType, TransactionActivityType } from '../ActivityDetail/types';
+import { DelegationActivityType, TransactionActivityType, ConwayEraCertificatesTypes } from '../ActivityDetail/types';
 import type { ActivityType } from '../ActivityDetail/types';
 import styles from './AssetActivityItem.module.scss';
 import { ActivityTypeIcon } from '../ActivityDetail/ActivityTypeIcon';
@@ -93,6 +94,7 @@ const ActivityStatusIcon = ({ status, type }: ActivityStatusIconProps) => {
 const negativeBalanceStyling: Set<Partial<ActivityType>> = new Set([
   TransactionActivityType.outgoing,
   DelegationActivityType.delegationRegistration,
+  ConwayEraCertificatesTypes.Registration,
   TransactionActivityType.self,
   DelegationActivityType.delegation
 ]);
@@ -115,7 +117,13 @@ export const AssetActivityItem = ({
 
   const getText = useCallback(
     (items: number): { text: string; suffix: string } => {
-      if (type in DelegationActivityType || type === TransactionActivityType.self) return { text: amount, suffix: '' };
+      if (
+        type in DelegationActivityType ||
+        type === ConwayEraCertificatesTypes.Registration ||
+        type === ConwayEraCertificatesTypes.Unregistration ||
+        type === TransactionActivityType.self
+      )
+        return { text: amount, suffix: '' };
 
       const assetsIdsText = assets
         ?.slice(0, items)
@@ -161,7 +169,9 @@ export const AssetActivityItem = ({
   const assetsText = useMemo(() => getText(assetsToShow), [getText, assetsToShow]);
 
   const assetAmountContent =
-    type in DelegationActivityType ? (
+    type in DelegationActivityType ||
+    type === ConwayEraCertificatesTypes.Registration ||
+    type === ConwayEraCertificatesTypes.Unregistration ? (
       <p data-testid="tokens-amount" className={styles.description}>
         {DELEGATION_ASSET_NUMBER} {t('core.assetActivityItem.entry.token')}
       </p>
@@ -192,7 +202,11 @@ export const AssetActivityItem = ({
         </div>
         <div data-testid="asset-info" className={styles.info}>
           <h6 data-testid="transaction-type" className={styles.title}>
-            {isPendingTx && type !== TransactionActivityType.self && !(type in DelegationActivityType)
+            {isPendingTx &&
+            type !== TransactionActivityType.self &&
+            !(type in DelegationActivityType) &&
+            type !== ConwayEraCertificatesTypes.Registration &&
+            type !== ConwayEraCertificatesTypes.Unregistration
               ? t('core.assetActivityItem.entry.name.sending')
               : t(`core.assetActivityItem.entry.name.${type}` as unknown as CoreTranslationKey)}
           </h6>

--- a/packages/core/src/ui/components/ActivityDetail/ActivityTypeIcon.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/ActivityTypeIcon.tsx
@@ -75,10 +75,14 @@ export const ActivityTypeIcon = ({ type }: ActivityTypeIconProps): React.ReactEl
   const icon = (type && activityTypeIcon[type]) || RefreshOutlinedIcon;
   const iconStyle = { fontSize: txIconSize() };
 
+  const isDelegationActivity =
+    type === ConwayEraCertificatesTypes.Unregistration || type === ConwayEraCertificatesTypes.Registration;
+
   const isGovernanceTx =
-    Object.values(ConwayEraCertificatesTypes).includes(type as unknown as ConwayEraCertificatesTypes) ||
-    type in ConwayEraGovernanceActions ||
-    type in Cip1694GovernanceActivityType;
+    !isDelegationActivity &&
+    (Object.values(ConwayEraCertificatesTypes).includes(type as unknown as ConwayEraCertificatesTypes) ||
+      type in ConwayEraGovernanceActions ||
+      type in Cip1694GovernanceActivityType);
 
   return (
     <Flex

--- a/packages/core/src/ui/components/ActivityDetail/ActivityTypeIcon.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/ActivityTypeIcon.tsx
@@ -60,6 +60,8 @@ const activityTypeIcon: Record<ActivityType, React.FC<React.SVGProps<SVGSVGEleme
   [ConwayEraCertificatesTypes.RegisterDelegateRepresentative]: RegisterDelegateRepresentativeIcon,
   [ConwayEraCertificatesTypes.UnregisterDelegateRepresentative]: UnregisterDelegateRepresentativeIcon,
   [ConwayEraCertificatesTypes.VoteDelegation]: VoteDelegationIcon,
+  [ConwayEraCertificatesTypes.Registration]: ClipboardCheckOutlineIcon,
+  [ConwayEraCertificatesTypes.Unregistration]: ClipboardXOutlineComponentIcon,
   [TransactionActivityType.rewards]: RewardsIcon,
   [TransactionActivityType.incoming]: IncomingIcon,
   [TransactionActivityType.outgoing]: OutgoingIcon,

--- a/packages/core/src/ui/components/ActivityDetail/types.ts
+++ b/packages/core/src/ui/components/ActivityDetail/types.ts
@@ -2,6 +2,8 @@ import { Wallet } from '@lace/cardano';
 
 // supported certificates actions
 export enum ConwayEraCertificatesTypes {
+  'Registration' = Wallet.Cardano.CertificateType.Registration,
+  'Unregistration' = Wallet.Cardano.CertificateType.Unregistration,
   'AuthorizeCommitteeHot' = Wallet.Cardano.CertificateType.AuthorizeCommitteeHot,
   'RegisterDelegateRepresentative' = Wallet.Cardano.CertificateType.RegisterDelegateRepresentative,
   'ResignCommitteeCold' = Wallet.Cardano.CertificateType.ResignCommitteeCold,

--- a/packages/staking/src/features/overview/helpers/hasPendingDelegationTransaction.ts
+++ b/packages/staking/src/features/overview/helpers/hasPendingDelegationTransaction.ts
@@ -1,7 +1,12 @@
-import { ActivityStatus, AssetActivityListProps, DelegationActivityType } from '@lace/core';
+import { ActivityStatus, AssetActivityListProps, ConwayEraCertificatesTypes, DelegationActivityType } from '@lace/core';
 import flatMap from 'lodash/flatMap';
 
 export const hasPendingDelegationTransaction = (walletActivities: AssetActivityListProps[]) =>
   flatMap(walletActivities, ({ items }) => items).some(
-    ({ type, status }) => type && type in DelegationActivityType && status === ActivityStatus.PENDING
+    ({ type, status }) =>
+      type &&
+      (type in DelegationActivityType ||
+        type === ConwayEraCertificatesTypes.Registration ||
+        type === ConwayEraCertificatesTypes.Unregistration) &&
+      status === ActivityStatus.PENDING
   );

--- a/packages/translation/src/lib/translations/core/en.json
+++ b/packages/translation/src/lib/translations/core/en.json
@@ -139,6 +139,8 @@
   "core.assetActivityItem.entry.name.delegation": "Delegation",
   "core.assetActivityItem.entry.name.delegationDeregistration": "Stake Key De-Registration",
   "core.assetActivityItem.entry.name.delegationRegistration": "Stake Key Registration",
+  "core.assetActivityItem.entry.name.UnRegistrationCertificate": "Stake Key De-Registration",
+  "core.assetActivityItem.entry.name.RegistrationCertificate": "Stake Key Registration",
   "core.assetActivityItem.entry.name.HardForkInitiationAction": "Hard Fork Initiation Action",
   "core.assetActivityItem.entry.name.incoming": "Received",
   "core.assetActivityItem.entry.name.InfoAction": "Info Action",


### PR DESCRIPTION
add proper mappers for missed conway era certs

# Checklist

- [x] JIRA - [LW-10782](https://input-output.atlassian.net/browse/LW-10782)
- [x] JIRA - [LW-10789](https://input-output.atlassian.net/browse/LW-10789)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Extend tx inspection related mappers with missed conway era certs.

## Testing

Follow the steps in the description of the ticket.

## Screenshots

<img width="1728" alt="Screenshot 2024-06-20 at 23 25 06" src="https://github.com/input-output-hk/lace/assets/7934077/2999be97-031f-451f-b04d-ed0ac28768bb">
<img width="1728" alt="Screenshot 2024-06-20 at 23 25 16" src="https://github.com/input-output-hk/lace/assets/7934077/69d60cf5-04e0-4429-942e-70ea6bb61dc8">



[LW-10789]: https://input-output.atlassian.net/browse/LW-10789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LW-10782]: https://input-output.atlassian.net/browse/LW-10782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ