### PR TITLE
fix: balance to BigInt convertion no longer crash with big numbers

### DIFF
--- a/packages/cardano/src/wallet/util/asset-balance.ts
+++ b/packages/cardano/src/wallet/util/asset-balance.ts
@@ -26,5 +26,5 @@ export const assetBalanceToBigInt = (balanceWithDecimals: string, assetInfo: Ass
 
   if (!decimals) return BigInt(balanceWithDecimals);
 
-  return BigInt(new BigNumber(balanceWithDecimals).times(new BigNumber(BASE).pow(decimals)).toString());
+  return BigInt(new BigNumber(balanceWithDecimals).times(new BigNumber(BASE).pow(decimals)).toFixed(0).toString());
 };


### PR DESCRIPTION
# Checklist

- [x] JIRA - \<[link](https://input-output.atlassian.net/browse/LW-11465)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---
The assetBalanceToBigInt function was crashing when a big number and many decimals were passed to it, this is because  BigNumber toString compacts the number notation with big numbers to something like **2.222222222222222e+21** which cant be parsed by BigInt.

## Proposed solution

Add toFixed(0) to it, so we force the string representation to always display all digits correctly.

