### PR TITLE
feat(nami): pending tx poc

### DIFF
--- a/packages/nami/src/adapters/transactions.ts
+++ b/packages/nami/src/adapters/transactions.ts
@@ -78,9 +78,10 @@ const getTxType = ({
 };
 
 const dateFromUnix = (
-  slot: Wallet.Cardano.Slot,
   eraSummaries: OutsideHandlesContextValue['eraSummaries'],
+  slot?: Wallet.Cardano.Slot,
 ) => {
+  if (!slot) return new Date();
   const slotTimeCalc = Wallet.createSlotTimeCalc(eraSummaries);
   const date = slotTimeCalc(slot);
 
@@ -242,7 +243,7 @@ const getExtra = async ({
 }: GetExtraProps): Promise<Extra[]> => {
   const extra: Extra[] = [];
 
-  if (tx.witness.redeemers?.length) {
+  if (tx.witness?.redeemers?.length) {
     extra.push('contract');
   } else if (txType === 'multisig') {
     extra.push('multisig');
@@ -305,6 +306,7 @@ export type TxInfo = Pick<TransactionDetail, 'metadata'> &
     lovelace: bigint;
     assets: NamiAsset[];
     refund: string;
+    pending: boolean;
   };
 
 export interface EncodeToCborArgs {
@@ -369,31 +371,38 @@ export const getTxInfo = async ({
   protocolParameters: Wallet.Cardano.ProtocolParameters;
   assetInfo: Wallet.Assets;
   rewardAccounts: Wallet.Cardano.RewardAccountInfo[];
-}): Promise<TxInfo | undefined> => {
+}): Promise<TxInfo> => {
   const rewardAccountsAddresses = new Set(rewardAccounts?.map(a => a.address));
   const currentAddress = addresses[0];
 
-  if (!protocolParameters || !('blockHeader' in tx)) return undefined;
   const implicitCoin = Wallet.Cardano.util.computeImplicitCoin(
     protocolParameters,
     tx.body,
   );
   const uTxOList = {
-    inputs: tx.body.inputs,
+    inputs: tx.body.inputs as unknown as Wallet.Cardano.HydratedTxIn[],
     outputs: tx.body.outputs,
-    collaterals: tx.body.collaterals,
+    collaterals: tx.body
+      .collaterals as unknown as Wallet.Cardano.HydratedTxIn[],
   };
   const type = getTxType({
     currentAddress,
     addresses: addresses,
     uTxOList,
   });
-  const date = dateFromUnix(tx.blockHeader.slot, eraSummaries);
+  let date = new Date();
+  if ('blockHeader' in tx) {
+    date = dateFromUnix(eraSummaries, tx.blockHeader.slot);
+  } else if ('submittedAt' in tx) {
+    date = dateFromUnix(eraSummaries, tx.submittedAt);
+  }
   const txInputs = await getTxInputsValueAndAddress(tx.body.inputs);
   const amounts = calculateAmount({
     currentAddress,
     uTxOList: { ...uTxOList, inputs: txInputs },
-    validContract: tx.inputSource === Wallet.Cardano.InputSource.inputs,
+    validContract:
+      'inputSource' in tx &&
+      tx.inputSource === Wallet.Cardano.InputSource.inputs,
   });
   const assets = amounts.filter(amount => amount.unit !== 'lovelace');
   const lovelaceAsset = amounts.find(amount => amount.unit === 'lovelace');
@@ -408,21 +417,23 @@ export const getTxInfo = async ({
   });
 
   const info: TxInfo = {
+    pending: !('blockHeader' in tx),
     txHash: tx.id.toString(),
     fees: tx.body.fee.toString(),
     deposit: implicitCoin.deposit?.toString() ?? '',
     refund: implicitCoin.reclaimDeposit?.toString() ?? '',
-    metadata: [...(tx.auxiliaryData?.blob?.entries() ?? [])].map(
-      ([key, value]) => ({
-        label: key.toString(),
-        json_metadata: Wallet.cardanoMetadatumToObj(value),
-      }),
-    ),
+    metadata: [
+      ...(('auxiliaryData' in tx ? tx.auxiliaryData?.blob?.entries() : []) ??
+        []),
+    ].map(([key, value]) => ({
+      label: key.toString(),
+      json_metadata: Wallet.cardanoMetadatumToObj(value),
+    })),
     date,
     timestamp: getTimestamp(date),
     type,
     extra: await getExtra({
-      tx,
+      tx: tx as unknown as Wallet.Cardano.HydratedTx,
       txType: type,
       certificateInspectorFactory,
       rewardAccountsAddresses,
@@ -483,6 +494,8 @@ export const mapWalletActivities = memoize(
     return await Promise.all(
       [
         ...transactions.outgoing.inFlight,
+        // TODO: track signed tx
+        // ...transactions.outgoing.signed,
         ...transactions.history.sort(
           (tx1, tx2) => tx2.blockHeader.slot - tx1.blockHeader.slot,
         ),
@@ -517,7 +530,7 @@ export const useWalletTxs = () => {
     assetInfo,
     createHistoricalOwnInputResolver,
   } = useOutsideHandles();
-  const [txs, setTxs] = useState<(TxInfo | undefined)[]>();
+  const [txs, setTxs] = useState<TxInfo[]>();
   const rewardAccounts = useObservable(
     inMemoryWallet.delegation.rewardAccounts$,
   );

--- a/packages/nami/src/ui/app/components/historyViewer.tsx
+++ b/packages/nami/src/ui/app/components/historyViewer.tsx
@@ -24,9 +24,7 @@ const HistoryViewer = () => {
   const transactions = useWalletTxs();
 
   const { cardanoCoin } = useCommonOutsideHandles();
-  const [historySlice, setHistorySlice] = React.useState<
-    (TxInfo | undefined)[] | undefined
-  >();
+  const [historySlice, setHistorySlice] = React.useState<TxInfo[] | undefined>();
   const [page, setPage] = React.useState(1);
   const [isFinal, setIsFinal] = React.useState(false);
 


### PR DESCRIPTION
# Checklist

- [ ] JIRA - no ticket yet
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Considering that lace currently operates with activities and since no pending tx info (only skeleton) is currently displayed in the nami/nami mode, we should compile a list of requirements that should be mapped as DoDs in the potential ticket.

- [ ] review existing [pr](https://github.com/input-output-hk/nami/pull/966) in the nami repo, that brings mempool history support?
- [ ] transaction icon to display (lace shows same icon for all pending tx)
- [ ] define total amount displayed (+assets)
- [ ] defined extra info that could be displayed base on pending tx type
- [ ] handle signed (awaiting cosignatures) transactions
- [ ] anything more?

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

<img width="499" alt="Screenshot 2024-12-19 at 14 22 46" src="https://github.com/user-attachments/assets/4dcbfe0f-f693-491f-9111-56f89fabfc5e" />
