### PR TITLE
test(extension): fix default preprod network url

### DIFF
--- a/.github/workflows/e2e-tests-linux-split.yml
+++ b/.github/workflows/e2e-tests-linux-split.yml
@@ -108,9 +108,9 @@ env:
   NODE_OPTIONS: --max-old-space-size=16384
   BRANCH: ${{ github.ref_name }}
   CARDANO_MAINNET_URL: ${{ github.event.inputs.cardano_mainnet_url || 'dev-mainnet.lw.iog.io' }}
-  CARDANO_PREPROD_URL: ${{ github.event.inputs.cardano_preprod_url || 'cardano_preprod_url' }}
+  CARDANO_PREPROD_URL: ${{ github.event.inputs.cardano_preprod_url || 'dev-preprod.lw.iog.io' }}
   CARDANO_PREVIEW_URL: ${{ github.event.inputs.cardano_preview_url || 'dev-preview.lw.iog.io' }}
-  BUILD_ARTIFACT_NAME: lace-${{ github.event.inputs.cardano_preprod_url || 'cardano_preprod_url' }}-${{ github.sha }}
+  BUILD_ARTIFACT_NAME: lace-${{ github.event.inputs.cardano_preprod_url || 'dev-preprod.lw.iog.io' }}-${{ github.sha }}
 
 jobs:
   setup:


### PR DESCRIPTION
Fix default preprod network url for e2e regression workflow