### PR TITLE
fix(nami): add bech32 encoding fallback for nami mode

### DIFF
--- a/packages/nami/src/adapters/transactions.ts
+++ b/packages/nami/src/adapters/transactions.ts
@@ -128,11 +128,26 @@ const getAddressCredentials = (
   Wallet.Crypto.Hash28ByteBase16 | undefined,
   Wallet.Crypto.Hash28ByteBase16 | undefined,
 ] => {
-  const addr = Wallet.Cardano.Address.fromBech32(address);
-  return [
-    addr.getProps().paymentPart?.hash,
-    addr.getProps().delegationPart?.hash,
-  ];
+  try {
+    const addr = Wallet.Cardano.Address.fromBech32(address);
+    return [
+      addr.getProps().paymentPart?.hash,
+      addr.getProps().delegationPart?.hash,
+    ];
+  } catch (error) {
+    // try casting as byron address
+    try {
+      const addr = Wallet.Cardano.Address.fromBase58(address);
+      return [
+        addr.getProps().paymentPart?.hash,
+        addr.getProps().delegationPart?.hash,
+      ];
+    } catch (error) {
+      console.error(error);
+    }
+    console.error(error);
+    return [undefined, undefined];
+  }
 };
 
 const matchesAnyCredential = (


### PR DESCRIPTION
implement try/catch with undefined fallback
prevents nami crashing if bech32 or base8 decode fails, or throws due to:
- invalid string length
- mixed formatting
- any other issue related to encoding

# Checklist

- [x] JIRA - [LW-11769](https://input-output.atlassian.net/browse/LW-11769)
- companion PR to https://github.com/input-output-hk/nami/pull/962

---

## Proposed solution

Added try/catch with additional attempt to cast as byron address, with appropriate error fallback

## Testing

Use same wallet addr provided in the companion PR before and after applying these changes


[LW-11769]: https://input-output.atlassian.net/browse/LW-11769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ