### PR TITLE
fix: prevent displaying poor connection pill for 404 responses

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/onError.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/onError.ts
@@ -6,10 +6,15 @@ import { backendFailures$, requestMessage$ } from './services';
 const INTERNAL_SERVER_ERROR_STATUS_CODE = 500;
 const GATEWAY_TIMEOUT_STATUS_CODE = 503;
 const UNAUTHORIZED_STATUS_CODE = 401;
+const NOT_FOUND_STATUS_CODE = 404;
 
 const handleProviderServerErrors = (data: WebRequest.OnCompletedDetailsType) => {
   if (data?.type === 'xmlhttprequest' && runtime.getURL('').startsWith(data.initiator)) {
-    if (data.statusCode > UNAUTHORIZED_STATUS_CODE && data.statusCode < GATEWAY_TIMEOUT_STATUS_CODE) {
+    const statusCodeQualifiedAsFailure =
+      data.statusCode !== NOT_FOUND_STATUS_CODE &&
+      data.statusCode > UNAUTHORIZED_STATUS_CODE &&
+      data.statusCode < GATEWAY_TIMEOUT_STATUS_CODE;
+    if (statusCodeQualifiedAsFailure) {
       // A backend service request has failed, increment the failed requests count
       backendFailures$.next(backendFailures$.value + 1);
     } else {


### PR DESCRIPTION
# Checklist

- [x] JIRA - [\<link>](https://input-output.atlassian.net/browse/LW-12096)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Excluding 404 responses from the check for poor connection

## Testing

Run HD wallet sync and check if there is not poor connection pill
