### PR TITLE
fix(extension): signTransaction component no longer crash when enter is pressed on password input

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/SignTransaction.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/SignTransaction.tsx
@@ -65,6 +65,18 @@ export const SignTransaction = (): React.ReactElement => {
     setPreviousView();
   };
 
+  const handleSubmit = useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!confirmIsDisabled) {
+        onConfirm();
+      }
+    },
+    [onConfirm, confirmIsDisabled]
+  );
+
   return (
     <Layout title={undefined}>
       <div className={styles.passwordContainer}>
@@ -74,6 +86,7 @@ export const SignTransaction = (): React.ReactElement => {
           </h5>
           <Password
             onChange={handleChange}
+            onSubmit={handleSubmit}
             error={validPassword === false}
             errorMessage={t('browserView.transaction.send.error.invalidPassword')}
             autoFocus


### PR DESCRIPTION
DApp auth confirm crash on 'enter' key

# Checklist

- [x] JIRA - \<[link](https://input-output.atlassian.net/browse/LW-11411)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Manage onSubmit to avoid reload on Password form.
