### PR TITLE
fix(extension): send balance UI no longer glitches when input field loses focus

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -19,8 +19,7 @@ import {
   useSubmitingState,
   useTransactionProps,
   useMetadata,
-  useAnalyticsSendFlowTriggerPoint,
-  useMaxAdaStatus
+  useAnalyticsSendFlowTriggerPoint
 } from '../../store';
 import { useHandleClose } from './Header';
 import { useWalletStore } from '@src/stores';
@@ -89,7 +88,6 @@ export const Footer = withAddressBookContext(
     const { list: addressList, utils } = useAddressBookContext();
     const { updateRecord: updateAddress, deleteRecord: deleteAddress } = utils;
     const handleResolver = useHandleResolver();
-    const { isMaxAdaLoading } = useMaxAdaStatus();
     const { sharedWalletKey, getSignPolicy } = useSharedWalletData();
 
     const isSummaryStep = currentSection.currentSection === Sections.SUMMARY;
@@ -418,8 +416,7 @@ export const Footer = withAddressBookContext(
     }, [t, currentSection.currentSection]);
 
     const isConfirmButtonDisabled =
-      (confirmDisable || isSubmitDisabled || isMaxAdaLoading) &&
-      currentSection.currentSection !== Sections.ADDRESS_CHANGE;
+      (confirmDisable || isSubmitDisabled) && currentSection.currentSection !== Sections.ADDRESS_CHANGE;
 
     const submitHwFormStep = useCallback(() => {
       triggerSubmit();


### PR DESCRIPTION
# Checklist

- [X] JIRA - \<[link](https://input-output.atlassian.net/browse/LW-10796)>
- [] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Currently in Lace when the input field loses focus (blur) the UI re-renders with the review-transaction greyed disabled for a split second, If the user changes focus by clicking the button, it needs to click twice. This is caused by a specific flag that checks whether the max ADA available was already computed to be used in a specific button of the UI. I removed this check, now the UI re-renders with the button enabled. Removing this check doesn't seems to have any negative effect in the MAX ADA functionality.

The interface now doesn't require a double click on the review button
## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes
