### PR TITLE
LW-11277 refactor: simplify Ada Handle provider configuration

### DIFF
--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -77,12 +77,6 @@ CEXPLORER_URL_PREVIEW=https://preview.cexplorer.io
 CEXPLORER_URL_PREPROD=https://preprod.cexplorer.io
 CEXPLORER_URL_SANCHONET=https://sancho.cexplorer.io
 
-# ADA Handle URLs
-ADA_HANDLE_URL_MAINNET=https://dev-mainnet.lw.iog.io/
-ADA_HANDLE_URL_PREPROD=https://dev-preprod.lw.iog.io/
-ADA_HANDLE_URL_PREVIEW=https://dev-preview.lw.iog.io/
-ADA_HANDLE_URL_SANCHONET=
-
 # Manifest.json
 LACE_EXTENSION_KEY=gafhhkghbfjjkeiendhlofajokpaflmk
 

--- a/apps/browser-extension-wallet/.env.developerpreview
+++ b/apps/browser-extension-wallet/.env.developerpreview
@@ -75,12 +75,6 @@ CEXPLORER_URL_PREVIEW=https://preview.cexplorer.io
 CEXPLORER_URL_PREPROD=https://preprod.cexplorer.io
 CEXPLORER_URL_SANCHONET=https://sancho.cexplorer.io
 
-# ADA Handle URLs
-ADA_HANDLE_URL_MAINNET=https://dev-mainnet.lw.iog.io
-ADA_HANDLE_URL_PREVIEW=https://dev-preview.lw.iog.io
-ADA_HANDLE_URL_PREPROD=https://dev-preprod.lw.iog.io
-ADA_HANDLE_URL_SANCHONET=
-
 # Manifest.json
 LACE_EXTENSION_KEY=djcdfchkaijggdjokfomholkalbffgil
 

--- a/apps/browser-extension-wallet/.env.example
+++ b/apps/browser-extension-wallet/.env.example
@@ -75,12 +75,6 @@ CEXPLORER_URL_PREVIEW=https://preview.cexplorer.io
 CEXPLORER_URL_PREPROD=https://preprod.cexplorer.io
 CEXPLORER_URL_SANCHONET=https://sancho.cexplorer.io
 
-# ADA Handle URLs
-ADA_HANDLE_URL_MAINNET=https://dev-mainnet.lw.iog.io
-ADA_HANDLE_URL_PREVIEW=https://dev-preview.lw.iog.io
-ADA_HANDLE_URL_PREPROD=https://dev-preprod.lw.iog.io
-ADA_HANDLE_URL_SANCHONET=
-
 # Manifest.json
 LACE_EXTENSION_KEY=gafhhkghbfjjkeiendhlofajokpaflmk
 

--- a/apps/browser-extension-wallet/manifest.json
+++ b/apps/browser-extension-wallet/manifest.json
@@ -19,7 +19,7 @@
   "permissions": ["webRequest", "storage", "tabs", "unlimitedStorage"],
   "host_permissions": ["<all_urls>"],
   "content_security_policy": {
-    "extension_pages": "default-src 'self' $LOCALHOST_DEFAULT_SRC; frame-src https://connect.trezor.io/ https://www.youtube-nocookie.com; script-src 'self' 'wasm-unsafe-eval' $LOCALHOST_SCRIPT_SRC; font-src 'self' https://use.typekit.net; object-src 'self'; connect-src $CARDANO_SERVICES_URLS $ADA_HANDLE_URLS https://coingecko.live-mainnet.eks.lw.iog.io https://muesliswap.live-mainnet.eks.lw.iog.io $LOCALHOST_CONNECT_SRC $POSTHOG_HOST https://use.typekit.net data:; style-src * 'unsafe-inline'; img-src * data:;"
+    "extension_pages": "default-src 'self' $LOCALHOST_DEFAULT_SRC; frame-src https://connect.trezor.io/ https://www.youtube-nocookie.com; script-src 'self' 'wasm-unsafe-eval' $LOCALHOST_SCRIPT_SRC; font-src 'self' https://use.typekit.net; object-src 'self'; connect-src $CARDANO_SERVICES_URLS https://coingecko.live-mainnet.eks.lw.iog.io https://muesliswap.live-mainnet.eks.lw.iog.io $LOCALHOST_CONNECT_SRC $POSTHOG_HOST https://use.typekit.net data:; style-src * 'unsafe-inline'; img-src * data:;"
   },
   "content_scripts": [
     {

--- a/apps/browser-extension-wallet/src/features/ada-handle/config.ts
+++ b/apps/browser-extension-wallet/src/features/ada-handle/config.ts
@@ -1,11 +1,1 @@
-import { Cardano } from '@cardano-sdk/core';
-import { Wallet } from '@lace/cardano';
-
-export const ADA_HANDLE_POLICY_ID = Wallet.ADA_HANDLE_POLICY_ID;
 export const isAdaHandleEnabled = process.env.USE_ADA_HANDLE === 'true';
-export const HANDLE_SERVER_URLS: Record<Cardano.NetworkMagics, string> = {
-  [Cardano.NetworkMagics.Mainnet]: process.env.ADA_HANDLE_URL_MAINNET,
-  [Cardano.NetworkMagics.Preprod]: process.env.ADA_HANDLE_URL_PREPROD,
-  [Cardano.NetworkMagics.Preview]: process.env.ADA_HANDLE_URL_PREVIEW,
-  [Cardano.NetworkMagics.Sanchonet]: process.env.ADA_HANDLE_URL_SANCHONET
-};

--- a/apps/browser-extension-wallet/src/hooks/useHandleResolver.ts
+++ b/apps/browser-extension-wallet/src/hooks/useHandleResolver.ts
@@ -1,20 +1,23 @@
+import { getBaseUrlForChain } from '@src/utils/chain';
+import { getChainName } from '@src/utils/get-chain-name';
 import { useMemo } from 'react';
 import { useWalletStore } from '@src/stores';
 import { handleHttpProvider } from '@cardano-sdk/cardano-services-client';
-import { HandleProvider } from '@cardano-sdk/core';
-import { HANDLE_SERVER_URLS } from '@src/features/ada-handle/config';
 import { logger } from '@lib/wallet-api-ui';
+import axiosFetchAdapter from '@vespaiach/axios-fetch-adapter';
+import { HandleProvider } from '@cardano-sdk/core';
 
 export const useHandleResolver = (): HandleProvider => {
-  const {
-    currentChain: { networkMagic }
-  } = useWalletStore();
+  const { currentChain } = useWalletStore();
+  const baseCardanoServicesUrl = getBaseUrlForChain(getChainName(currentChain));
 
-  return useMemo(() => {
-    const serverUrl = HANDLE_SERVER_URLS[networkMagic as keyof typeof HANDLE_SERVER_URLS];
-    return handleHttpProvider({
-      baseUrl: serverUrl,
-      logger
-    });
-  }, [networkMagic]);
+  return useMemo(
+    () =>
+      handleHttpProvider({
+        adapter: axiosFetchAdapter,
+        baseUrl: baseCardanoServicesUrl,
+        logger
+      }),
+    [baseCardanoServicesUrl]
+  );
 };

--- a/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
@@ -26,11 +26,11 @@ import {
   walletRepositoryProperties
 } from '@cardano-sdk/web-extension';
 import { Wallet } from '@lace/cardano';
-import { HANDLE_SERVER_URLS } from '@src/features/ada-handle/config';
 import { Cardano, HandleProvider } from '@cardano-sdk/core';
 import { cacheActivatedWalletAddressSubscription } from './cache-wallets-address';
 import axiosFetchAdapter from '@vespaiach/axios-fetch-adapter';
 import { SharedWalletScriptKind } from '@lace/core';
+import { getBaseUrlForChain } from '@utils/chain';
 
 const logger = console;
 
@@ -65,7 +65,7 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
     const chainName: Wallet.ChainName = chainIdToChainName(chainId);
     const providers = await getProviders(chainName);
 
-    const baseUrl = HANDLE_SERVER_URLS[Cardano.ChainIds[chainName].networkMagic];
+    const baseUrl = getBaseUrlForChain(chainName);
 
     // This is used in place of the handle provider for environments where the handle provider is not available
     const noopHandleResolver: HandleProvider = {
@@ -88,7 +88,7 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
           handleProvider: baseUrl
             ? handleHttpProvider({
                 adapter: axiosFetchAdapter,
-                baseUrl: HANDLE_SERVER_URLS[Cardano.ChainIds[chainName].networkMagic],
+                baseUrl,
                 logger
               })
             : noopHandleResolver,
@@ -117,7 +117,7 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
         handleProvider: baseUrl
           ? handleHttpProvider({
               adapter: axiosFetchAdapter,
-              baseUrl: HANDLE_SERVER_URLS[Cardano.ChainIds[chainName].networkMagic],
+              baseUrl,
               logger
             })
           : noopHandleResolver,

--- a/apps/browser-extension-wallet/webpack-utils.js
+++ b/apps/browser-extension-wallet/webpack-utils.js
@@ -16,10 +16,6 @@ const transformManifest = (content, mode) => {
         '$CARDANO_SERVICES_URLS',
         `${process.env.CARDANO_SERVICES_URL_MAINNET} ${process.env.CARDANO_SERVICES_URL_PREPROD} ${process.env.CARDANO_SERVICES_URL_PREVIEW} ${process.env.CARDANO_SERVICES_URL_SANCHONET}`
       )
-      .replace(
-        '$ADA_HANDLE_URLS',
-        `${process.env.ADA_HANDLE_URL_MAINNET} ${process.env.ADA_HANDLE_URL_PREPROD} ${process.env.ADA_HANDLE_URL_PREVIEW} ${process.env.ADA_HANDLE_URL_SANCHONET}`
-      )
       .replace('$LOCALHOST_DEFAULT_SRC', mode === 'development' ? 'http://localhost:3000' : '')
       .replace('$LOCALHOST_SCRIPT_SRC', mode === 'development' ? 'http://localhost:3000' : '')
       .replace(


### PR DESCRIPTION
## Proposed solution

There's no need to manage a separate set of configuration for this provider, given we're now using the same backend.

## Testing
- Remove `ADA_HANDLE_URL_*` from `.env`
- Set `CARDANO_SERVICES_URL_PREPROD` to `https://live-preprod.lw.iog.io`
- Create dev build
- Load extension and observe expected behaviour
- Check to see that handle requests on _preprod_ are being resolved by the `live-` server from the send form and address book.


