### PR TITLE
ci: do not add multiple npmScope entry in .yarnrc.yamla

### DIFF
--- a/.github/shared/build/action.yml
+++ b/.github/shared/build/action.yml
@@ -48,10 +48,25 @@ runs:
         key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
     - name: Configure Yarn to use GitHub Packages
       run: |
-        echo "npmScopes:" >> ~/.yarnrc.yml
-        echo "  input-output-hk:" >> ~/.yarnrc.yml
-        echo "    npmRegistryServer: \"https://npm.pkg.github.com\"" >> ~/.yarnrc.yml
-        echo "    npmAuthToken: \"${{ inputs.GITHUB_TOKEN }}\"" >> ~/.yarnrc.yml
+        SCOPE="input-output-hk"
+        FILE="$HOME/.yarnrc.yml"
+        if grep -q "npmScopes:" "$FILE"; then
+          if ! grep -q "$SCOPE:" "$FILE"; then
+            echo "  $SCOPE:" >> "$FILE"
+            echo "    npmRegistryServer: \"https://npm.pkg.github.com\"" >> "$FILE"
+            echo "    npmAuthToken: \"${{ inputs.GITHUB_TOKEN }}\"" >> "$FILE"
+            echo "Added $SCOPE to $FILE"
+          else
+            echo "$SCOPE already present in $FILE"
+          fi
+        else
+          echo "npmScopes:" >> "$FILE"
+          echo "  $SCOPE:" >> "$FILE"
+          echo "    npmRegistryServer: \"https://npm.pkg.github.com\"" >> "$FILE"
+          echo "    npmAuthToken: \"${{ inputs.GITHUB_TOKEN }}\"" >> "$FILE"
+          echo "Added npmScopes and $SCOPE to $FILE"
+        fi
+
       shell: bash
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
In this PR I'm checking if npmScope exists in ~/.yarnrc.yml before adding it.

This is the case for self hosted runners which are not terminated after each run, so multiple workflow runs add multiple entries to `~/.yarnrc.yaml` file which produce errors like this:

```
YAMLException: duplicated mapping key at line 5, column -142:
    npmScopes:
    ^
    at generateError (/usr/lib/node_modules/yarn/lib/cli.js:126542:10)
    at throwError (/usr/lib/node_modules/yarn/lib/cli.js:126548:9)
    at storeMappingPair (/usr/lib/node_modules/yarn/lib/cli.js:126710:7)
    at readBlockMapping (/usr/lib/node_modules/yarn/lib/cli.js:127473:9)
    at composeNode (/usr/lib/node_modules/yarn/lib/cli.js:127734:12)
    at readDocument (/usr/lib/node_modules/yarn/lib/cli.js:127894:3)
    at loadDocuments (/usr/lib/node_modules/yarn/lib/cli.js:127950:5)
    at load (/usr/lib/node_modules/yarn/lib/cli.js:127971:19)
    at safeLoad (/usr/lib/node_modules/yarn/lib/cli.js:127993:10)
    at parse (/usr/lib/node_modules/yarn/lib/cli.js:[64](https://github.com/input-output-hk/lace/actions/runs/9740491575/job/26877714997#step:6:67)242:18)
Error: YAMLException: duplicated mapping key at line 5, column -142:
    npmScopes:
    ^
    at generateError (/usr/lib/node_modules/yarn/lib/cli.js:12[65](https://github.com/input-output-hk/lace/actions/runs/9740491575/job/26877714997#step:6:68)42:10)
    at throwError (/usr/lib/node_modules/yarn/lib/cli.js:126548:9)
    at storeMappingPair (/usr/lib/node_modules/yarn/lib/cli.js:12[67](https://github.com/input-output-hk/lace/actions/runs/9740491575/job/26877714997#step:6:70)10:7)
    at readBlockMapping (/usr/lib/node_modules/yarn/lib/cli.js:127473:9)
    at composeNode (/usr/lib/node_modules/yarn/lib/cli.js:127734:12)
    at readDocument (/usr/lib/node_modules/yarn/lib/cli.js:127894:3)
    at loadDocuments (/usr/lib/node_modules/yarn/lib/cli.js:127950:5)
    at load (/usr/lib/node_modules/yarn/lib/cli.js:127971:19)
    at safeLoad (/usr/lib/node_modules/yarn/lib/cli.js:127993:10)
    at parse (/usr/lib/node_modules/yarn/lib/cli.js:64242:18)
```