### PR TITLE
feat(nami): [lw-1200] show tx related error after ui related ones in …

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/CoinInput/useSelectedCoins.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/CoinInput/useSelectedCoins.tsx
@@ -86,9 +86,6 @@ export const useSelectedCoins = ({
    */
   const getError = useCallback(
     (inputId: string, assetInput: AssetInfo): string | undefined => {
-      // If there is an error with the transaction, then display it over any other potential error
-      if (builtTxError) return builtTxError;
-
       // If the asset has an input value but there is no sufficient balance, then display an insufficient balance error.
       if (assetInput?.value && assetInput.value !== '0' && !!insufficientBalanceInputs?.includes(inputId)) {
         return COIN_SELECTION_ERRORS.BALANCE_INSUFFICIENT_ERROR;
@@ -101,6 +98,8 @@ export const useSelectedCoins = ({
       if (address && isValidAddress(address) && assetInputList.every((item) => !(item.value && Number(item.value)))) {
         return COIN_SELECTION_ERRORS.BUNDLE_AMOUNT_IS_EMPTY;
       }
+      // Display an error with the tx itself
+      if (builtTxError) return builtTxError;
       // eslint-disable-next-line consistent-return
       return undefined;
     },


### PR DESCRIPTION
…asset input

# Checklist

- [x] JIRA - [LW-12000](https://input-output.atlassian.net/browse/LW-12000)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Scenario 1: amount entered is higher than available and lower than total
Scenario 2: amount is higher that the total.

Once you build the tx it would not differentiate between two scenarios above and gives you the same general "Insufficient balance" error. Changing the order we handle these error fixes the issue.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12000]: https://input-output.atlassian.net/browse/LW-12000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ