### PR TITLE
LW-11892 fix: base wallet is now only loaded in background script

### DIFF
--- a/apps/browser-extension-wallet/src/features/nami-migration/Activating.tsx
+++ b/apps/browser-extension-wallet/src/features/nami-migration/Activating.tsx
@@ -2,13 +2,14 @@ import React, { useEffect } from 'react';
 
 import { NamiMigrationUpdatingYourWallet } from '@lace/core';
 import { consumeRemoteApi, RemoteApiPropertyType } from '@cardano-sdk/web-extension';
-import { NamiMigrationAPI, NamiMigrationChannels } from '@lib/scripts/background/nami-migration';
+import type { NamiMigrationAPI } from '@lib/scripts/background/nami-migration';
 import { runtime } from 'webextension-polyfill';
 import { useHistory } from 'react-router-dom';
 import { walletRoutePaths as routes } from '@routes/wallet-paths';
 import { useCurrencyStore } from '@providers/currency';
 import { MigrationState } from './migration-tool/migrator/migration-state.data';
 import { useTheme } from '@providers/ThemeProvider/context';
+import { NamiMigrationChannels } from '@lib/scripts/types';
 
 const namiMigrationRemoteApi = consumeRemoteApi<Pick<NamiMigrationAPI, 'startMigration' | 'checkMigrationStatus'>>(
   {

--- a/apps/browser-extension-wallet/src/features/nami-migration/NamiMigrationGuard.tsx
+++ b/apps/browser-extension-wallet/src/features/nami-migration/NamiMigrationGuard.tsx
@@ -1,5 +1,5 @@
 import { consumeRemoteApi, RemoteApiPropertyType } from '@cardano-sdk/web-extension';
-import { NamiMigrationAPI, NamiMigrationChannels } from '@lib/scripts/background/nami-migration';
+import type { NamiMigrationAPI } from '@lib/scripts/background/nami-migration';
 import { getBackgroundStorage } from '@lib/scripts/background/storage';
 import { MigrationState } from './migration-tool/migrator/migration-state.data';
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
@@ -9,7 +9,7 @@ import { walletRoutePaths as routes } from '@routes/wallet-paths';
 import { useWalletStore } from '@src/stores';
 import { APP_MODE_POPUP } from '@src/utils/constants';
 import { useBackgroundServiceAPIContext } from '@providers';
-import { BrowserViewSections } from '@lib/scripts/types';
+import { BrowserViewSections, NamiMigrationChannels } from '@lib/scripts/types';
 import { NamiMigration } from './NamiMigration';
 
 const namiMigrationRemoteApi = consumeRemoteApi<Pick<NamiMigrationAPI, 'checkMigrationStatus' | 'abortMigration'>>(

--- a/apps/browser-extension-wallet/src/lib/scripts/background/nami-migration.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/nami-migration.ts
@@ -8,6 +8,7 @@ import { currencyCode } from '@providers/currency/constants';
 import { exposeApi, getWalletStoreId, RemoteApiPropertyType } from '@cardano-sdk/web-extension';
 import { storage } from '@cardano-sdk/wallet';
 import { of } from 'rxjs';
+import { NamiMigrationChannels } from '@lib/scripts/types';
 
 const collateralRepository: CollateralRepository = async ({ utxo, chainId, walletId, accountIndex }) => {
   const walletStoreId = getWalletStoreId(walletId, chainId, accountIndex);
@@ -27,10 +28,6 @@ const startMigration = async () => {
     themeColor: state.themeColor
   };
 };
-
-export enum NamiMigrationChannels {
-  MIGRATION = 'migration'
-}
 
 export interface NamiMigrationAPI {
   checkMigrationStatus: () => Promise<MigrationState>;

--- a/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
@@ -39,6 +39,10 @@ import { ExperimentName } from '@providers/ExperimentsProvider/types';
 import { requestMessage$ } from './services/utilityServices';
 import { MessageTypes } from '../types';
 
+if (typeof window !== 'undefined') {
+  throw new TypeError('This module should only be imported in service worker');
+}
+
 // It is important that this file is not exported from index,
 // because creating wallet repository with store creates an actual pouchdb database
 // which results in some trash files when running the tests (leveldb directory)

--- a/apps/browser-extension-wallet/src/lib/scripts/types/index.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/index.ts
@@ -3,3 +3,4 @@ export * from './dapp-service';
 export * from './userIdService';
 export * from './prices';
 export * from './storage';
+export * from './nami-migration-channels';

--- a/apps/browser-extension-wallet/src/lib/scripts/types/nami-migration-channels.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/nami-migration-channels.ts
@@ -1,0 +1,3 @@
+export enum NamiMigrationChannels {
+  MIGRATION = 'migration'
+}


### PR DESCRIPTION
# Checklist

- [x] JIRA - \<[link](https://input-output.atlassian.net/browse/LW-11892)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

Lace wallet is importing from background script in the UI script, which is causing the wallet to be instantiated in the UI script every time a new tab or popup is opened.
