### PR TITLE
fix: [lw-12156] fix remove wallet account functionality in nami mode

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -662,7 +662,10 @@ export const useWalletManager = (): UseWalletManager => {
    */
   const deleteWallet = useCallback(
     // eslint-disable-next-line max-statements
-    async (isForgotPasswordFlow = false): Promise<WalletManagerActivateProps | undefined> => {
+    async (
+      isForgotPasswordFlow = false,
+      nextWallet?: AnyWallet<Wallet.WalletMetadata, Wallet.AccountMetadata>
+    ): Promise<WalletManagerActivateProps | undefined> => {
       let walletToDelete: Pick<WalletManagerActivateProps, 'walletId'> = await firstValueFrom(
         walletManager.activeWalletId$
       );
@@ -685,7 +688,7 @@ export const useWalletManager = (): UseWalletManager => {
       }
       await walletRepository.removeWallet(walletToDelete.walletId);
 
-      const wallets = await firstValueFrom(walletRepository.wallets$);
+      const wallets = nextWallet ? [nextWallet] : await firstValueFrom(walletRepository.wallets$);
       if (wallets.length > 0) {
         const activateProps = {
           walletId: wallets[0].walletId,

--- a/packages/nami/src/ui/indexMain.tsx
+++ b/packages/nami/src/ui/indexMain.tsx
@@ -63,7 +63,7 @@ const App = () => {
     defaultSubmitApi,
     isValidURL,
     setAvatar,
-    removeWallet,
+    removeWallet: removeWalletUtil,
     setDeletingWallet,
   } = useOutsideHandles();
 
@@ -112,11 +112,12 @@ const App = () => {
     activateAccount,
     removeAccount,
     updateAccountMetadata,
+    removeWallet,
   } = useAccountUtil({
     chainId: currentChain,
     addAccount: addLaceAccount,
     removeAccount: async props => walletRepository.removeAccount(props),
-    removeWallet,
+    removeWallet: removeWalletUtil,
     activateAccount: async (props, force) =>
       walletManager.activate(props, force),
     wallets$: walletRepository.wallets$,
@@ -260,6 +261,7 @@ const App = () => {
             addAccount={addAccount}
             activateAccount={activateAccount}
             removeAccount={removeAccount}
+            removeWallet={removeWallet}
             assets={assets}
             nfts={nfts}
             setAvatar={setAvatar}


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12156](https://input-output.atlassian.net/browse/LW-12156)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

`deleteWallet` is called when there is no accounts left in active wallet. Current in nami `remove account` implementation would try to switch to the next available account/wallet before calling remove wallet, but `deleteWallet` util operates with currently active wallet, as result, wrong wallet is deleted.

As a solution we need to provide `deleteWallet` util from in `useWalletManager` hook with the next wallet to restore as param.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12156]: https://input-output.atlassian.net/browse/LW-12156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ