### PR TITLE
fix: [lw-11926] catch unvalid regex error in word list search util

### DIFF
--- a/packages/core/src/ui/utils/word-list-search.ts
+++ b/packages/core/src/ui/utils/word-list-search.ts
@@ -18,6 +18,12 @@ export const wordListSearch = (
   if (!searchWord || !wordList?.length) return suggestionList;
 
   const parsedSearchWord = isCaseSensitive ? searchWord : searchWord.toLowerCase();
+  let parsedSearchWordRegExp;
+  try {
+    parsedSearchWordRegExp = new RegExp(`^${parsedSearchWord}.*$`);
+  } catch {
+    return suggestionList;
+  }
 
   while (continueSearching) {
     const currentWord = wordList[currentWordIdx];
@@ -36,10 +42,9 @@ export const wordListSearch = (
   }
 
   for (let idx = 0; idx < suggestionListLength; idx++) {
-    const startWith = new RegExp(`^${parsedSearchWord}.*$`);
     const currentWord = wordList[currentWordIdx + idx];
 
-    if (startWith.test(currentWord)) {
+    if (parsedSearchWordRegExp.test(currentWord)) {
       suggestionList.push(currentWord);
     }
   }


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-11926](https://input-output.atlassian.net/browse/LW-11926)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Handle invalid regexp thrown from word-list-search util with simple try catch clause.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes
