### PR TITLE
fix: ensure wallet creation completes before creating alias

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/context.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/context.tsx
@@ -104,7 +104,7 @@ export const RestoreWalletProvider = ({ children }: Props): React.ReactElement =
   const finalizeWalletRestoration = useCallback(
     async (params: Partial<CreateWalletParams>) => {
       const { source, wallet } = await createWallet(params);
-      void sendPostWalletAddAnalytics({
+      await sendPostWalletAddAnalytics({
         extendedAccountPublicKey: source.account.extendedAccountPublicKey,
         postHogActionHdWallet: postHogActions.restore.HD_WALLET,
         postHogActionWalletAdded: postHogActions.restore.WALLET_ADDED,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/useHotWalletCreation.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/useHotWalletCreation.ts
@@ -40,8 +40,8 @@ export const useHotWalletCreation = ({ initialMnemonic }: UseSoftwareWalletCreat
     })();
   }, [createWalletData.name, walletManager.walletRepository, setCreateWalletData]);
 
-  const createWallet = (newData: Partial<CreateWalletParams>) =>
-    walletManager.createWallet({
+  const createWallet = async (newData: Partial<CreateWalletParams>) =>
+    await walletManager.createWallet({
       ...createWalletData,
       ...newData
     });

--- a/packages/e2e-tests/src/features/analytics/AnalyticsOnboardingEvents.feature
+++ b/packages/e2e-tests/src/features/analytics/AnalyticsOnboardingEvents.feature
@@ -28,9 +28,9 @@ Feature: Analytics - Posthog - Onboarding - Extended View
     And I validate latest analytics single event "onboarding | restore wallet revamp |  enter your recovery phrase  | next | click"
     When I enter wallet name: "ValidName", password: "N_8J@bne87A" and password confirmation: "N_8J@bne87A"
     And I click "Enter wallet" button
-    Then I validate latest analytics single event "onboarding | restore wallet revamp | let's set up your new wallet | enter wallet | click"
-#    And "$create_alias" PostHog event was sent  // TODO: uncomment when LW-12025 is fixed
-#    And I validate that alias event has assigned same user id "5b3ca1f1f7a14aad1e79f46213e2777d" in posthog
+    Then I validate latest analytics single event "onboarding | restore wallet revamp | added"
+    And "$create_alias" PostHog event was sent
+    And I validate that alias event has assigned same user id "9646a33207b90ae60ae83770aaa82597" in posthog
 
   @LW-7365
   Scenario: Analytics - Onboarding new wallet events


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-12025
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Alias uses the hash of the `extendedAccountPublicKey` as wallet ID to tag events and make them less anonymous. Currently we don't wait for wallet creation to complete before sending events which does not allow an alias to be created since the wallet ID is unavailable.

This PR waits for the wallet creation to complete and the wallet ID to be available before sending analytics and creating alias.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes
