### PR TITLE
LW-10620: prepare Lace to support custom network

### DIFF
--- a/apps/browser-extension-wallet/src/features/ada-handle/config.ts
+++ b/apps/browser-extension-wallet/src/features/ada-handle/config.ts
@@ -3,8 +3,9 @@ import { Wallet } from '@lace/cardano';
 
 export const ADA_HANDLE_POLICY_ID = Wallet.ADA_HANDLE_POLICY_ID;
 export const isAdaHandleEnabled = process.env.USE_ADA_HANDLE === 'true';
-export const HANDLE_SERVER_URLS: Record<Exclude<Cardano.NetworkMagics, Cardano.NetworkMagics.Sanchonet>, string> = {
+export const HANDLE_SERVER_URLS: Record<Cardano.NetworkMagics, string> = {
   [Cardano.NetworkMagics.Mainnet]: process.env.ADA_HANDLE_URL_MAINNET,
   [Cardano.NetworkMagics.Preprod]: process.env.ADA_HANDLE_URL_PREPROD,
-  [Cardano.NetworkMagics.Preview]: process.env.ADA_HANDLE_URL_PREVIEW
+  [Cardano.NetworkMagics.Preview]: process.env.ADA_HANDLE_URL_PREVIEW,
+  [Cardano.NetworkMagics.Sanchonet]: process.env.ADA_HANDLE_URL_SANCHONET
 };

--- a/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
@@ -78,14 +78,7 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
         stores,
         handleProvider: handleHttpProvider({
           adapter: axiosFetchAdapter,
-          baseUrl:
-            HANDLE_SERVER_URLS[
-              // TODO: remove exclude to support sanchonet
-              Cardano.ChainIds[chainName].networkMagic as Exclude<
-                Cardano.NetworkMagics,
-                Cardano.NetworkMagics.Sanchonet
-              >
-            ],
+          baseUrl: HANDLE_SERVER_URLS[Cardano.ChainIds[chainName].networkMagic],
           logger
         }),
         addressDiscovery: new HDSequentialDiscovery(providers.chainHistoryProvider, DEFAULT_LOOK_AHEAD_SEARCH),

--- a/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
@@ -21,7 +21,7 @@ import {
 } from '@cardano-sdk/web-extension';
 import { Wallet } from '@lace/cardano';
 import { HANDLE_SERVER_URLS } from '@src/features/ada-handle/config';
-import { Cardano, NotImplementedError } from '@cardano-sdk/core';
+import { Cardano, HandleProvider, NotImplementedError } from '@cardano-sdk/core';
 import { cacheActivatedWalletAddressSubscription } from './cache-wallets-address';
 import axiosFetchAdapter from '@vespaiach/axios-fetch-adapter';
 
@@ -70,17 +70,27 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
       extendedAccountPublicKey: walletAccount.extendedAccountPublicKey
     });
 
+    const mockHandleResolver: HandleProvider = {
+      resolveHandles: async () => [],
+      healthCheck: async () => ({ ok: true }),
+      getPolicyIds: async () => []
+    };
+
+    const baseUrl = HANDLE_SERVER_URLS[Cardano.ChainIds[chainName].networkMagic];
+
     return createPersonalWallet(
       { name: walletAccount.metadata.name },
       {
         logger,
         ...providers,
         stores,
-        handleProvider: handleHttpProvider({
-          adapter: axiosFetchAdapter,
-          baseUrl: HANDLE_SERVER_URLS[Cardano.ChainIds[chainName].networkMagic],
-          logger
-        }),
+        handleProvider: baseUrl
+          ? handleHttpProvider({
+              adapter: axiosFetchAdapter,
+              baseUrl: HANDLE_SERVER_URLS[Cardano.ChainIds[chainName].networkMagic],
+              logger
+            })
+          : mockHandleResolver,
         addressDiscovery: new HDSequentialDiscovery(providers.chainHistoryProvider, DEFAULT_LOOK_AHEAD_SEARCH),
         witnesser,
         bip32Account

--- a/apps/browser-extension-wallet/webpack-utils.js
+++ b/apps/browser-extension-wallet/webpack-utils.js
@@ -18,7 +18,7 @@ const transformManifest = (content, mode) => {
       )
       .replace(
         '$ADA_HANDLE_URLS',
-        `${process.env.ADA_HANDLE_URL_MAINNET} ${process.env.ADA_HANDLE_URL_PREPROD} ${process.env.ADA_HANDLE_URL_PREVIEW}`
+        `${process.env.ADA_HANDLE_URL_MAINNET} ${process.env.ADA_HANDLE_URL_PREPROD} ${process.env.ADA_HANDLE_URL_PREVIEW} ${process.env.ADA_HANDLE_URL_SANCHONET}`
       )
       .replace('$LOCALHOST_DEFAULT_SRC', mode === 'development' ? 'http://localhost:3000' : '')
       .replace('$LOCALHOST_SCRIPT_SRC', mode === 'development' ? 'http://localhost:3000' : '')


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Using "Sanchonet" as placeholder for the custom networks.
Developer preview option should be used to build with the custom network.
Use the `.env` file to override the sanchonet URLs that Lace connects to, for configuring custom networks.

```
# Use sanchonet network as placeholder for the custom network
CARDANO_SERVICES_URL_SANCHONET=https://custom-network-url.domain

# BUILD_DEV_PREVIEW is needed to enable Sanchonet option to show up in Lace
BUILD_DEV_PREVIEW=true
```

## Testing

See `.env` example above.


