### PR TITLE
fix: [lw-12138] handle not available navigator.hid in send flow

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/hardware-wallet/context.tsx
@@ -80,9 +80,16 @@ export const HardwareWalletProvider = ({ children }: HardwareWalletProviderProps
     };
   }, [connectedUsbDevice, connection]);
 
-  const closeConnection = useCallback(() => {
+  const closeConnection = useCallback(async () => {
     if (connection.type === WalletType.Ledger) {
-      void connection.value.transport.close();
+      try {
+        await connection.value.transport.close();
+      } catch (error) {
+        // hw-transport-webusb also adds a disconnect event listener while creating a Ledger transport,
+        // so calling close() method will throw an error, since the device is already disconnected
+        if (error instanceof Error && error.message.includes('The device was disconnected.')) return;
+        throw error;
+      }
     }
   }, [connection]);
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -41,6 +41,7 @@ import { withSignTxConfirmation } from '@lib/wallet-api-ui';
 import type { TranslationKey } from '@lace/translation';
 import { Serialization } from '@cardano-sdk/core';
 import { exportMultisigTransaction, PasswordObj, useSecrets } from '@lace/core';
+import { WalletType } from '@cardano-sdk/web-extension';
 
 export const nextStepBtnLabels: Partial<Record<Sections, TranslationKey>> = {
   [Sections.FORM]: 'browserView.transaction.send.footer.review',
@@ -275,6 +276,8 @@ export const Footer = withAddressBookContext(
     );
 
     useEffect(() => {
+      const isHardwareWallet = [WalletType.Ledger, WalletType.Trezor].includes(walletType);
+      if (!isHardwareWallet || typeof navigator?.hid?.addEventListener !== 'function') return () => void 0;
       const onHardwareWalletDisconnect = (event: HIDConnectionEvent) => {
         if (event.device.opened) {
           setSection({ currentSection: Sections.FAIL_TX });
@@ -287,7 +290,7 @@ export const Footer = withAddressBookContext(
       return () => {
         navigator.hid.removeEventListener('disconnect', onHardwareWalletDisconnect);
       };
-    }, [setSection, setSubmitingTxState, isPopupView]);
+    }, [setSection, setSubmitingTxState, isPopupView, walletType]);
 
     const onConfirm = useCallback(
       (passphrase: Partial<PasswordObj>) => {


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12138](https://input-output.atlassian.net/browse/LW-12138)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Investigation summary.

#### Scenario 1.

Lace crashes.

**Scope:** Signing step is affected in the send flow. (extension is not usable, recovers after refreshing).

**Affects:** Chrome browser, Android and Linux (screen size from the recordings suggests it is some kind of mobile os) platform.

**Reason:** Lace is trying to listen for 'disconnect' event on navigator.hid property, that is undefined.

**Browser compatibility:** hid is compatible with Chrome, Edge (v89 and higher), Opera (v75 and higher). Also [it seems like](https://issues.chromium.org/issues/40628009) only desktop versions of such browsers are supported.

**Proposed solution:** we could check for navigator.hid availability (and do nothing in case it is not there).

**Implications:** in case we cannot listed for disconnect event, user might be stuck* on the signing step, still could reopen the drawer, but all the progress would be lost.

 

#### Scenario 2.

Lace does not crash (error is observed in the console) scenario.

**Proposed solution:** Simply awaiting [this call ](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/hardware-ledger/src/LedgerKeyAgent.ts#L385)seems* to be enough to suppress and error (was not able to test properly).

## Testing

**Scenario 1:** App should not crash (on specific platform/browser)
**Scenario 2:** There should be no error thrown.

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12138]: https://input-output.atlassian.net/browse/LW-12138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ