### PR TITLE
chore: revert temporary override chain-history version to support pre-p2p back-end

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useChainHistoryProvider.ts
+++ b/apps/browser-extension-wallet/src/hooks/useChainHistoryProvider.ts
@@ -15,14 +15,7 @@ export const useChainHistoryProvider = ({ chainName }: UseChainHistoryProviderAr
   const baseCardanoServicesUrl = getBaseUrlForChain(chainName);
 
   return useMemo(
-    () =>
-      chainHistoryHttpProvider({
-        adapter: axiosFetchAdapter,
-        baseUrl: baseCardanoServicesUrl,
-        logger,
-        // TODO: remove apiVersion override once the back-ends are all updated to P2P (Node 8.9.2)
-        apiVersion: '3.0.1'
-      }),
+    () => chainHistoryHttpProvider({ adapter: axiosFetchAdapter, baseUrl: baseCardanoServicesUrl, logger }),
     [baseCardanoServicesUrl]
   );
 };

--- a/packages/cardano/src/wallet/lib/providers.ts
+++ b/packages/cardano/src/wallet/lib/providers.ts
@@ -75,8 +75,7 @@ export const createProviders = ({
     txSubmitProvider: createTxSubmitProvider(httpProviderConfig, customSubmitTxUrl),
     stakePoolProvider: stakePoolHttpProvider(httpProviderConfig),
     utxoProvider: utxoHttpProvider(httpProviderConfig),
-    // TODO: remove apiVersion override once the back-ends are all updated to P2P (Node 8.9.2)
-    chainHistoryProvider: chainHistoryHttpProvider({ ...httpProviderConfig, apiVersion: '3.0.1' }),
+    chainHistoryProvider: chainHistoryHttpProvider(httpProviderConfig),
     rewardsProvider: rewardsHttpProvider(httpProviderConfig)
   };
 };


### PR DESCRIPTION
This reverts commit 822ed979b62c200e00be7761f44d5b630788f820.

# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

No need to support two versions of chain-history provider.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes
