### PR TITLE
feat: add blockfrost input resolver and address discovery

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
@@ -43,6 +43,7 @@ export const getProviders = async (chainName: Wallet.ChainName): Promise<Wallet.
   const baseCardanoServicesUrl = getBaseUrlForChain(chainName);
   const magic = getMagicForChain(chainName);
   const { customSubmitTxUrl, featureFlags } = await getBackgroundStorage();
+
   const isExperimentEnabled = (experimentName: ExperimentName) => !!(featureFlags?.[magic]?.[experimentName] ?? false);
 
   return Wallet.createProviders({
@@ -65,7 +66,8 @@ export const getProviders = async (chainName: Wallet.ChainName): Promise<Wallet.
       useBlockfrostNetworkInfoProvider: isExperimentEnabled(ExperimentName.BLOCKFROST_NETWORK_INFO_PROVIDER),
       useBlockfrostRewardsProvider: isExperimentEnabled(ExperimentName.BLOCKFROST_REWARDS_PROVIDER),
       useBlockfrostTxSubmitProvider: isExperimentEnabled(ExperimentName.BLOCKFROST_TX_SUBMIT_PROVIDER),
-      useBlockfrostUtxoProvider: isExperimentEnabled(ExperimentName.BLOCKFROST_UTXO_PROVIDER)
+      useBlockfrostUtxoProvider: isExperimentEnabled(ExperimentName.BLOCKFROST_UTXO_PROVIDER),
+      useBlockfrostAddressDiscovery: isExperimentEnabled(ExperimentName.BLOCKFROST_ADDRESS_DISCOVERY)
     }
   });
 };

--- a/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
@@ -2,14 +2,7 @@
 import { runtime, storage as webStorage } from 'webextension-polyfill';
 import { of, combineLatest, map, EMPTY, BehaviorSubject, Observable, from, firstValueFrom, defaultIfEmpty } from 'rxjs';
 import { getProviders } from './config';
-import {
-  DEFAULT_LOOK_AHEAD_SEARCH,
-  DEFAULT_POLLING_CONFIG,
-  HDSequentialDiscovery,
-  createPersonalWallet,
-  storage,
-  createSharedWallet
-} from '@cardano-sdk/wallet';
+import { DEFAULT_POLLING_CONFIG, createPersonalWallet, storage, createSharedWallet } from '@cardano-sdk/wallet';
 import { handleHttpProvider } from '@cardano-sdk/cardano-services-client';
 import {
   AnyWallet,
@@ -177,6 +170,7 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
       ? // eslint-disable-next-line no-magic-numbers
         Number(process.env.WALLET_POLLING_INTERVAL_IN_SEC) * 1000
       : DEFAULT_POLLING_CONFIG.pollInterval;
+
     return createPersonalWallet(
       {
         name: walletAccount.metadata.name,
@@ -196,7 +190,6 @@ const walletFactory: WalletFactory<Wallet.WalletMetadata, Wallet.AccountMetadata
               logger
             })
           : noopHandleResolver,
-        addressDiscovery: new HDSequentialDiscovery(providers.chainHistoryProvider, DEFAULT_LOOK_AHEAD_SEARCH),
         witnesser,
         bip32Account
       }

--- a/apps/browser-extension-wallet/src/providers/ExperimentsProvider/config.ts
+++ b/apps/browser-extension-wallet/src/providers/ExperimentsProvider/config.ts
@@ -12,6 +12,7 @@ export const getDefaultFeatureFlags = (): FallbackConfiguration => ({
   [ExperimentName.BLOCKFROST_REWARDS_PROVIDER]: false,
   [ExperimentName.BLOCKFROST_TX_SUBMIT_PROVIDER]: false,
   [ExperimentName.BLOCKFROST_UTXO_PROVIDER]: false,
+  [ExperimentName.BLOCKFROST_ADDRESS_DISCOVERY]: false,
   [ExperimentName.EXTENSION_STORAGE]: false,
   [ExperimentName.USE_DREP_PROVIDER_OVERRIDE]: false,
   [ExperimentName.DAPP_EXPLORER]: false
@@ -59,6 +60,10 @@ export const experiments: ExperimentsConfig = {
     default: false
   },
   [ExperimentName.BLOCKFROST_UTXO_PROVIDER]: {
+    value: false,
+    default: false
+  },
+  [ExperimentName.BLOCKFROST_ADDRESS_DISCOVERY]: {
     value: false,
     default: false
   },

--- a/apps/browser-extension-wallet/src/providers/ExperimentsProvider/types.ts
+++ b/apps/browser-extension-wallet/src/providers/ExperimentsProvider/types.ts
@@ -17,6 +17,7 @@ export enum ExperimentName {
   BLOCKFROST_REWARDS_PROVIDER = 'blockfrost-rewards-provider',
   BLOCKFROST_TX_SUBMIT_PROVIDER = 'blockfrost-tx-submit-provider',
   BLOCKFROST_UTXO_PROVIDER = 'blockfrost-utxo-provider',
+  BLOCKFROST_ADDRESS_DISCOVERY = 'blockfrost-address-discovery',
   EXTENSION_STORAGE = 'extension-storage',
   USE_DREP_PROVIDER_OVERRIDE = 'use-drep-provider-override',
   DAPP_EXPLORER = 'dapp-explorer'

--- a/packages/cardano/src/wallet/index.ts
+++ b/packages/cardano/src/wallet/index.ts
@@ -85,6 +85,8 @@ export * from '@wallet/lib/get-auxiliary-data';
 export * as util from '@wallet/util';
 export * from '@wallet/lib/providers';
 export * from '@wallet/lib/config';
+export * from '@wallet/lib/blockfrost-input-resolver';
+export * from '@wallet/lib/blockfrost-address-discovery';
 
 export * as mockUtils from '@wallet/test/mocks';
 export * from '@wallet/types';

--- a/packages/cardano/src/wallet/lib/__tests__/blockfrost-address-discovery.test.ts
+++ b/packages/cardano/src/wallet/lib/__tests__/blockfrost-address-discovery.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable no-magic-numbers */
+import { BlockfrostAddressDiscovery } from '../blockfrost-address-discovery';
+import { Cardano } from '@cardano-sdk/core';
+import { BlockfrostClient, BlockfrostError } from '@cardano-sdk/cardano-services-client';
+import { Logger } from 'ts-log';
+import { AddressType, Bip32Account, KeyRole } from '@cardano-sdk/key-management';
+
+jest.mock('@cardano-sdk/cardano-services-client');
+
+describe('BlockfrostAddressDiscovery', () => {
+  let clientMock: jest.Mocked<BlockfrostClient>;
+  let loggerMock: jest.Mocked<Logger>;
+  let accountMock: jest.Mocked<Bip32Account>;
+  let addressDiscovery: BlockfrostAddressDiscovery;
+
+  beforeEach(() => {
+    clientMock = {
+      request: jest.fn()
+    } as unknown as jest.Mocked<BlockfrostClient>;
+
+    loggerMock = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    } as unknown as jest.Mocked<Logger>;
+
+    accountMock = {
+      deriveAddress: jest.fn()
+    } as unknown as jest.Mocked<Bip32Account>;
+
+    addressDiscovery = new BlockfrostAddressDiscovery(clientMock, loggerMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should discover addresses correctly', async () => {
+    const rewardAccount = 'stake1u9p...' as Cardano.RewardAccount;
+    const paymentAddress1 = 'addr1...' as Cardano.PaymentAddress;
+    const paymentAddress2 = 'addr2...' as Cardano.PaymentAddress;
+
+    accountMock.deriveAddress
+      .mockResolvedValueOnce({
+        address: paymentAddress1,
+        rewardAccount,
+        type: AddressType.External,
+        index: 0,
+        networkId: Cardano.NetworkId.Mainnet,
+        accountIndex: 0,
+        stakeKeyDerivationPath: {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      })
+      .mockResolvedValue({
+        address: paymentAddress2,
+        rewardAccount,
+        type: AddressType.External,
+        index: 1,
+        networkId: Cardano.NetworkId.Mainnet,
+        accountIndex: 0,
+        stakeKeyDerivationPath: {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      });
+
+    clientMock.request.mockResolvedValueOnce([
+      {
+        address: paymentAddress1,
+        rewardAccount,
+        type: AddressType.External,
+        index: 0,
+        networkId: Cardano.NetworkId.Mainnet,
+        accountIndex: 0,
+        stakeKeyDerivationPath: {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      },
+      {
+        address: paymentAddress2,
+        rewardAccount,
+        type: AddressType.External,
+        index: 1,
+        networkId: Cardano.NetworkId.Mainnet,
+        accountIndex: 0,
+        stakeKeyDerivationPath: {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      }
+    ]);
+
+    const result = await addressDiscovery.discover(accountMock);
+
+    expect(result).toHaveLength(2);
+    expect(clientMock.request).toHaveBeenCalledWith(`accounts/${rewardAccount}/addresses?count=100&page=1`);
+  });
+
+  it('should not throw if Blockfrost returns 404 not found', async () => {
+    const rewardAccount = 'stake1u9p...' as Cardano.RewardAccount;
+    const paymentAddress1 = 'addr1...' as Cardano.PaymentAddress;
+
+    accountMock.deriveAddress.mockResolvedValue({
+      address: paymentAddress1,
+      rewardAccount,
+      type: AddressType.External,
+      index: 0,
+      networkId: Cardano.NetworkId.Mainnet,
+      accountIndex: 0,
+      stakeKeyDerivationPath: {
+        index: 0,
+        role: KeyRole.Stake
+      }
+    });
+
+    const error = new BlockfrostError(404, 'Not Found');
+    error.status = 404;
+
+    clientMock.request.mockRejectedValueOnce(error);
+    const result = await addressDiscovery.discover(accountMock);
+    expect(result).toHaveLength(1); // There is always at least one address
+  });
+
+  it('should handle unknown/franken addresses gracefully', async () => {
+    const rewardAccount = 'stake1u9p...' as Cardano.RewardAccount;
+    const paymentAddress1 = 'addr1...' as Cardano.PaymentAddress;
+    const frankenAddress = 'addrUnknown...' as Cardano.PaymentAddress;
+
+    accountMock.deriveAddress.mockResolvedValue({
+      address: paymentAddress1,
+      rewardAccount,
+      type: AddressType.External,
+      index: 0,
+      networkId: Cardano.NetworkId.Mainnet,
+      accountIndex: 0,
+      stakeKeyDerivationPath: {
+        index: 0,
+        role: KeyRole.Stake
+      }
+    });
+
+    clientMock.request.mockResolvedValueOnce([{ address: paymentAddress1 }, { address: frankenAddress }]);
+
+    const result = await addressDiscovery.discover(accountMock);
+
+    expect(result).toHaveLength(1);
+    expect(loggerMock.warn).toHaveBeenCalledWith('The following addresses under stakeIndex 0 were not matched:', [
+      frankenAddress
+    ]);
+  });
+});

--- a/packages/cardano/src/wallet/lib/__tests__/blockfrost-input-resolver.test.ts
+++ b/packages/cardano/src/wallet/lib/__tests__/blockfrost-input-resolver.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable no-magic-numbers, camelcase */
+import { BlockfrostInputResolver } from '../blockfrost-input-resolver';
+import { Cardano } from '@cardano-sdk/core';
+import { BlockfrostClient, BlockfrostError, BlockfrostToCore } from '@cardano-sdk/cardano-services-client';
+import { Logger } from 'ts-log';
+
+jest.mock('@cardano-sdk/cardano-services-client');
+
+describe('BlockfrostInputResolver', () => {
+  let clientMock: jest.Mocked<BlockfrostClient>;
+  let loggerMock: jest.Mocked<Logger>;
+  let resolver: BlockfrostInputResolver;
+
+  beforeEach(() => {
+    clientMock = {
+      request: jest.fn()
+    } as unknown as jest.Mocked<BlockfrostClient>;
+
+    loggerMock = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn()
+    } as unknown as jest.Mocked<Logger>;
+
+    resolver = new BlockfrostInputResolver(clientMock, loggerMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should resolve input using hints if available', async () => {
+    const txIn: Cardano.TxIn = { txId: 'txId1' as Cardano.TransactionId, index: 0 };
+    const hint = {
+      id: 'txId1' as Cardano.TransactionId,
+      body: {
+        outputs: [{ address: 'addr1' as Cardano.PaymentAddress, value: { coins: BigInt(1000) } }]
+      }
+    } as Cardano.Tx;
+
+    const result = await resolver.resolveInput(txIn, { hints: [hint] });
+
+    expect(result).toEqual(hint.body.outputs[0]);
+  });
+
+  it('should fetch transaction output on first resolve and use cache on second resolve', async () => {
+    const txIn: Cardano.TxIn = { txId: 'txId2' as Cardano.TransactionId, index: 1 };
+    const responseMock = {
+      outputs: [{ output_index: 1, address: 'addr2', amount: [{ unit: 'lovelace', quantity: '2000' }] }]
+    };
+
+    clientMock.request.mockResolvedValue(responseMock);
+
+    jest.spyOn(BlockfrostToCore, 'txOut').mockReturnValue({
+      address: 'addr2' as Cardano.PaymentAddress,
+      value: { coins: BigInt(2000) }
+    } as Cardano.TxOut);
+
+    const result1 = await resolver.resolveInput(txIn);
+
+    expect(result1).toEqual({ address: 'addr2', value: { coins: BigInt(2000) } });
+    expect(clientMock.request).toHaveBeenCalledWith('txs/txId2/utxos');
+    expect(clientMock.request).toHaveBeenCalledTimes(1);
+
+    const result2 = await resolver.resolveInput(txIn);
+
+    expect(result2).toEqual(result1);
+    expect(clientMock.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return null if transaction output is not found', async () => {
+    const txIn: Cardano.TxIn = { txId: 'txId3' as Cardano.TransactionId, index: 2 };
+    const responseMock = { outputs: [] };
+    clientMock.request.mockResolvedValue(responseMock);
+
+    const result = await resolver.resolveInput(txIn);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for 404 errors from Blockfrost', async () => {
+    const txIn: Cardano.TxIn = { txId: 'txId4' as Cardano.TransactionId, index: 0 };
+
+    const error = new BlockfrostError(404, 'Not Found');
+    error.status = 404;
+
+    clientMock.request.mockRejectedValue(error);
+
+    const result = await resolver.resolveInput(txIn);
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw errors for non-404 Blockfrost errors', async () => {
+    const txIn: Cardano.TxIn = { txId: 'txId5' as Cardano.TransactionId, index: 0 };
+    const error = new BlockfrostError(500, 'Invalid Request');
+    error.status = 500;
+
+    clientMock.request.mockRejectedValue(error);
+
+    try {
+      await resolver.resolveInput(txIn);
+    } catch (error_) {
+      expect(error_).toBeInstanceOf(BlockfrostError);
+      expect(error_.status).toEqual(500);
+    }
+  });
+});

--- a/packages/cardano/src/wallet/lib/blockfrost-address-discovery.ts
+++ b/packages/cardano/src/wallet/lib/blockfrost-address-discovery.ts
@@ -1,0 +1,249 @@
+/* eslint-disable no-constant-condition */
+import { Cardano } from '@cardano-sdk/core';
+import { BlockfrostClient, BlockfrostError } from '@cardano-sdk/cardano-services-client';
+import { Logger } from 'ts-log';
+import { Responses } from '@blockfrost/blockfrost-js';
+import { AddressDiscovery } from '@cardano-sdk/wallet';
+import { AddressType, Bip32Account, GroupedAddress, KeyRole } from '@cardano-sdk/key-management';
+import uniqBy from 'lodash/uniqBy';
+
+/**
+ * How far we search for stake keys before concluding there are no more stake credentials.
+ */
+const STAKE_KEY_GAP = 5;
+
+/**
+ * How far we search for payment addresses under a single stake key
+ * before concluding that no more addresses exist (or that they are “franken”).
+ */
+const PAYMENT_CREDENTIAL_GAP = 100;
+
+/**
+ * Fetch size for Blockfrost addresses per page.
+ */
+const BLOCKFROST_PAGE_SIZE = 100;
+
+const NOT_FOUND_STATUS = 404;
+
+/**
+ * Fetch all addresses associated with a reward account from Blockfrost,
+ * handling pagination until the response has fewer than BLOCKFROST_PAGE_SIZE items.
+ */
+const fetchAllAddressesForAccount = async (
+  client: BlockfrostClient,
+  rewardAccount: Cardano.RewardAccount,
+  logger: Logger
+): Promise<Cardano.PaymentAddress[]> => {
+  const allAddresses: Cardano.PaymentAddress[] = [];
+  let page = 1;
+
+  logger.debug(`Fetching addresses for stake ${rewardAccount} (paginated)...`);
+
+  while (true) {
+    try {
+      const response = await client.request<Responses['account_addresses_content']>(
+        `accounts/${rewardAccount}/addresses?count=${BLOCKFROST_PAGE_SIZE}&page=${page}`
+      );
+
+      if (!response || response.length === 0) {
+        break;
+      }
+
+      for (const entry of response) {
+        allAddresses.push(entry.address as unknown as Cardano.PaymentAddress);
+      }
+
+      if (response.length < BLOCKFROST_PAGE_SIZE) {
+        break; // no more pages
+      }
+
+      ++page;
+    } catch (error: unknown) {
+      if (error instanceof BlockfrostError && error?.status === NOT_FOUND_STATUS) {
+        logger.debug(`No addresses found for stake ${rewardAccount}. 404 from Blockfrost.`);
+        break;
+      }
+      logger.error(`Error fetching addresses for stake ${rewardAccount}:`, error);
+      throw error;
+    }
+  }
+
+  logger.debug(`Fetched ${allAddresses.length} addresses for stake ${rewardAccount}`);
+  return allAddresses;
+};
+
+/**
+ * Derive the reward account (stake address) at a given stakeIndex.
+ */
+const deriveRewardAccount = async (account: Bip32Account, stakeIndex: number): Promise<Cardano.RewardAccount> => {
+  const address = await account.deriveAddress({ type: AddressType.External, index: 0 }, stakeIndex);
+
+  return address.rewardAccount;
+};
+
+/**
+ * Derive a payment address at a given (payment) index + address type (internal/external).
+ */
+const derivePaymentAddress = async (
+  account: Bip32Account,
+  paymentIndex: number,
+  stakeIndex: number,
+  isInternal: boolean
+): Promise<GroupedAddress> => {
+  const type = isInternal ? AddressType.Internal : AddressType.External;
+  return account.deriveAddress({ type, index: paymentIndex }, stakeIndex);
+};
+
+/**
+ * Discover addresses under a single stake key, up to the payment gap.
+ * - We keep deriving external & internal addresses for paymentIndex=0..∞,
+ *   stopping once we hit PAYMENT_CREDENTIAL_GAP misses in a row.
+ *
+ * @returns Array of discovered (matched) addresses + leftover “unknown/franken” addresses
+ */
+const discoverAddressesForStakeKey = async (
+  account: Bip32Account,
+  logger: Logger,
+  stakeIndex: number,
+  allAddressesForStake: Cardano.PaymentAddress[]
+): Promise<{ discovered: GroupedAddress[]; unknown: Cardano.PaymentAddress[] }> => {
+  const discovered: GroupedAddress[] = [];
+  const uniqueAddressesForStake = new Set(allAddressesForStake);
+
+  let gapCount = 0;
+  let paymentIndex = 0;
+
+  // Keep deriving payment addresses until we reach PAYMENT_CREDENTIAL_GAP consecutive misses
+  while (true) {
+    if (gapCount >= PAYMENT_CREDENTIAL_GAP) {
+      logger.debug(`Hit payment gap of ${PAYMENT_CREDENTIAL_GAP} for stakeIndex ${stakeIndex}. Stopping.`);
+      break;
+    }
+
+    const externalAddr = await derivePaymentAddress(account, paymentIndex, stakeIndex, false);
+    const externalInSet = uniqueAddressesForStake.has(externalAddr.address as Cardano.PaymentAddress);
+
+    const internalAddr = await derivePaymentAddress(account, paymentIndex, stakeIndex, true);
+    const internalInSet = uniqueAddressesForStake.has(internalAddr.address as Cardano.PaymentAddress);
+
+    if (externalInSet) {
+      discovered.push({
+        ...externalAddr,
+        stakeKeyDerivationPath: { index: stakeIndex, role: KeyRole.Stake }
+      });
+      uniqueAddressesForStake.delete(externalAddr.address as Cardano.PaymentAddress);
+    }
+
+    if (internalInSet) {
+      discovered.push({
+        ...internalAddr,
+        stakeKeyDerivationPath: { index: stakeIndex, role: KeyRole.Stake }
+      });
+      uniqueAddressesForStake.delete(internalAddr.address as Cardano.PaymentAddress);
+    }
+
+    if (!externalInSet && !internalInSet) {
+      gapCount++;
+    } else {
+      gapCount = 0;
+    }
+
+    ++paymentIndex;
+  }
+
+  const unknown = [...uniqueAddressesForStake];
+
+  return { discovered, unknown };
+};
+
+/**
+ * Main discovery logic:
+ *   1. Stake key gap: we keep deriving stake keys until we have
+ *      STAKE_KEY_GAP consecutive stake keys that yield zero discovered addresses.
+ *   2. Payment credential gap: for each stake key, we stop deriving
+ *      payment addresses once we have PAYMENT_CREDENTIAL_GAP consecutive misses.
+ */
+const discoverAddresses = async (
+  account: Bip32Account,
+  client: BlockfrostClient,
+  logger: Logger
+): Promise<GroupedAddress[]> => {
+  const discoveredAll: GroupedAddress[] = [];
+  let stakeIndex = 0;
+  let stakeGapCount = 0;
+
+  while (stakeGapCount < STAKE_KEY_GAP) {
+    logger.debug(`Deriving reward account for stake index ${stakeIndex}...`);
+    const rewardAccount = await deriveRewardAccount(account, stakeIndex);
+
+    logger.debug(`Fetching addresses for stake credential ${rewardAccount}...`);
+    const allAddressesForStake = await fetchAllAddressesForAccount(client, rewardAccount, logger);
+
+    if (allAddressesForStake.length === 0) {
+      stakeGapCount++;
+      stakeIndex++;
+      continue;
+    }
+
+    stakeGapCount = 0;
+
+    const { discovered, unknown } = await discoverAddressesForStakeKey(
+      account,
+      logger,
+      stakeIndex,
+      allAddressesForStake
+    );
+
+    discoveredAll.push(...discovered);
+
+    // Any leftover addresses are unknown / “franken”
+    if (unknown.length > 0) {
+      logger.warn(`The following addresses under stakeIndex ${stakeIndex} were not matched:`, unknown);
+    }
+
+    ++stakeIndex;
+  }
+
+  return discoveredAll;
+};
+
+/**
+ * Example BlockfrostAddressDiscovery class that:
+ *   - Paginates all addresses from each reward account
+ *   - Derives addresses sequentially and checks if they match
+ *   - Uses a gap-based approach for both stake keys AND payment addresses
+ *   - Logs leftover addresses as unknown
+ */
+export class BlockfrostAddressDiscovery implements AddressDiscovery {
+  readonly #logger: Logger;
+  readonly #client: BlockfrostClient;
+
+  constructor(client: BlockfrostClient, logger: Logger) {
+    this.#client = client;
+    this.#logger = logger;
+  }
+
+  public async discover(manager: Bip32Account): Promise<GroupedAddress[]> {
+    this.#logger.info('Discovering addresses using Blockfrost...');
+
+    const firstAddress = await manager.deriveAddress({ index: 0, type: AddressType.External }, 0);
+
+    const discoveredAddresses = await discoverAddresses(manager, this.#client, this.#logger);
+
+    const addresses = uniqBy([firstAddress, ...discoveredAddresses], 'address');
+
+    // We need to make sure the addresses are sorted since the wallet assumes that the first address
+    // in the list is the change address (payment cred 0 and stake cred 0).
+    addresses.sort((a, b) => {
+      const indexDiff = a.index - b.index;
+      if (indexDiff !== 0) return indexDiff;
+
+      if (a.stakeKeyDerivationPath && b.stakeKeyDerivationPath) {
+        return a.stakeKeyDerivationPath.index - b.stakeKeyDerivationPath.index;
+      }
+      return 0;
+    });
+
+    return addresses;
+  }
+}

--- a/packages/cardano/src/wallet/lib/blockfrost-input-resolver.ts
+++ b/packages/cardano/src/wallet/lib/blockfrost-input-resolver.ts
@@ -1,0 +1,106 @@
+/* eslint-disable unicorn/no-null, @typescript-eslint/no-non-null-assertion */
+import { Cardano } from '@cardano-sdk/core';
+import { BlockfrostClient, BlockfrostError, BlockfrostToCore } from '@cardano-sdk/cardano-services-client';
+import { Logger } from 'ts-log';
+import { Responses } from '@blockfrost/blockfrost-js';
+
+const NOT_FOUND_STATUS = 404;
+
+/**
+ * Converts a Cardano.TxIn object to a unique UTXO ID.
+ *
+ * @param txIn - The transaction input containing a transaction ID and index.
+ * @returns A string representing the unique UTXO ID in the format `txId#index`.
+ */
+const txInToId = (txIn: Cardano.TxIn): string => `${txIn.txId}#${txIn.index}`;
+
+/**
+ * A resolver class to fetch and resolve transaction inputs using Blockfrost API.
+ */
+export class BlockfrostInputResolver implements Cardano.InputResolver {
+  readonly #logger: Logger;
+  readonly #client: BlockfrostClient;
+  readonly #txCache = new Map<string, Cardano.TxOut>();
+
+  /**
+   * Constructs a new BlockfrostInputResolver.
+   *
+   * @param client - The Blockfrost client instance to interact with the Blockfrost API.
+   * @param logger - The logger instance to log messages to.
+   */
+  constructor(client: BlockfrostClient, logger: Logger) {
+    this.#client = client;
+    this.#logger = logger;
+  }
+
+  /**
+   * Resolves a transaction input (`Cardano.TxIn`) to its corresponding output (`Cardano.TxOut`).
+   *
+   * @param txIn - The transaction input to resolve, including its transaction ID and index.
+   * @param options - Optional resolution options (I.E hints for faster lookup).
+   * @returns A promise that resolves to the corresponding `Cardano.TxOut` if found, or `null` if not.
+   */
+  public async resolveInput(txIn: Cardano.TxIn, options?: Cardano.ResolveOptions): Promise<Cardano.TxOut | null> {
+    this.#logger.debug(`Resolving input ${txIn.txId}#${txIn.index}`);
+
+    if (options?.hints) {
+      for (const hint of options.hints) {
+        if (txIn.txId === hint.id && hint.body.outputs.length > txIn.index) {
+          this.#logger.debug(`Resolved input ${txIn.txId}#${txIn.index} from hint`);
+          return hint.body.outputs[txIn.index];
+        }
+      }
+    }
+
+    const out = await this.fetchAndCacheTxOut(txIn);
+    if (!out) return null;
+
+    return out;
+  }
+
+  /**
+   * Fetches and caches the transaction output (`Cardano.TxOut`) for a given transaction input (`Cardano.TxIn`).
+   *
+   * @private
+   * @param txIn - The transaction input to fetch and cache the output for.
+   * @returns A promise that resolves to the corresponding `Cardano.TxOut` if found, or `null` if not.
+   */
+  private async fetchAndCacheTxOut(txIn: Cardano.TxIn): Promise<Cardano.TxOut | null> {
+    const id = txInToId(txIn);
+
+    if (this.#txCache.has(id)) {
+      this.#logger.debug(`Resolved input ${txIn.txId}#${txIn.index} from cache`);
+      return this.#txCache.get(id)!;
+    }
+
+    let response;
+
+    try {
+      response = await this.#client.request<Responses['tx_content_utxo']>(`txs/${txIn.txId}/utxos`);
+    } catch (error: unknown) {
+      this.#logger.error(`Failed to fetch transaction ${txIn.txId}`, error);
+
+      if (error instanceof BlockfrostError && error?.status === NOT_FOUND_STATUS) {
+        return null;
+      }
+
+      throw error;
+    }
+
+    for (const blockfrostUTxO of response.outputs) {
+      if (blockfrostUTxO.output_index !== txIn.index) {
+        continue;
+      }
+
+      const coreTxOut = BlockfrostToCore.txOut(blockfrostUTxO);
+
+      this.#txCache.set(id, coreTxOut);
+
+      this.#logger.debug(`Resolved input ${txIn.txId}#${txIn.index} from Blockfrost`);
+      return coreTxOut;
+    }
+
+    this.#logger.error(`Failed to resolve input ${txIn.txId}#${txIn.index}`);
+    return null;
+  }
+}

--- a/packages/cardano/src/wallet/lib/cardano-wallet.ts
+++ b/packages/cardano/src/wallet/lib/cardano-wallet.ts
@@ -12,7 +12,13 @@ import {
   UtxoProvider,
   DRepProvider
 } from '@cardano-sdk/core';
-import { ObservableWallet, BaseWalletDependencies, storage, restoreKeyAgent } from '@cardano-sdk/wallet';
+import {
+  ObservableWallet,
+  BaseWalletDependencies,
+  storage,
+  restoreKeyAgent,
+  AddressDiscovery
+} from '@cardano-sdk/wallet';
 import * as KeyManagement from '@cardano-sdk/key-management';
 import { AnyWallet, Bip32WalletAccount, SigningCoordinatorConfirmationApi } from '@cardano-sdk/web-extension';
 import { ChainName } from '../types';
@@ -66,6 +72,7 @@ export interface WalletProvidersDependencies {
   chainHistoryProvider: ChainHistoryProvider;
   wsProvider?: WsProvider;
   drepProvider: DRepProvider;
+  addressDiscovery?: AddressDiscovery;
 }
 
 export interface CreatePersonalWallet {


### PR DESCRIPTION
# Checklist

- [x] JIRA - \<[link](https://input-output.atlassian.net/browse/LW-12074)>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

Lace currently consumes takes a long time to resolve wallet addresses.

## Proposed solution

This PR introduces a new BlockfrostAddressDiscovery which uses accounts to fetch all relevant addresses. This PR also introduces a new BlockfrostInputResolver


