### PR TITLE
test(extension): e2e add noStrictFlaky option

### DIFF
--- a/packages/e2e-tests/wdio.conf.base.ts
+++ b/packages/e2e-tests/wdio.conf.base.ts
@@ -134,6 +134,7 @@ export const config: WebdriverIO.Config = {
     tags: extensionUtils.isMainnet() ? '@Mainnet' : '@Testnet',
     tagsInTitle: true,
     timeout: 200_000,
-    retry: 1
+    retry: 1,
+    noStrictFlaky: true
   } as WebdriverIO.CucumberOpts
 };


### PR DESCRIPTION
[LW-10859](https://input-output.atlassian.net/browse/LW-10859)

Adding 'noStrictFlaky' flag to cucumber options. This will not fail a suite which had a failed test that passed on retry.
Works as advertised, test on cucumber report is marked as failed but not failing whole runner results as it passed on retry:
![CleanShot 2024-07-16 at 19 51 05@2x](https://github.com/user-attachments/assets/628db504-badb-4b10-8adf-ce0c40bd7d3b)
![CleanShot 2024-07-16 at 19 52 11@2x](https://github.com/user-attachments/assets/36ecc0e5-7b0f-4d67-90f4-b782704bd815)


[LW-10859]: https://input-output.atlassian.net/browse/LW-10859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ