### PR TITLE
fix: align extension storage 'set' and 'observeAll' with pouchdb storage behavior

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/storage/extension-store.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/storage/extension-store.ts
@@ -2,6 +2,7 @@
 import { storage as extensionStorage, Storage } from 'webextension-polyfill';
 import { fromEventPattern, mergeMap, Observable, share } from 'rxjs';
 import { Logger } from 'ts-log';
+import { fromSerializableObject } from '@cardano-sdk/util';
 
 export abstract class ExtensionStore {
   protected readonly storageChange$: Observable<{ key: string; change: Storage.StorageChange }>;
@@ -13,7 +14,9 @@ export abstract class ExtensionStore {
       (handler) => this.storage.onChanged.addListener(handler),
       (handler) => this.storage.onChanged.removeListener(handler)
     ).pipe(
-      mergeMap((changes) => Object.entries(changes).map(([key, change]) => ({ key, change }))),
+      mergeMap((changes) =>
+        Object.entries(changes).map(([key, change]) => ({ key, change: fromSerializableObject(change) }))
+      ),
       share()
     );
   }

--- a/packages/e2e-tests/src/fixture/walletRepositoryInitializer.ts
+++ b/packages/e2e-tests/src/fixture/walletRepositoryInitializer.ts
@@ -16,11 +16,12 @@ export const clearWalletRepository = async (): Promise<void> => {
   await switchToWindowWithLace(0);
   await browser.execute(`
     return (async () => {
-      await window.walletManager.deactivate();
       const wallets = await window.firstValueFrom(window.walletRepository.wallets$);
-      for (const wallet of wallets) {
+      // reversing in order to delete shared wallets before dependent wallets
+      for (const wallet of wallets.reverse()) {
         await window.walletRepository.removeWallet(wallet.walletId);
       }
+      await window.walletManager.deactivate();
       return JSON.stringify(wallets);
     })()
   `);
@@ -32,23 +33,41 @@ export const getWalletsFromRepository = async (): Promise<any[]> =>
       return wallets;
   `);
 
-export const addAndActivateWalletInRepository = async (wallet: string): Promise<number> =>
+const addWalletInRepository = async (wallet: string): Promise<void> => {
   await browser.execute(
     `
-      let walletsObj = JSON.parse('${wallet}');
-      await walletRepository.addWallet(walletsObj[0]);
-       await walletManager.activate({
-        walletId: walletsObj[0].walletId,
-        accountIndex: walletsObj[0].accounts[0].accountIndex,
-        chainId: { networkId: 0, networkMagic: 1 }
-      })
+      return (async () => {
+        let walletsObj = JSON.parse('${wallet}');
+        await walletRepository.addWallet(walletsObj[0]);
+      })()
+    `
+  );
+};
+
+export const addAndActivateWalletInRepository = async (wallet: string): Promise<void> =>
+  await browser.execute(
+    `
+      return (async () => {
+        let walletsObj = JSON.parse('${wallet}');
+        await walletRepository.addWallet(walletsObj[0]);
+        // wait for Lace to auto-activate the added wallet,
+        // which might use a different network than we want to set here
+        // this is still a race and we should rework wallet initialization
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        await walletManager.activate({
+          walletId: walletsObj[0].walletId,
+          accountIndex: walletsObj[0].accounts[0].accountIndex,
+          chainId: { networkId: 0, networkMagic: 1 }
+        });
+      })()
   `
   );
 
 export const addAndActivateWalletsInRepository = async (wallets: TestWalletName[]): Promise<void> => {
   const walletsRepositoryArray = wallets.map((wallet) => getTestWallet(wallet).repository as string);
 
-  for (const wallet of walletsRepositoryArray.reverse()) {
-    await addAndActivateWalletInRepository(wallet);
+  for (const wallet of walletsRepositoryArray.slice(1).reverse()) {
+    await addWalletInRepository(wallet);
   }
+  await addAndActivateWalletInRepository(walletsRepositoryArray[0]);
 };


### PR DESCRIPTION
# Checklist

- [x] JIRA - \<[LW-11986](https://input-output.atlassian.net/browse/LW-11986), [LW-11993](https://input-output.atlassian.net/browse/LW-11993)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

### LW-11986

deleting a wallet does:
1. delete it from repository
2. check remaining wallets, activate if some wallet exists

there was a bug where step 2. would find the wallet that was just deleted and try to activate it, because extension storage 'observeAll' emits slightly later

953d5507d066ea149bc92381488a105657eb7046

### LW-11993

set()/get() applies toSerializableObject/fromSerializableObject respectively
storageChange$ did not, resulting in emitting slightly different objects
that were not processed by fromSerializableObject util this broke disabling accounts that were just enabled
and possibly some other functionality

487502c4b8b1c4340d1808f38b754ebb9bd21592

[LW-11986]: https://input-output.atlassian.net/browse/LW-11986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LW-11993]: https://input-output.atlassian.net/browse/LW-11993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ