### PR TITLE
fix: [lw-12050] fix dapp popup related stylings on win platform

### DIFF
--- a/apps/browser-extension-wallet/src/dapp-connector.tsx
+++ b/apps/browser-extension-wallet/src/dapp-connector.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-nested-ternary */
 import * as React from 'react';
 import { render } from 'react-dom';
 import { DappConnectorView } from '@routes';
@@ -21,7 +22,7 @@ import { storage } from 'webextension-polyfill';
 import { TxWitnessRequestProvider } from '@providers/TxWitnessRequestProvider';
 
 const App = (): React.ReactElement => {
-  const [mode, setMode] = useState<'lace' | 'nami'>();
+  const [mode, setMode] = useState<'lace' | 'nami' | undefined>();
 
   storage.onChanged.addListener((changes) => {
     const oldModeValue = changes.BACKGROUND_STORAGE?.oldValue?.namiMigration;
@@ -58,7 +59,7 @@ const App = (): React.ReactElement => {
                           <AddressesDiscoveryOverlay>
                             <UIThemeProvider>
                               <TxWitnessRequestProvider>
-                                {mode === 'nami' ? <NamiDappConnector /> : <DappConnectorView />}
+                                {!mode ? <></> : mode === 'nami' ? <NamiDappConnector /> : <DappConnectorView />}
                               </TxWitnessRequestProvider>
                             </UIThemeProvider>
                           </AddressesDiscoveryOverlay>

--- a/apps/browser-extension-wallet/src/features/dapp/components/Connect.module.scss
+++ b/apps/browser-extension-wallet/src/features/dapp/components/Connect.module.scss
@@ -52,7 +52,7 @@
 }
 
 .footer {
-  background-color: var(--bg-color-white);
+  background-color: var(--light-mode-body, var(--dark-mode-bg-black));
   @extend %flex-column;
   justify-content: center;
   gap: size_unit(1);

--- a/apps/browser-extension-wallet/src/routes/DappConnectorView.tsx
+++ b/apps/browser-extension-wallet/src/routes/DappConnectorView.tsx
@@ -27,6 +27,7 @@ import { DappSignDataSuccess } from '@src/features/dapp/components/DappSignDataS
 import { DappSignDataFail } from '@src/features/dapp/components/DappSignDataFail';
 import { Crash } from '@components/Crash';
 import { useFatalError } from '@hooks/useFatalError';
+import { POPUP_WINDOW } from '@src/utils/constants';
 
 dayjs.extend(duration);
 
@@ -57,6 +58,15 @@ export const DappConnectorView = (): React.ReactElement => {
     };
     load();
   }, [isWalletLocked, cardanoWallet]);
+
+  useEffect(() => {
+    // Windows is somehow not opening the popup with the right size. Dynamically changing it, fixes it for now:
+    if (navigator.userAgent.includes('Win')) {
+      const width = POPUP_WINDOW.width + (window.outerWidth - window.innerWidth);
+      const height = POPUP_WINDOW.height + (window.outerHeight - window.innerHeight);
+      window.resizeTo(width, height);
+    }
+  }, []);
 
   const isLoading = useMemo(() => hdDiscoveryStatus !== 'Idle', [hdDiscoveryStatus]);
   const fatalError = useFatalError();


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12050](https://input-output.atlassian.net/browse/LW-12050)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Popup is not opened with the correct side on windows.
Set popup size automatically.

## Testing

- check extension popup (nami/lace on win/non win)
- check dapp popup (nami/lace on win/non win)
- check hw related popups (there is separate hw tab for nami mode)

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12050]: https://input-output.atlassian.net/browse/LW-12050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ