### PR TITLE
fix: improve shared wallet xpub key generation

### DIFF
--- a/packages/core/src/shared-wallets/flow-stories/AddSharedWalletStorybookHelper.tsx
+++ b/packages/core/src/shared-wallets/flow-stories/AddSharedWalletStorybookHelper.tsx
@@ -40,13 +40,12 @@ type AddSharedWalletFlowProps = {
   modalOpen?: boolean;
 };
 
-const generateSharedWalletKey = makeGenerateSharedWalletKey({
-  chainId: Wallet.Cardano.ChainIds.Preprod,
-  getMnemonic: async () => Wallet.KeyManagement.util.generateMnemonicWords(),
-});
-
 export const sharedWalletKey =
   '979693650bb44f26010e9f7b3b550b0602c748d1d00981747bac5c34cf5b945fe01a39317b9b701e58ee16b5ed16aa4444704b98cc997bdd6c5a9502a8b7d70d';
+
+const generateSharedWalletKey = makeGenerateSharedWalletKey({
+  getSharedWalletExtendedPublicKey: async () => Wallet.Crypto.Bip32PublicKeyHex(sharedWalletKey),
+});
 
 export const activeWalletName = 'My wallet';
 


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-11859
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Previously, we created a keyAgent just to get the xpub key of the wallet. There is no need for that, Since there's already [functionality to generate xpub key](https://github.com/input-output-hk/lace/blob/main/apps/browser-extension-wallet/src/hooks/useWalletManager.ts#L154-L183) from an encrypted passphrase, I extended it to be able to generate CIP-1854 xpub keys too.

## Testing

I tested manually and works as expected.

## Screenshots

Attach screenshots here if implementation involves some UI changes
