### PR TITLE
fix: show an error when trying to deregister stake key with rewards w…

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useBuildDelegation.ts
+++ b/apps/browser-extension-wallet/src/hooks/useBuildDelegation.ts
@@ -1,15 +1,19 @@
 import { useCallback } from 'react';
 import { useStakePoolDetails } from '@src/features/stake-pool-details/store';
-import { StakingError } from '@src/views/browser-view/features/staking/types';
+import { StakingErrorType } from '@src/views/browser-view/features/staking/types';
 import { useWalletStore } from '../stores';
 import { useDelegationStore } from '../features/delegation/stores';
 import { InputSelectionFailure } from '@cardano-sdk/input-selection';
 import { Wallet } from '@lace/cardano';
+import { DeRegistrationsWithRewardsLocked } from '@cardano-sdk/tx-construction';
 
-const ERROR_MESSAGES: { [key: string]: StakingError } = {
-  [InputSelectionFailure.UtxoFullyDepleted]: StakingError.UTXO_FULLY_DEPLETED,
-  [InputSelectionFailure.UtxoBalanceInsufficient]: StakingError.UTXO_BALANCE_INSUFFICIENT
-};
+const ERROR_MESSAGES = {
+  [InputSelectionFailure.UtxoFullyDepleted]: StakingErrorType.UTXO_FULLY_DEPLETED,
+  [InputSelectionFailure.UtxoBalanceInsufficient]: StakingErrorType.UTXO_BALANCE_INSUFFICIENT
+} as const;
+
+const isDeRegistrationsWithRewardsLockedError = (error: unknown): error is DeRegistrationsWithRewardsLocked =>
+  !!error && typeof error === 'object' && 'name' in error && error.name === DeRegistrationsWithRewardsLocked.name;
 
 export const useBuildDelegation = (): { buildDelegation: () => Promise<void> } => {
   const { inMemoryWallet } = useWalletStore();
@@ -30,9 +34,20 @@ export const useBuildDelegation = (): { buildDelegation: () => Promise<void> } =
         setDelegationTxFee(tx.body.fee.toString());
         setStakingError();
       } catch (error) {
-        // TODO: check for error instance after LW-6749
-        if (typeof error === 'object' && Object.values(InputSelectionFailure).includes(error.failure)) {
-          setStakingError(ERROR_MESSAGES[error?.failure]);
+        if (isDeRegistrationsWithRewardsLockedError(error)) {
+          setStakingError({
+            data: error.keysWithLockedRewards,
+            type: StakingErrorType.REWARDS_LOCKED
+          });
+        } else if (
+          // TODO: check for error instance after LW-6749
+          typeof error === 'object' &&
+          Object.values(InputSelectionFailure).includes(error.failure) &&
+          error.failure in ERROR_MESSAGES
+        ) {
+          setStakingError({
+            type: ERROR_MESSAGES[error.failure as keyof typeof ERROR_MESSAGES]
+          });
         }
       } finally {
         setIsBuildingTx(false);

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolDetails/StakePoolConfirmation.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakePoolDetails/StakePoolConfirmation.tsx
@@ -17,7 +17,7 @@ import { sectionsConfig, useStakePoolDetails } from '../../store';
 import Cardano from '../../../../../../assets/images/cardano-blue-bg.png';
 import styles from './StakePoolConfirmation.module.scss';
 import ArrowDown from '../../../../../../assets/icons/arrow-down.component.svg';
-import { Sections, StakingError } from '@views/browser/features/staking/types';
+import { Sections, StakingErrorType } from '@views/browser/features/staking/types';
 import { useDelegationTransaction } from '@views/browser/features/staking/hooks';
 import { BrowserViewSections } from '@lib/scripts/types';
 import { ContinueInBrowserDialog } from '@components/ContinueInBrowserDialog';
@@ -75,8 +75,8 @@ export const StakePoolConfirmation = ({ popupView }: StakePoolConfirmationProps)
       : undefined;
 
   const ErrorMessages = {
-    [StakingError.UTXO_FULLY_DEPLETED]: t('browserView.staking.details.errors.utxoFullyDepleted'),
-    [StakingError.UTXO_BALANCE_INSUFFICIENT]: t('browserView.staking.details.errors.utxoBalanceInsufficient')
+    [StakingErrorType.UTXO_FULLY_DEPLETED]: t('browserView.staking.details.errors.utxoFullyDepleted'),
+    [StakingErrorType.UTXO_BALANCE_INSUFFICIENT]: t('browserView.staking.details.errors.utxoBalanceInsufficient')
   };
 
   const ItemStatRenderer = ({ img, text, subText }: statRendererProps) => (
@@ -108,9 +108,9 @@ export const StakePoolConfirmation = ({ popupView }: StakePoolConfirmationProps)
           {t('browserView.staking.details.confirmation.subTitle')}
         </div>
       </div>
-      {stakingError && (
+      {stakingError && stakingError.type !== StakingErrorType.REWARDS_LOCKED && (
         <div>
-          <Banner customIcon={ExclamationMarkIcon} withIcon message={ErrorMessages[stakingError]} />
+          <Banner customIcon={ExclamationMarkIcon} withIcon message={ErrorMessages[stakingError.type]} />
         </div>
       )}
       <div className={cn(styles.container, { [styles.popupView]: popupView })} data-testid="sp-confirmation-container">

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/types/stakingStore.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/types/stakingStore.ts
@@ -1,3 +1,4 @@
+import { DataOfKeyWithLockedRewards } from '@cardano-sdk/tx-construction';
 export enum Sections {
   DETAIL = 'detail',
   CONFIRMATION = 'confirmation',
@@ -6,10 +7,19 @@ export enum Sections {
   FAIL_TX = 'fail_tx'
 }
 
-export enum StakingError {
+export enum StakingErrorType {
   UTXO_FULLY_DEPLETED = 'UTXO_FULLY_DEPLETED',
-  UTXO_BALANCE_INSUFFICIENT = 'UTXO_BALANCE_INSUFFICIENT'
+  UTXO_BALANCE_INSUFFICIENT = 'UTXO_BALANCE_INSUFFICIENT',
+  REWARDS_LOCKED = 'REWARDS_LOCKED'
 }
+
+export type StakingError =
+  | { type: StakingErrorType.UTXO_BALANCE_INSUFFICIENT }
+  | { type: StakingErrorType.UTXO_FULLY_DEPLETED }
+  | {
+      data: DataOfKeyWithLockedRewards[];
+      type: StakingErrorType.REWARDS_LOCKED;
+    };
 
 export interface SectionConfig {
   currentSection: Sections;

--- a/apps/browser-extension-wallet/src/views/nami-mode/NamiView.tsx
+++ b/apps/browser-extension-wallet/src/views/nami-mode/NamiView.tsx
@@ -45,8 +45,9 @@ import { getWalletAccountsQtyString } from '@src/utils/get-wallet-count-string';
 import { useNetworkError } from '@hooks/useNetworkError';
 import { createHistoricalOwnInputResolver } from '@src/utils/own-input-resolver';
 import { walletRoutePaths } from '@routes';
+import { StakingErrorType } from '@views/browser/features/staking/types';
 
-const { AVAILABLE_CHAINS, DEFAULT_SUBMIT_API } = config();
+const { AVAILABLE_CHAINS, DEFAULT_SUBMIT_API, GOV_TOOLS_URLS } = config();
 
 export const NamiView = withDappContext((): React.ReactElement => {
   const { setFiatCurrency, fiatCurrency } = useCurrencyStore();
@@ -119,7 +120,7 @@ export const NamiView = withDappContext((): React.ReactElement => {
     useDelegationStore();
   const { buildDelegation } = useBuildDelegation();
   const { signAndSubmitTransaction } = useDelegationTransaction();
-  const { isBuildingTx, stakingError, setIsBuildingTx } = useStakePoolDetails();
+  const { isBuildingTx, stakingError, setIsBuildingTx, setStakingError } = useStakePoolDetails();
   const walletState = useWalletState();
   const secretsUtil = useSecrets();
   const openExternalLink = useExternalLinkOpener();
@@ -133,7 +134,8 @@ export const NamiView = withDappContext((): React.ReactElement => {
     setDelegationTxFee();
     setDelegationTxBuilder();
     setIsBuildingTx(false);
-  }, [secretsUtil, setDelegationTxBuilder, setDelegationTxFee, setIsBuildingTx]);
+    setStakingError();
+  }, [secretsUtil, setDelegationTxBuilder, setDelegationTxFee, setIsBuildingTx, setStakingError]);
 
   const rewardAccounts = useObservable(inMemoryWallet.delegation.rewardAccounts$);
   const isStakeRegistered =
@@ -227,7 +229,8 @@ export const NamiView = withDappContext((): React.ReactElement => {
         collateralTxBuilder,
         setSelectedStakePool,
         isBuildingTx,
-        stakingError,
+        stakingError: stakingError?.type,
+        accountsWithLockedRewards: stakingError?.type === StakingErrorType.REWARDS_LOCKED && stakingError.data,
         getStakePoolInfo,
         resetDelegationState,
         hasNoFunds,
@@ -247,7 +250,8 @@ export const NamiView = withDappContext((): React.ReactElement => {
         assetInfo: walletState?.assetInfo,
         createHistoricalOwnInputResolver,
         lockedStakeRewards,
-        redirectToStaking
+        redirectToStaking,
+        govToolsUrl: GOV_TOOLS_URLS[environmentName]
       }}
     >
       <CommonOutsideHandlesProvider

--- a/packages/nami/src/features/outside-handles-provider/types.ts
+++ b/packages/nami/src/features/outside-handles-provider/types.ts
@@ -1,6 +1,9 @@
 import type { CreateWalletParams } from '../../types/wallet';
 import type { EraSummary } from '@cardano-sdk/core';
-import type { TxBuilder } from '@cardano-sdk/tx-construction';
+import type {
+  DataOfKeyWithLockedRewards,
+  TxBuilder,
+} from '@cardano-sdk/tx-construction';
 import type {
   AnyBip32Wallet,
   WalletManagerActivateProps,
@@ -25,6 +28,12 @@ export interface WalletManagerAddAccountProps {
   metadata: Wallet.AccountMetadata;
   accountIndex: number;
   passphrase?: Uint8Array;
+}
+
+export enum StakingErrorType {
+  UTXO_FULLY_DEPLETED = 'UTXO_FULLY_DEPLETED',
+  UTXO_BALANCE_INSUFFICIENT = 'UTXO_BALANCE_INSUFFICIENT',
+  REWARDS_LOCKED = 'REWARDS_LOCKED',
 }
 
 export interface OutsideHandlesContextValue {
@@ -82,7 +91,8 @@ export interface OutsideHandlesContextValue {
     pool: Readonly<Wallet.Cardano.StakePool | undefined>,
   ) => void;
   isBuildingTx: boolean;
-  stakingError: string;
+  stakingError?: StakingErrorType;
+  accountsWithLockedRewards?: DataOfKeyWithLockedRewards[];
   getStakePoolInfo: (
     id: Readonly<Wallet.Cardano.PoolId>,
   ) => Promise<Wallet.Cardano.StakePool[]>;
@@ -133,4 +143,5 @@ export interface OutsideHandlesContextValue {
   ) => Wallet.Cardano.InputResolver;
   lockedStakeRewards: bigint;
   redirectToStaking: () => void;
+  govToolsUrl: string;
 }

--- a/packages/staking/src/features/Drawer/confirmation/LockedStakeKeysList.module.scss
+++ b/packages/staking/src/features/Drawer/confirmation/LockedStakeKeysList.module.scss
@@ -1,0 +1,10 @@
+@import '../../../../../../packages/common/src/ui/styles/theme.scss';
+
+ul.lockedStakeKeysList.lockedStakeKeysList {
+  margin-top: size_unit(1);
+  margin-bottom: size_unit(1);
+
+  p.content.content {
+    margin-bottom: 0;
+  }
+}

--- a/packages/staking/src/features/Drawer/confirmation/LockedStakeKeysList.tsx
+++ b/packages/staking/src/features/Drawer/confirmation/LockedStakeKeysList.tsx
@@ -1,0 +1,26 @@
+import { DataOfKeyWithLockedRewards } from '@cardano-sdk/tx-construction';
+import { Flex } from '@input-output-hk/lace-ui-toolkit';
+import { Ellipsis } from '@lace/common';
+import styles from './LockedStakeKeysList.module.scss';
+
+type LockedStakeKeysListProps = {
+  items: DataOfKeyWithLockedRewards[];
+};
+
+export const LockedStakeKeysList = ({ items }: LockedStakeKeysListProps) => (
+  <ul className={styles.lockedStakeKeysList}>
+    {items.map(({ cbor, key }) => (
+      <li key={key}>
+        <Flex>
+          <Ellipsis text={key} beforeEllipsis={16} afterEllipsis={10} textClassName={styles.content} />
+          {!!cbor && (
+            <>
+              &nbsp;(
+              <Ellipsis text={cbor} beforeEllipsis={10} afterEllipsis={10} textClassName={styles.content} />)
+            </>
+          )}
+        </Flex>
+      </li>
+    ))}
+  </ul>
+);

--- a/packages/staking/src/features/Drawer/confirmation/StakePoolConfirmationContent.module.scss
+++ b/packages/staking/src/features/Drawer/confirmation/StakePoolConfirmationContent.module.scss
@@ -29,7 +29,7 @@
   display: flex;
   flex-direction: column;
   gap: size_unit(3);
-  align-items: flex-start;
+  align-items: stretch;
 
   @media (max-width: $breakpoint-popup) {
     padding-bottom: size_unit(7);

--- a/packages/staking/src/features/outside-handles-provider/types.ts
+++ b/packages/staking/src/features/outside-handles-provider/types.ts
@@ -110,5 +110,5 @@ export type OutsideHandlesContextValue = {
     areAllRegisteredStakeKeysWithoutVotingDelegation: boolean;
     poolIdToRewardAccountsMap: Map<string, Wallet.Cardano.RewardAccountInfo[]>;
   };
-  govToolUrl?: string;
+  govToolUrl: string;
 };

--- a/packages/staking/src/features/store/stakingStore.ts
+++ b/packages/staking/src/features/store/stakingStore.ts
@@ -1,9 +1,19 @@
+import { DataOfKeyWithLockedRewards } from '@cardano-sdk/tx-construction';
 import { create } from 'zustand';
 
-export enum StakingError {
+export enum StakingErrorType {
   UTXO_FULLY_DEPLETED = 'UTXO_FULLY_DEPLETED',
   UTXO_BALANCE_INSUFFICIENT = 'UTXO_BALANCE_INSUFFICIENT',
+  REWARDS_LOCKED = 'REWARDS_LOCKED',
 }
+
+export type StakingError =
+  | { type: StakingErrorType.UTXO_BALANCE_INSUFFICIENT }
+  | { type: StakingErrorType.UTXO_FULLY_DEPLETED }
+  | {
+      data: DataOfKeyWithLockedRewards[];
+      type: StakingErrorType.REWARDS_LOCKED;
+    };
 
 export interface StakingStore {
   isStakeConfirmationVisible: boolean;

--- a/packages/translation/src/lib/translations/staking/en.json
+++ b/packages/translation/src/lib/translations/staking/en.json
@@ -58,6 +58,7 @@
   "drawer.confirmation.button.signing": "Signing in progress",
   "drawer.confirmation.cardanoName": "Cardano",
   "drawer.confirmation.chargedDepositAmountInfo": "The amount you'll be charged for registering your stake key.",
+  "drawer.confirmation.errors.rewardsLocked": "Due to Cardano protocol rules, some of your stake keys cannot be de-registered as they have pending rewards. To withdraw the rewards, you must first delegate the voting power of those stake keys using <Link>Gov.tools</Link> portal. Once delegated, you will be able to de-register the keys.<keys>",
   "drawer.confirmation.errors.utxoBalanceInsufficient": "Balance Insufficient",
   "drawer.confirmation.errors.utxoFullyDepleted": "UTxO Fully Depleted",
   "drawer.confirmation.noPools": "No pools",


### PR DESCRIPTION
…ithout vote

# Checklist

- [x] JIRA - [\<link>](https://input-output.atlassian.net/browse/LW-11898)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Background

We want to block de-registering stake keys if they:
 - have rewards and
 - have no drep delegation or drep is inactive

Related PR in SDK repo: [link](https://github.com/input-output-hk/cardano-js-sdk/pull/1547)

## Proposed solution

- Lace:
  - show a banner on a confirmation step
  - block the confirm button
  - hide costs section
- Nami: display popup with
  - a banner
  - close button
- in both modes banner content is the same - an explanation and a list of affected stake keys and their cbor-ized versions

## Testing

1. Ensure you have at least one reward account with revards and "incorrect" votes delegation (see background section)
3. Undelegate from the stake pool associated with those rewards (to attempt to deregister stake key)

## Screenshots

<img width="680" alt="image" src="https://github.com/user-attachments/assets/c90fa489-bf2e-4649-8139-a5b6892d919b" />
<img width="367" alt="image" src="https://github.com/user-attachments/assets/d79e2c86-ebf4-4ca2-a095-36383a1753e6" />