### PR TITLE
fix(nami): use same collateral check as in Lace [LW-11900]

### DIFF
--- a/apps/browser-extension-wallet/src/views/nami-mode/NamiView.tsx
+++ b/apps/browser-extension-wallet/src/views/nami-mode/NamiView.tsx
@@ -90,7 +90,8 @@ export const NamiView = withDappContext((): React.ReactElement => {
     isInitializing,
     initializeCollateralTx,
     submitCollateralTx,
-    txBuilder: collateralTxBuilder
+    txBuilder: collateralTxBuilder,
+    hasEnoughAda: hasEnoughAdaForCollateral
   } = useCollateral();
 
   const [isCompatibilityMode, setIsCompatibilityMode] = useState<boolean>();
@@ -191,6 +192,7 @@ export const NamiView = withDappContext((): React.ReactElement => {
         isCompatibilityMode,
         handleAnalyticsChoice,
         handleCompatibilityModeChoice,
+        hasEnoughAdaForCollateral,
         createWallet: createWalletFromPrivateKey,
         getMnemonic,
         deleteWallet,

--- a/packages/nami/src/features/outside-handles-provider/types.ts
+++ b/packages/nami/src/features/outside-handles-provider/types.ts
@@ -41,6 +41,7 @@ export interface OutsideHandlesContextValue {
   handleCompatibilityModeChoice: (
     isCompatibilityMode: boolean,
   ) => Promise<void>;
+  hasEnoughAdaForCollateral: boolean;
   createWallet: (
     args: Readonly<CreateWalletParams>,
   ) => Promise<Wallet.CardanoWallet>;

--- a/packages/nami/src/ui/app/components/transactionBuilder.tsx
+++ b/packages/nami/src/ui/app/components/transactionBuilder.tsx
@@ -118,6 +118,7 @@ const TransactionBuilder = (undefined, ref) => {
     isInitializingCollateral,
     initializeCollateralTx: initializeCollateral,
     collateralFee,
+    hasEnoughAdaForCollateral,
     buildDelegation,
     setSelectedStakePool,
     delegationTxFee,
@@ -248,12 +249,8 @@ const TransactionBuilder = (undefined, ref) => {
       }
       collateralRef.current?.openModal();
 
-      const available = await firstValueFrom(
-        inMemoryWallet.balance.utxo.available$,
-      );
-
       try {
-        if (available.coins < BigInt(5_000_000)) {
+        if (!hasEnoughAdaForCollateral) {
           setData(d => ({
             ...d,
             error: 'Transaction not possible (maybe insufficient balance)',


### PR DESCRIPTION
# Checklist

- [x] https://input-output.atlassian.net/browse/LW-11900

---

## Proposed solution

This PR fixes the collateral check in Nami by introducing the same check as used for Lace.

## Testing

- Setup a wallet with 5.5 ADA which should fail the collateral check in Lace (but not in Nami mode on `main` branch)
- For this PR test that the collateral check fails for both Lace and Nami mode (as expected)
