### PR TITLE
test: authenticate to fetch artifacts from diff workflow run

### DIFF
--- a/.github/workflows/e2e-tests-linux-split.yml
+++ b/.github/workflows/e2e-tests-linux-split.yml
@@ -132,6 +132,7 @@ jobs:
         with:
           name: '${{ env.BUILD_ARTIFACT_NAME }}'
           path: ./apps/browser-extension-wallet/dist
+          github-token: ${{ secrets.GH_TOKEN }}
 
       - name: Execute E2E tests
         uses: ./.github/actions/test/e2e


### PR DESCRIPTION
Provide `github-token` for `actions/download-artifact@v4` to authenticate with GitHub API.

```
# The GitHub token used to authenticate with the GitHub API.
# This is required when downloading artifacts from a different repository or from a different workflow run.
# Optional. If unspecified, the action will download artifacts from the current repo and the current workflow run.
github-token:
```

https://github.com/actions/download-artifact