### PR TITLE
feat: add caching for dapp radar api requests

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/dapp/explorer/services/cache.test.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/dapp/explorer/services/cache.test.ts
@@ -1,0 +1,108 @@
+import { CacheRepo, localStorageItemName, makeCacheRequest, oneDayOfCacheValidity } from './cache';
+
+const currentDate = new Date();
+jest.useFakeTimers().setSystemTime(currentDate);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const prepareCacheRequestFn = (params: { getLocalStorageItem?: (key: string) => any } = {}) => {
+  const getLocalStorageItem = params.getLocalStorageItem ?? jest.fn();
+  const setLocalStorageItem = jest.fn();
+
+  return {
+    cacheRequest: makeCacheRequest({ getLocalStorageItem, setLocalStorageItem }),
+    setLocalStorageItem
+  };
+};
+
+const cacheKey = 'cacheKey';
+
+describe('DApp Explorer data cache', () => {
+  it('returns cached response', async () => {
+    const expectedValue = 'cached value';
+    const { cacheRequest } = prepareCacheRequestFn({
+      getLocalStorageItem: jest
+        .fn()
+        .mockReturnValue(JSON.stringify({ [cacheKey]: { data: expectedValue, timestamp: currentDate.getTime() } }))
+    });
+
+    expect(await cacheRequest(cacheKey, () => void 0)).toEqual(expectedValue);
+  });
+
+  it('calls fetchData function if there is no particular data in cache', async () => {
+    const { cacheRequest } = prepareCacheRequestFn();
+    const fetchDataMock = jest.fn();
+    await cacheRequest(cacheKey, fetchDataMock);
+
+    expect(fetchDataMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls fetchData function if cached data expired', async () => {
+    const { cacheRequest } = prepareCacheRequestFn({
+      getLocalStorageItem: jest.fn().mockReturnValue(
+        JSON.stringify({
+          [cacheKey]: { data: 'data', timestamp: currentDate.getTime() - oneDayOfCacheValidity }
+        })
+      )
+    });
+    const fetchDataMock = jest.fn();
+    await cacheRequest(cacheKey, fetchDataMock);
+
+    expect(fetchDataMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns fetchData response', async () => {
+    const { cacheRequest } = prepareCacheRequestFn();
+    const expectedValue = 'expected value';
+    const fetchDataMock = jest.fn().mockReturnValue(expectedValue);
+
+    expect(await cacheRequest(cacheKey, fetchDataMock)).toEqual(expectedValue);
+  });
+
+  it('stores fetched data in cache', async () => {
+    const { cacheRequest, setLocalStorageItem } = prepareCacheRequestFn();
+    const response = 'response';
+    const fetchDataMock = jest.fn().mockReturnValue(response);
+    await cacheRequest(cacheKey, fetchDataMock);
+
+    const expectedValue = JSON.stringify({
+      [cacheKey]: {
+        data: response,
+        timestamp: currentDate.getTime()
+      }
+    });
+
+    expect(setLocalStorageItem).toHaveBeenCalledTimes(1);
+    expect(setLocalStorageItem).toHaveBeenCalledWith(localStorageItemName, expectedValue);
+  });
+
+  it('do not override cache added in the meantime', async () => {
+    const initailCacheRepo: CacheRepo = {
+      first: { data: 'data', timestamp: currentDate.getTime() }
+    };
+    const nextCacheRepo: CacheRepo = {
+      ...initailCacheRepo,
+      second: { data: 'data', timestamp: currentDate.getTime() }
+    };
+
+    const { cacheRequest, setLocalStorageItem } = prepareCacheRequestFn({
+      getLocalStorageItem: jest
+        .fn()
+        .mockReturnValueOnce(JSON.stringify(initailCacheRepo))
+        .mockReturnValueOnce(JSON.stringify(nextCacheRepo))
+    });
+    const response = 'response';
+    const fetchDataMock = jest.fn().mockReturnValue(response);
+    await cacheRequest(cacheKey, fetchDataMock);
+
+    const expectedValue = JSON.stringify({
+      ...nextCacheRepo,
+      [cacheKey]: {
+        data: response,
+        timestamp: currentDate.getTime()
+      }
+    });
+
+    expect(setLocalStorageItem).toHaveBeenCalledTimes(1);
+    expect(setLocalStorageItem).toHaveBeenCalledWith(localStorageItemName, expectedValue);
+  });
+});

--- a/apps/browser-extension-wallet/src/views/browser-view/features/dapp/explorer/services/cache.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/dapp/explorer/services/cache.ts
@@ -1,0 +1,56 @@
+type CacheEntry<Data> = {
+  data: Data;
+  timestamp: number;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CacheRepo = Record<string, CacheEntry<any>>;
+
+export const localStorageItemName = 'dapp-explorer-data-cache';
+// eslint-disable-next-line no-magic-numbers
+export const oneDayOfCacheValidity = 1000 * 60 * 60 * 24;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isCacheStillValid = (cacheEntry: CacheEntry<any> | undefined): cacheEntry is CacheEntry<any> =>
+  !!cacheEntry && new Date(cacheEntry.timestamp + oneDayOfCacheValidity) > new Date();
+
+type MakeCacheRequestParams = {
+  getLocalStorageItem: (key: string) => string;
+  setLocalStorageItem: (key: string, value: string) => void;
+};
+
+const parseRawCacheRepo = (rawCacheRepo: string) => {
+  let cacheRepo: CacheRepo = {};
+  try {
+    if (rawCacheRepo) {
+      cacheRepo = JSON.parse(rawCacheRepo);
+    }
+  } catch (error) {
+    console.error('Failed to parse dapp explorer data cache', error);
+  }
+  return cacheRepo;
+};
+
+export const makeCacheRequest =
+  ({ getLocalStorageItem, setLocalStorageItem }: MakeCacheRequestParams) =>
+  async <Response>(cacheKey: string, fetchData: () => Promise<Response>): Promise<Response> => {
+    let cacheRepo = parseRawCacheRepo(getLocalStorageItem(localStorageItemName));
+    const cacheEntry: CacheEntry<Response> | undefined = cacheRepo[cacheKey];
+    if (isCacheStillValid(cacheEntry)) return cacheEntry.data;
+
+    const response = await fetchData();
+    const newCacheEntry: CacheEntry<Response> = {
+      data: response,
+      timestamp: Date.now()
+    };
+
+    cacheRepo = parseRawCacheRepo(getLocalStorageItem(localStorageItemName));
+    cacheRepo[cacheKey] = newCacheEntry;
+    setLocalStorageItem(localStorageItemName, JSON.stringify(cacheRepo));
+
+    return response;
+  };
+
+export const cacheRequest = makeCacheRequest({
+  getLocalStorageItem: (key) => window.localStorage.getItem(key),
+  setLocalStorageItem: (key, value) => window.localStorage.setItem(key, value)
+});


### PR DESCRIPTION
# Checklist

- [x] JIRA - [\<link>](https://input-output.atlassian.net/browse/LW-12143)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

- storing DApp Radar API responses in a local storage entry
- each entry has a timestamp of insertion
- if the timestamp is older than one day the entry is considered expired
- if no cache entry then DApp Radar API request is performed

## Testing

- Ensure requests are performed only once
- Modify timestamp of particular cache entry (the one with `dapp-explorer-data-cache` name) to make it older than 1 day and ensure the request is made.

