### PR TITLE
fix: confirm button is now disabled if password is empty on staking confirmation screen

### DIFF
--- a/.github/actions/chromatic/action.yml
+++ b/.github/actions/chromatic/action.yml
@@ -23,7 +23,7 @@ runs:
 
     - name: Publish to Chromatic
       if: github.ref != 'refs/heads/main'
-      uses: chromaui/action@v1
+      uses: chromaui/action@v10
       with:
         projectToken: ${{ inputs.TOKEN }}
         workingDir: ./${{ inputs.DIR }}
@@ -33,7 +33,7 @@ runs:
 
     - name: Publish to Chromatic and auto accept changes
       if: github.ref == 'refs/heads/main'
-      uses: chromaui/action@v1
+      uses: chromaui/action@v10
       with:
         projectToken: ${{ inputs.TOKEN }}
         autoAcceptChanges: true

--- a/packages/staking/src/features/Drawer/SignConfirmation.tsx
+++ b/packages/staking/src/features/Drawer/SignConfirmation.tsx
@@ -87,7 +87,7 @@ export const SignConfirmationFooter = (): ReactElement => {
   const { analytics } = useOutsideHandles();
   const { t } = useTranslation();
 
-  const isSubmitDisabled = useMemo(() => isSubmitingTx || !password, [isSubmitingTx, password]);
+  const isSubmitDisabled = useMemo(() => isSubmitingTx || !password?.value, [isSubmitingTx, password?.value]);
 
   const cleanPasswordInput = useCallback(() => {
     removePassword();


### PR DESCRIPTION
Password confirmation on Staking drawer gets stuck if you press confirm with empty password

# Checklist

- [x] JIRA - \<[link](https://input-output.atlassian.net/issues/LW-11405)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Component was not checking against the password component value. This is now fixed