### PR TITLE
fix: hardware wallet dApp connector now uses the same window size as regular wallets

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
@@ -2,7 +2,7 @@ import { cip30 as walletCip30 } from '@cardano-sdk/wallet';
 import { ensureUiIsOpenAndLoaded } from './util';
 import { userPromptService } from './services/dappService';
 import { authenticator } from './authenticator';
-import { wallet$, walletManager, walletRepository } from './wallet';
+import { wallet$ } from './wallet';
 import { runtime, Tabs, tabs } from 'webextension-polyfill';
 import { exposeApi, RemoteApiPropertyType, cip30 } from '@cardano-sdk/web-extension';
 import { DAPP_CHANNELS } from '../../../utils/constants';
@@ -47,7 +47,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
   signTx: pDebounce(
     async () => {
       try {
-        const tab = await ensureUiIsOpenAndLoaded({ walletManager, walletRepository }, '#/dapp/sign-tx');
+        const tab = await ensureUiIsOpenAndLoaded('#/dapp/sign-tx');
         const ready = await userPromptService.readyToSignTx();
         if (!ready) return false;
         return cancelOnTabClose(tab);
@@ -62,7 +62,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
   signData: pDebounce(
     async () => {
       try {
-        const tab = await ensureUiIsOpenAndLoaded({ walletManager, walletRepository }, '#/dapp/sign-data');
+        const tab = await ensureUiIsOpenAndLoaded('#/dapp/sign-data');
         const ready = await userPromptService.readyToSignData();
         if (!ready) return false;
         return cancelOnTabClose(tab);
@@ -86,7 +86,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
 
         const dappInfo = await senderToDappInfo(args.sender);
         dappSetCollateral$.next({ dappInfo, collateralRequest: args.data });
-        await ensureUiIsOpenAndLoaded({ walletManager, walletRepository }, '#/dapp/set-collateral');
+        await ensureUiIsOpenAndLoaded('#/dapp/set-collateral');
 
         return userPromptService.getCollateralRequest();
       } catch (error) {

--- a/apps/browser-extension-wallet/src/lib/scripts/background/requestAccess.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/requestAccess.ts
@@ -9,7 +9,6 @@ import { authenticator } from './authenticator';
 import { AUTHORIZED_DAPPS_KEY } from '../types';
 import { Wallet } from '@lace/cardano';
 import { BehaviorSubject } from 'rxjs';
-import { walletManager, walletRepository } from './wallet';
 import { senderToDappInfo } from '@src/utils/senderToDappInfo';
 
 const DEBOUNCE_THROTTLE = 500;
@@ -19,7 +18,7 @@ export const dappInfo$ = new BehaviorSubject<Wallet.DappInfo>(undefined);
 export const requestAccess: RequestAccess = async (sender: Runtime.MessageSender) => {
   const { logo, name, url } = await senderToDappInfo(sender);
   dappInfo$.next({ logo, name, url });
-  await ensureUiIsOpenAndLoaded({ walletManager, walletRepository }, '#/dapp/connect', false);
+  await ensureUiIsOpenAndLoaded('#/dapp/connect');
   const isAllowed = await userPromptService.allowOrigin(url);
   if (isAllowed === 'deny') return Promise.reject();
   if (isAllowed === 'allow') {

--- a/apps/browser-extension-wallet/src/utils/constants.ts
+++ b/apps/browser-extension-wallet/src/utils/constants.ts
@@ -94,16 +94,6 @@ export const POPUP_WINDOW_NAMI = {
 
 export const POPUP_WINDOW_NAMI_TITLE = 'Nami (Lace)';
 
-export const HW_POPUP_WINDOW = {
-  width: 900,
-  height: 630
-};
-
-export const HW_POPUP_WINDOW_NAMI = {
-  width: 400,
-  height: 800
-};
-
 export const DAPP_CHANNELS = {
   userPrompt: `user-prompt-${process.env.WALLET_NAME}`,
   authenticator: `authenticator-${process.env.WALLET_NAME}`,


### PR DESCRIPTION
# Checklist

- [x] JIRA - \<link>
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Hardware wallets dApp connector were displayed wider because it required displaying an extra popup for device selection. This is no longer required.

## Testing

Both hardware wallets and in memory wallet dApp connector use the same popup and size

## Screenshots
![Screenshot from 2024-10-30 12-04-32](https://github.com/user-attachments/assets/96649d8a-0f70-432d-ad96-6f6ffc0e85ed)

![Screenshot from 2024-10-30 12-05-15](https://github.com/user-attachments/assets/f4197627-9fd5-4c66-be34-7f2a5e96389c)

