### PR TITLE
fix(extension): fix bind context to updateWalletMetadata for subscriptions

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/cache-wallets-address.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/cache-wallets-address.ts
@@ -36,5 +36,7 @@ export const cacheActivatedWalletAddressSubscription = (
   walletManager: WalletManager<Wallet.WalletMetadata, Wallet.AccountMetadata>,
   walletRepository: WalletRepository<Wallet.WalletMetadata, Wallet.AccountMetadata>
 ): void => {
-  walletMetadataWithAddresses(walletManager, walletRepository).subscribe(walletRepository.updateWalletMetadata);
+  walletMetadataWithAddresses(walletManager, walletRepository).subscribe((updateProps) =>
+    walletRepository.updateWalletMetadata(updateProps)
+  );
 };


### PR DESCRIPTION
The `updateWalletMetadata` method was losing its context (this) when used as a callback, resulting in a `TypeError` because `this` on  the `this.#logger` call was undefined.

# Checklist

- [x] JIRA - \<[link](https://input-output.atlassian.net/browse/LW-11392)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Changed the function call within the subscription to use an arrow function. This modification ensures that the context of this is preserved.
