### PR TITLE
fix(extension): footer rendering in PaperWalletSettingsDrawer [LW-12080]

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/PaperWalletSettingsDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/PaperWalletSettingsDrawer.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/no-null */
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useWalletManager } from '@hooks';
 import { Drawer, DrawerHeader, DrawerNavigation, PostHogAction } from '@lace/common';
 import { i18n } from '@lace/translation';
@@ -58,6 +58,9 @@ export const PaperWalletSettingsDrawer = ({ isOpen, onClose, popupView = false }
   const { walletInfo } = useWalletStore();
   const { CHAIN } = config();
   const [passphrase, setPassphrase] = useState<string[]>([]);
+  // Create a ref to access password without creating dependencies
+  const passwordRef = useRef(password);
+  passwordRef.current = password;
 
   const analytics = useAnalyticsContext();
 
@@ -125,7 +128,7 @@ export const PaperWalletSettingsDrawer = ({ isOpen, onClose, popupView = false }
     }
   }, [stage, isPasswordValid, setPgpInfo, pgpInfo, setPassword, formattedWalletName]);
 
-  const footer = () => {
+  const footer = useMemo(() => {
     switch (stage) {
       case 'secure': {
         return (
@@ -145,9 +148,9 @@ export const PaperWalletSettingsDrawer = ({ isOpen, onClose, popupView = false }
         return (
           <Button.CallToAction
             w="$fill"
-            disabled={!password.value}
+            disabled={!passwordRef.current.value}
             label={i18n.t('browserView.settings.generatePaperWallet.title')}
-            onClick={() => handleVerifyPass(password)}
+            onClick={() => handleVerifyPass(passwordRef.current)}
             data-testid="generate-paper-wallet-button"
           />
         );
@@ -191,7 +194,7 @@ export const PaperWalletSettingsDrawer = ({ isOpen, onClose, popupView = false }
       default:
         throw new Error(INCORRECT_STAGE_ERROR);
     }
-  };
+  }, [stage, pgpInfo, setStage, handleVerifyPass, pdfInstance, formattedWalletName, analytics]);
 
   const drawerHeader = useMemo(() => {
     switch (stage) {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/sign-message/SignMessageDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/sign-message/SignMessageDrawer.tsx
@@ -27,8 +27,7 @@ export const SignMessageDrawer: React.FC = () => {
   const [selectedAddress, setSelectedAddress] = useState('');
   const [message, setMessage] = useState('');
   const [shouldShowPasswordPrompt, setShouldShowPasswordPrompt] = useState(false);
-  // This is required as we can't memoize password, but we need to pass most recent value to handleSign.
-  // There might be a better way to do this, but it requires refactoring of the whole component + useDrawerConfiguration
+  // Create a ref to access password without creating dependencies
   const passwordRef = useRef(password);
   passwordRef.current = password;
 

--- a/packages/e2e-tests/src/assert/settings/EnterYourPasswordDrawerAssert.ts
+++ b/packages/e2e-tests/src/assert/settings/EnterYourPasswordDrawerAssert.ts
@@ -26,7 +26,7 @@ class EnterYourPasswordDrawerAssert {
       await t('browserView.settings.security.showPassphraseDrawer.warning')
     );
 
-    await EnterYourPasswordDrawer.generatePaperWalletButton.waitForEnabled();
+    await EnterYourPasswordDrawer.generatePaperWalletButton.waitForDisplayed();
     expect(await EnterYourPasswordDrawer.generatePaperWalletButton.getText()).to.equal(
       await t('browserView.settings.generatePaperWallet.title')
     );


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-12080)

---

## Proposed solution
Fix regression introduced in #1614 + unify the approach to handling password refs.

## Testing
1. Open Lace.
2. Open user menu.
3. Click on Settings.
4. Click on Generate paper wallet
5. Click on Next button 
6. Provide the password and click "Generate paper wallet"

## Screenshots
<img width="681" alt="image" src="https://github.com/user-attachments/assets/b93cf2ca-3c1d-4efd-9aa6-19b167c5ccad" />