### PR TITLE
fix: [lw-11875] remove status info from reward activity details

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityDetail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityDetail.tsx
@@ -136,7 +136,6 @@ export const ActivityDetail = ({ price }: ActivityDetailProps): ReactElement => 
     return (
       <RewardsDetails
         name={name}
-        status={activityInfo.status}
         includedDate={activityInfo.activity.includedUtcDate}
         includedTime={activityInfo.activity.includedUtcTime}
         amountTransformer={amountTransformer}

--- a/packages/core/src/ui/components/ActivityDetail/RewardsDetails.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/RewardsDetails.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import cn from 'classnames';
 import { Tooltip } from 'antd';
 import styles from './TransactionDetails.module.scss';
-import { ActivityStatus } from '../Transaction';
 import { Ellipsis } from '@lace/common';
 import { ActivityDetailHeader } from './ActivityDetailHeader';
 import { useTranslation } from 'react-i18next';
@@ -21,7 +20,6 @@ export type RewardsInfo = {
 export interface RewardsDetailsProps {
   name: string;
   headerDescription?: string;
-  status: ActivityStatus.SPENDABLE;
   includedDate: string;
   includedTime: string;
   amountTransformer: (amount: string) => string;
@@ -32,7 +30,6 @@ export interface RewardsDetailsProps {
 export const RewardsDetails = ({
   name,
   headerDescription,
-  status,
   includedDate,
   includedTime,
   amountTransformer,
@@ -117,14 +114,6 @@ export const RewardsDetails = ({
             </div>
           )}
 
-          <div className={styles.details}>
-            <div className={styles.title} data-testid="rewards-status-title">
-              {t('core.activityDetails.status')}
-            </div>
-            <div data-testid="rewards-status" className={styles.detail}>{`${status
-              .charAt(0)
-              .toUpperCase()}${status.slice(1)}`}</div>
-          </div>
           <div className={styles.details}>
             <div className={styles.title} data-testid="rewards-epoch-title">
               {t('core.activityDetails.epoch')}

--- a/packages/core/src/ui/components/ActivityDetail/__tests__/RewardsDetails.test.tsx
+++ b/packages/core/src/ui/components/ActivityDetail/__tests__/RewardsDetails.test.tsx
@@ -3,13 +3,11 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { RewardsDetails, RewardsDetailsProps } from '../RewardsDetails';
-import { ActivityStatus } from '../../Transaction';
 
 describe('Testing ActivityDetailsBrowser component', () => {
   const rewardsDetailsProps: RewardsDetailsProps = {
     name: 'Name',
     headerDescription: 'Header Description',
-    status: ActivityStatus.SPENDABLE,
     includedDate: 'Date',
     includedTime: 'Time',
     amountTransformer: (amount) => `${amount} $`,

--- a/packages/e2e-tests/src/assert/transactionDetailsAssert.ts
+++ b/packages/e2e-tests/src/assert/transactionDetailsAssert.ts
@@ -431,18 +431,6 @@ class TransactionsDetailsAssert {
     await this.assertSeeRewardsStakePoolsSection();
     await this.assertSeeRewardsSinglePool();
 
-    await TransactionDetailsPage.transactionDetailsRewardsStatusTitle.waitForDisplayed();
-    expect(await TransactionDetailsPage.transactionDetailsRewardsStatusTitle.getText()).to.equal(
-      await t('core.activityDetails.status')
-    );
-    await TransactionDetailsPage.transactionDetailsRewardsStatus.waitForDisplayed();
-    expect(await TransactionDetailsPage.transactionDetailsRewardsStatus.getText()).to.be.oneOf([
-      'Spendable',
-      'Success',
-      'Sending',
-      'Error'
-    ]);
-
     await TransactionDetailsPage.transactionDetailsRewardsEpochTitle.waitForDisplayed();
     expect(await TransactionDetailsPage.transactionDetailsRewardsEpochTitle.getText()).to.equal(
       await t('core.activityDetails.epoch')

--- a/packages/e2e-tests/src/elements/transactionDetails.ts
+++ b/packages/e2e-tests/src/elements/transactionDetails.ts
@@ -58,8 +58,6 @@ class ActivityDetailsPage extends CommonDrawerElements {
   private TRANSACTION_DETAILS_REWARDS_POOL_ID = '[data-testid="rewards-pool-id"]';
   private TRANSACTION_DETAILS_REWARDS_SINGLE_POOL_ADA = '[data-testid="rewards-pool-reward-ada"]';
   private TRANSACTION_DETAILS_REWARDS_SINGLE_POOL_FIAT = '[data-testid="rewards-pool-reward-fiat"]';
-  private TRANSACTION_DETAILS_REWARDS_STATUS_TITLE = '[data-testid="rewards-status-title"]';
-  private TRANSACTION_DETAILS_REWARDS_STATUS = '[data-testid="rewards-status"]';
   private TRANSACTION_DETAILS_REWARDS_EPOCH_TITLE = '[data-testid="rewards-epoch-title"]';
   private TRANSACTION_DETAILS_REWARDS_EPOCH = '[data-testid="rewards-epoch"]';
   private TRANSACTION_DETAILS_REWARDS_TIMESTAMP_TITLE = '[data-testid="rewards-date-title"]';
@@ -303,14 +301,6 @@ class ActivityDetailsPage extends CommonDrawerElements {
 
   get transactionDetailsRewardsSinglePoolFiat(): Promise<WebdriverIO.ElementArray> {
     return $$(this.TRANSACTION_DETAILS_REWARDS_SINGLE_POOL_FIAT);
-  }
-
-  get transactionDetailsRewardsStatusTitle(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(this.TRANSACTION_DETAILS_REWARDS_STATUS_TITLE);
-  }
-
-  get transactionDetailsRewardsStatus(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $(this.TRANSACTION_DETAILS_REWARDS_STATUS);
   }
 
   get transactionDetailsRewardsEpochTitle(): ChainablePromiseElement<WebdriverIO.Element> {


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-11875](https://input-output.atlassian.net/browse/LW-11875)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Explain how does this PR solves the problem stated in JIRA ticket.
You can also enumerate different alternatives considered while approaching this task.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

<img width="670" alt="Screenshot 2024-12-04 at 23 17 08" src="https://github.com/user-attachments/assets/6f913da7-8053-4a06-889f-9e0638922e3a">



[LW-11875]: https://input-output.atlassian.net/browse/LW-11875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ