### PR TITLE
Update lint script to not tolerate warnings during linter runs

### DIFF
--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/WalletAccounts.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/WalletAccounts.tsx
@@ -134,12 +134,15 @@ export const WalletAccounts = ({ isPopup, onBack }: { isPopup: boolean; onBack: 
     [disableAccountConfirmation, accountsData]
   );
 
-  const showHWErrorState = useCallback((accountIndex: number) => {
-    enableAccountHWSigningDialog.setData({
-      accountIndex,
-      state: 'error'
-    });
-  }, [enableAccountHWSigningDialog]);
+  const showHWErrorState = useCallback(
+    (accountIndex: number) => {
+      enableAccountHWSigningDialog.setData({
+        accountIndex,
+        state: 'error'
+      });
+    },
+    [enableAccountHWSigningDialog]
+  );
 
   const unlockHWAccount = useCallback(
     async (accountIndex: number) => {

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/WalletAccounts.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/WalletAccounts.tsx
@@ -139,7 +139,7 @@ export const WalletAccounts = ({ isPopup, onBack }: { isPopup: boolean; onBack: 
       accountIndex,
       state: 'error'
     });
-  }, []);
+  }, [enableAccountHWSigningDialog]);
 
   const unlockHWAccount = useCallback(
     async (accountIndex: number) => {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cleanup": "yarn workspaces foreach run cleanup && yarn exec rm -rf node_modules storybook-static && rm -rf .cache/eslintcache",
     "common:lint": "yarn eslint-cmd \"packages/common/**/*.{js,ts,tsx}\"",
     "core:lint": "yarn eslint-cmd \"packages/core/**/*.{js,ts,tsx}\"",
-    "eslint-cmd": "eslint --cache --cache-location .cache/eslintcache --cache-strategy metadata --ignore-path ./.eslintignore",
+    "eslint-cmd": "eslint --cache --cache-location .cache/eslintcache --cache-strategy metadata --ignore-path ./.eslintignore --max-warnings=0",
     "extension:lint": "yarn eslint-cmd \"apps/browser-extension-wallet/**/*.{js,ts,tsx}\"",
     "format-check": "yarn workspaces foreach -ptv run format-check",
     "postinstall": "husky install & ts-patch install -s",
@@ -48,7 +48,7 @@
   },
   "lint-staged": {
     "*(apps/**/*.{js,ts,tsx}|packages/!(ui|translation)/**/*.{js,ts,tsx}|stories/**/*.{js,ts,tsx})": [
-      "eslint --cache --cache-location .cache/eslintcache --cache-strategy metadata --fix --ignore-path ./.eslintignore",
+      "eslint --cache --cache-location .cache/eslintcache --cache-strategy metadata --fix --ignore-path ./.eslintignore --max-warnings=0",
       "prettier --write"
     ],
     "*(packages/ui/**/*.{js,ts,tsx})": [


### PR DESCRIPTION
# Checklist


- [x] JIRA - \<link> https://input-output.atlassian.net/browse/LW-10614

---

## Proposed solution

This PR configures the CI to fail if one or more warnings are thrown in the linting job.

## Testing

1. Go to the actions tab here: https://github.com/input-output-hk/lace/actions/workflows/build-dev-preview.yml
2. Click on the `Run workflow` button and select `fail-linter-on-warning` from the branch selector dropdown
3. Click on `Run workflow` and wait for a few seconds while the workflow gets scheduled
4. Go into the workflow run and see the logs to confirm that the job would fail if any warnings are detected during linting

