### PR TITLE
fix(extension): signData component no longer crash when enter is pressed on password input

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/SignData.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/SignData.tsx
@@ -48,6 +48,18 @@ export const SignData = (): React.ReactElement => {
     return !password;
   }, [request, password]);
 
+  const handleSubmit = useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!confirmIsDisabled) {
+        onConfirm();
+      }
+    },
+    [onConfirm, confirmIsDisabled]
+  );
+
   return (
     <Layout title={undefined}>
       <div className={styles.passwordContainer}>
@@ -57,6 +69,7 @@ export const SignData = (): React.ReactElement => {
           </h5>
           <Password
             onChange={handleChange}
+            onSubmit={handleSubmit}
             error={validPassword === false}
             errorMessage={t('browserView.transaction.send.error.invalidPassword')}
           />


### PR DESCRIPTION
Sign Data confirm crash on 'enter' key

### **Checklist**

 JIRA - <[link](https://input-output.atlassian.net/browse/LW-11650)>


### **Proposed solution**

Manage onSubmit to avoid reload on Password form.
