### PR TITLE
fix(extension): [lw-10795] refresh delegation portfolio on account ch…

### DIFF
--- a/packages/staking/src/features/store/delegationPortfolioStore/useSyncDelegationPortfolioStore.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/useSyncDelegationPortfolioStore.ts
@@ -1,6 +1,7 @@
 import { useObservable } from '@lace/common';
 import { useOutsideHandles } from 'features/outside-handles-provider';
 import { useDelegationPortfolioStore } from 'features/store';
+import isUndefined from 'lodash/isUndefined';
 import { useEffect } from 'react';
 
 export const useSyncDelegationPortfolioStore = () => {
@@ -13,16 +14,19 @@ export const useSyncDelegationPortfolioStore = () => {
 
   useEffect(() => {
     if (
-      [delegationDistribution, delegationRewardsHistory, currentEpoch, currentChain, delegationPortfolio].every(Boolean)
+      [delegationDistribution, delegationRewardsHistory, currentEpoch, currentChain, delegationPortfolio].some((val) =>
+        isUndefined(val)
+      )
     ) {
-      portfolioMutators.setCardanoCoinSymbol(currentChain);
-      portfolioMutators.setCurrentPortfolio({
-        currentEpoch,
-        delegationDistribution: [...delegationDistribution.values()],
-        delegationPortfolio,
-        delegationRewardsHistory,
-      });
+      return;
     }
+    portfolioMutators.setCardanoCoinSymbol(currentChain);
+    portfolioMutators.setCurrentPortfolio({
+      currentEpoch,
+      delegationDistribution: [...delegationDistribution.values()],
+      delegationPortfolio,
+      delegationRewardsHistory,
+    });
   }, [
     currentChain,
     currentEpoch,


### PR DESCRIPTION
…ange

# Checklist

- [x] JIRA - [LW-10795](https://input-output.atlassian.net/browse/)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Unnecessary check for `delegationPortfolio` has been removed from `useSyncDelegationPortfolioStore` hook since it's pointing to the value returned from `walletStoreInMemoryWallet.delegation.portfolio$` observable and it might be `null`

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-10795]: https://input-output.atlassian.net/browse/LW-10795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ