### PR TITLE
fix: [LW-11938] remove inputs resolver that relies on chain history provider

### DIFF
--- a/apps/browser-extension-wallet/src/views/nami-mode/NamiView.tsx
+++ b/apps/browser-extension-wallet/src/views/nami-mode/NamiView.tsx
@@ -42,6 +42,7 @@ import { isKeyHashAddress } from '@cardano-sdk/wallet';
 import { BackgroundStorage } from '@lib/scripts/types';
 import { getWalletAccountsQtyString } from '@src/utils/get-wallet-count-string';
 import { useNetworkError } from '@hooks/useNetworkError';
+import { createHistoricalOwnInputResolver } from '@src/utils/own-input-resolver';
 
 const { AVAILABLE_CHAINS, DEFAULT_SUBMIT_API } = config();
 
@@ -235,7 +236,8 @@ export const NamiView = withDappContext((): React.ReactElement => {
         setDeletingWallet,
         chainHistoryProvider,
         protocolParameters: walletState?.protocolParameters,
-        assetInfo: walletState?.assetInfo
+        assetInfo: walletState?.assetInfo,
+        createHistoricalOwnInputResolver
       }}
     >
       <CommonOutsideHandlesProvider

--- a/packages/nami/src/features/outside-handles-provider/types.ts
+++ b/packages/nami/src/features/outside-handles-provider/types.ts
@@ -122,4 +122,16 @@ export interface OutsideHandlesContextValue {
   chainHistoryProvider: Wallet.ChainHistoryProvider;
   protocolParameters: Wallet.Cardano.ProtocolParameters;
   assetInfo: Wallet.Assets;
+  createHistoricalOwnInputResolver: (
+    props: Readonly<{
+      transactions: {
+        history: Wallet.Cardano.HydratedTx[];
+        outgoing: {
+          inFlight: Wallet.TxInFlight[];
+          signed: Wallet.KeyManagement.WitnessedTx[];
+        };
+      };
+      addresses: Wallet.WalletAddress[];
+    }>,
+  ) => Wallet.Cardano.InputResolver;
 }


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-11938](https://input-output.atlassian.net/browse/LW-11938)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Use custom input resolver to avoid additional calls to chain-history.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-11938]: https://input-output.atlassian.net/browse/LW-11938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ