### PR TITLE
fix: [lw-12155] handle page refresh in dapp connector

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/ConfirmData.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/ConfirmData.tsx
@@ -21,9 +21,9 @@ import { useAnalyticsContext } from '@providers';
 import { TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
 import { signingCoordinator } from '@lib/wallet-api-ui';
 import { senderToDappInfo } from '@src/utils/senderToDappInfo';
+import { useOnUnload } from './confirm-transaction/hooks';
 
 const INDENT_SPACING = 2;
-const DAPP_TOAST_DURATION = 50;
 
 const fromHex = (hexBlob: HexBlob): string => Buffer.from(hexBlob, 'hex').toString();
 
@@ -58,10 +58,10 @@ export const DappConfirmData = (): React.ReactElement => {
 
   const cancelTransaction = useCallback(async () => {
     await req.reject('User rejected to sign');
-    setTimeout(() => window.close(), DAPP_TOAST_DURATION);
+    window.close();
   }, [req]);
 
-  window.addEventListener('beforeunload', cancelTransaction);
+  useOnUnload(cancelTransaction);
 
   useEffect(() => {
     const subscription = signingCoordinator.signDataRequest$.pipe(take(1)).subscribe(async (r) => {

--- a/apps/browser-extension-wallet/src/features/dapp/components/SignData.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/SignData.tsx
@@ -12,6 +12,7 @@ import { useViewsFlowContext } from '@providers/ViewFlowProvider';
 import styles from './SignTransaction.module.scss';
 import { WalletType } from '@cardano-sdk/web-extension';
 import { createPassphrase } from '@lib/wallet-api-ui';
+import { useOnUnload } from './confirm-transaction/hooks';
 
 export const SignData = (): React.ReactElement => {
   const { t } = useTranslation();
@@ -63,6 +64,13 @@ export const SignData = (): React.ReactElement => {
     },
     [onConfirm, confirmIsDisabled]
   );
+
+  const cancelTransaction = useCallback(async () => {
+    await request.reject('User rejected to sign');
+    window.close();
+  }, [request]);
+
+  useOnUnload(cancelTransaction);
 
   return (
     <Layout title={undefined}>

--- a/apps/browser-extension-wallet/src/features/dapp/components/SignTransaction.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/SignTransaction.tsx
@@ -79,7 +79,11 @@ export const SignTransaction = (): React.ReactElement => {
     [onConfirm, confirmIsDisabled]
   );
 
-  useOnUnload(() => disallowSignTx(true));
+  const cancelTransaction = useCallback(() => {
+    disallowSignTx(true);
+  }, [disallowSignTx]);
+
+  useOnUnload(cancelTransaction);
 
   return (
     <Layout title={undefined}>

--- a/apps/browser-extension-wallet/src/features/dapp/components/SignTransaction.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/SignTransaction.tsx
@@ -13,11 +13,13 @@ import { useAnalyticsContext } from '@providers';
 import { TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
 import { WalletType } from '@cardano-sdk/web-extension';
 import { createPassphrase } from '@lib/wallet-api-ui';
+import { useDisallowSignTx, useOnUnload } from './confirm-transaction/hooks';
 
 export const SignTransaction = (): React.ReactElement => {
   const { t } = useTranslation();
   const {
-    utils: { setPreviousView }
+    utils: { setPreviousView },
+    signTxRequest: { request }
   } = useViewsFlowContext();
   const redirectToSignFailure = useRedirection(dAppRoutePaths.dappTxSignFailure);
   const redirectToSignSuccess = useRedirection(dAppRoutePaths.dappTxSignSuccess);
@@ -25,10 +27,7 @@ export const SignTransaction = (): React.ReactElement => {
   const { password, setPassword, clearSecrets } = useSecrets();
   const [validPassword, setValidPassword] = useState<boolean>();
   const analytics = useAnalyticsContext();
-
-  const {
-    signTxRequest: { request }
-  } = useViewsFlowContext();
+  const disallowSignTx = useDisallowSignTx(request);
 
   const onConfirm = useCallback(
     async (spendingPassphrase) => {
@@ -79,6 +78,8 @@ export const SignTransaction = (): React.ReactElement => {
     },
     [onConfirm, confirmIsDisabled]
   );
+
+  useOnUnload(() => disallowSignTx(true));
 
   return (
     <Layout title={undefined}>

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/ConfirmTransaction.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/ConfirmTransaction.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import cn from 'classnames';
 import { Button, PostHogAction } from '@lace/common';
 import { useTranslation } from 'react-i18next';
@@ -82,7 +82,11 @@ export const ConfirmTransaction = (): React.ReactElement => {
     disallowSignTx(true);
   };
 
-  useOnUnload(() => disallowSignTx(true));
+  const cancelTransaction = useCallback(() => {
+    disallowSignTx(true);
+  }, [disallowSignTx]);
+
+  useOnUnload(cancelTransaction);
 
   return (
     <Layout layoutClassname={cn(confirmTransactionError && styles.layoutError)} pageClassname={styles.spaceBetween}>

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/ConfirmTransaction.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/ConfirmTransaction.tsx
@@ -6,7 +6,7 @@ import { Layout } from '../Layout';
 import { useViewsFlowContext } from '@providers/ViewFlowProvider';
 import styles from './ConfirmTransaction.module.scss';
 import { useWalletStore } from '@stores';
-import { useDisallowSignTx, useSignWithHardwareWallet, useOnBeforeUnload } from './hooks';
+import { useDisallowSignTx, useSignWithHardwareWallet, useOnUnload } from './hooks';
 import { TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
 import { txSubmitted$ } from '@providers/AnalyticsProvider/onChain';
 import { useAnalyticsContext } from '@providers';
@@ -82,7 +82,7 @@ export const ConfirmTransaction = (): React.ReactElement => {
     disallowSignTx(true);
   };
 
-  useOnBeforeUnload(disallowSignTx);
+  useOnUnload(() => disallowSignTx(true));
 
   return (
     <Layout layoutClassname={cn(confirmTransactionError && styles.layoutError)} pageClassname={styles.spaceBetween}>

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/ConfirmTransaction.test.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/ConfirmTransaction.test.tsx
@@ -10,7 +10,7 @@ const mockConfirmTransactionContent = jest.fn(() => <span data-testid="ConfirmTr
 const mockUseDisallowSignTx = jest.fn();
 const mockUseViewsFlowContext = jest.fn();
 const mockUseSignWithHardwareWallet = jest.fn();
-const mockUseOnBeforeUnload = jest.fn();
+const mockUseOnUnload = jest.fn();
 const mockUseComputeTxCollateral = jest.fn().mockReturnValue(BigInt(1_000_000));
 const mockUseTxWitnessRequest = jest.fn().mockReturnValue({});
 const mockCreateTxInspector = jest.fn().mockReturnValue(() => ({ minted: [] as any, burned: [] as any }));
@@ -95,7 +95,7 @@ jest.mock('../hooks.ts', () => {
     ...original,
     useDisallowSignTx: mockUseDisallowSignTx,
     useSignWithHardwareWallet: mockUseSignWithHardwareWallet,
-    useOnBeforeUnload: mockUseOnBeforeUnload
+    useOnUnload: mockUseOnUnload
   };
 });
 
@@ -215,7 +215,7 @@ describe('Testing ConfirmTransaction component', () => {
       }));
     });
 
-    expect(mockUseOnBeforeUnload).toHaveBeenCalledWith(disallowSignTx);
+    expect(mockUseOnUnload).toHaveBeenCalledWith(disallowSignTx);
     expect(queryByTestId(testIds.dappTransactionConfirm)).toHaveTextContent('Confirm');
     expect(queryByTestId(testIds.dappTransactionConfirm)).not.toBeDisabled();
     expect(queryByTestId(testIds.dappTransactionCancel)).toHaveTextContent('Cancel');

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/ConfirmTransaction.test.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/ConfirmTransaction.test.tsx
@@ -250,7 +250,7 @@ describe('Testing ConfirmTransaction component', () => {
     expect(setNextViewMock).toHaveBeenCalled();
   });
 
-  test('Should reject transaction if unmonted', async () => {
+  test('Should reject transaction if unmounted', async () => {
     patchAddEventListener();
     mockGetKeyAgentType.mockReset();
     mockUseOnUnload.mockReset();

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/hooks.test.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/hooks.test.tsx
@@ -288,13 +288,13 @@ describe('Testing hooks', () => {
     const hook = renderHook(() => useOnUnload(cb));
 
     await hook.waitFor(() => {
-      window.dispatchEvent(new Event('beforeunload'));
+      window.dispatchEvent(new Event('unload'));
       expect(cb).toHaveBeenCalledTimes(1);
     });
 
     hook.unmount();
 
-    window.dispatchEvent(new Event('beforeunload'));
+    window.dispatchEvent(new Event('unload'));
     expect(cb).toHaveBeenCalledTimes(1);
 
     removeEventListeners();

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/hooks.test.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/__tests__/hooks.test.tsx
@@ -14,7 +14,7 @@ const mockCalculateAssetBalance = jest.fn();
 const mockLovelacesToAdaString = jest.fn();
 const mockUseWalletStore = jest.fn();
 import { act, cleanup } from '@testing-library/react';
-import { useCreateAssetList, useGetOwnPubDRepKeyHash, useOnBeforeUnload, useSignWithHardwareWallet } from '../hooks';
+import { useCreateAssetList, useGetOwnPubDRepKeyHash, useOnUnload, useSignWithHardwareWallet } from '../hooks';
 import { renderHook } from '@testing-library/react-hooks';
 import { Wallet } from '@lace/cardano';
 import * as hooks from '@hooks';
@@ -282,10 +282,10 @@ describe('Testing hooks', () => {
     });
   });
 
-  test('useOnBeforeUnload', async () => {
+  test('useOnUnload', async () => {
     patchAddEventListener();
     const cb = jest.fn();
-    const hook = renderHook(() => useOnBeforeUnload(cb));
+    const hook = renderHook(() => useOnUnload(cb));
 
     await hook.waitFor(() => {
       window.dispatchEvent(new Event('beforeunload'));

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/hooks.ts
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/hooks.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import isPlainObject from 'lodash/isPlainObject';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AssetProvider, AssetsMintedInspection, MintedAsset } from '@cardano-sdk/core';

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/hooks.ts
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/hooks.ts
@@ -151,7 +151,7 @@ export const useCreateMintedAssetList = ({
 
 export const useDisallowSignTx = (
   req: TransactionWitnessRequest<Wallet.WalletMetadata, Wallet.AccountMetadata>
-): ((close?: boolean) => void) => useCallback((close) => disallowSignTx(req, close), [req]);
+): ((close?: boolean) => Promise<void>) => useCallback(async (close) => await disallowSignTx(req, close), [req]);
 
 export const useAllowSignTx = (
   req: TransactionWitnessRequest<Wallet.WalletMetadata, Wallet.AccountMetadata>
@@ -184,11 +184,11 @@ export const useSignWithHardwareWallet = (
   return { isConfirmingTx, signWithHardwareWallet };
 };
 
-export const useOnBeforeUnload = (callBack: () => void): void => {
+export const useOnUnload = (callBack: () => void): void => {
   useEffect(() => {
-    window.addEventListener('beforeunload', callBack);
+    window.addEventListener('unload', callBack);
     return () => {
-      window.removeEventListener('beforeunload', callBack);
+      window.removeEventListener('unload', callBack);
     };
   }, [callBack]);
 };

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/utils.ts
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/utils.ts
@@ -9,8 +9,6 @@ import { of } from 'rxjs';
 
 const { CertificateType } = Wallet.Cardano;
 
-const DAPP_TOAST_DURATION = 50;
-
 export const readyToSign = (): void => {
   exposeApi<Pick<UserPromptService, 'readyToSignTx'>>(
     {
@@ -30,8 +28,11 @@ export const disallowSignTx = async (
   req: TransactionWitnessRequest<Wallet.WalletMetadata, Wallet.AccountMetadata>,
   close = false
 ): Promise<void> => {
-  await req.reject('User declined to sign');
-  close && setTimeout(() => window.close(), DAPP_TOAST_DURATION);
+  try {
+    await req?.reject('User declined to sign');
+  } finally {
+    close && window.close();
+  }
 };
 
 export const allowSignTx = async (

--- a/apps/browser-extension-wallet/src/lib/scripts/types/feature-flags.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/feature-flags.ts
@@ -101,6 +101,7 @@ type FeatureFlagCustomPayloads = {
 
 export type FeatureFlagPayloads = {
   [key in FeatureFlag]: FeatureFlagPayload;
-} & FeatureFlagCustomPayloads;
+} &
+  FeatureFlagCustomPayloads;
 
 export type RawFeatureFlagPayloads = Record<ExperimentName, JsonType>;

--- a/apps/browser-extension-wallet/src/views/nami-mode/NamiDappConnectorView.tsx
+++ b/apps/browser-extension-wallet/src/views/nami-mode/NamiDappConnectorView.tsx
@@ -25,6 +25,7 @@ import { useSecrets } from '@lace/core';
 import { getBackgroundStorage, setBackgroundStorage } from '@lib/scripts/background/storage';
 import { useTxWitnessRequest } from '@providers/TxWitnessRequestProvider';
 import type { TransactionWitnessRequest } from '@cardano-sdk/web-extension';
+import { useOnUnload } from '@src/features/dapp/components/confirm-transaction/hooks';
 
 const DAPP_TOAST_DURATION = 100;
 const dappConnector: Omit<DappConnector, 'getAssetInfos' | 'txWitnessRequest'> = {
@@ -213,7 +214,8 @@ export const NamiDappConnectorView = withDappContext((): React.ReactElement => {
         environmentName,
         dappConnector: { ...dappConnector, txWitnessRequest, getAssetInfos },
         switchWalletMode,
-        secretsUtil
+        secretsUtil,
+        useOnUnload
       }}
     >
       <CommonOutsideHandlesProvider

--- a/packages/nami/src/features/dapp-outside-handles-provider/types.ts
+++ b/packages/nami/src/features/dapp-outside-handles-provider/types.ts
@@ -69,4 +69,5 @@ export interface DappOutsideHandlesContextValue {
   dappConnector: DappConnector;
   switchWalletMode: () => Promise<void>;
   secretsUtil: ReturnType<typeof useSecrets>;
+  useOnUnload: (callback: () => void) => void;
 }

--- a/packages/nami/src/ui/app/pages/dapp-connector/signData.tsx
+++ b/packages/nami/src/ui/app/pages/dapp-connector/signData.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable functional/prefer-immutable-types */
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import {
   Box,
@@ -32,7 +32,7 @@ interface Props {
 
 export const SignData = ({ dappConnector, account }: Readonly<Props>) => {
   const capture = useCaptureEvent();
-  const { secretsUtil } = useDappOutsideHandles();
+  const { secretsUtil, useOnUnload } = useDappOutsideHandles();
   const ref = React.useRef();
   const [payload, setPayload] = React.useState('');
   const [address, setAddress] = React.useState('');
@@ -99,6 +99,14 @@ export const SignData = ({ dappConnector, account }: Readonly<Props>) => {
   React.useEffect(() => {
     loadData();
   }, []);
+
+  const cancelTransaction = useCallback(async () => {
+    await request?.reject(() => void 0);
+    window.close();
+  }, [request]);
+
+  useOnUnload(cancelTransaction);
+
   return (
     <>
       {isLoading ? (

--- a/packages/nami/src/ui/app/pages/dapp-connector/signTx.tsx
+++ b/packages/nami/src/ui/app/pages/dapp-connector/signTx.tsx
@@ -2,8 +2,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable max-params */
 /* eslint-disable unicorn/no-null */
-import { RefObject, useCallback } from 'react';
-import React from 'react';
+import type { RefObject } from 'react';
+import React, { useCallback } from 'react';
 
 import { metadatum, Serialization } from '@cardano-sdk/core';
 import { toSerializableObject } from '@cardano-sdk/util';

--- a/packages/nami/src/ui/app/pages/dapp-connector/signTx.tsx
+++ b/packages/nami/src/ui/app/pages/dapp-connector/signTx.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable max-params */
 /* eslint-disable unicorn/no-null */
-import type { RefObject } from 'react';
+import { RefObject, useCallback } from 'react';
 import React from 'react';
 
 import { metadatum, Serialization } from '@cardano-sdk/core';
@@ -86,7 +86,7 @@ export const SignTx = ({
     dappConnector: { txWitnessRequest },
   } = useDappOutsideHandles();
 
-  const { secretsUtil } = useDappOutsideHandles();
+  const { secretsUtil, useOnUnload } = useDappOutsideHandles();
   const ref = React.useRef();
   const [fee, setFee] = React.useState('0');
   const [value, setValue] = React.useState<TransactionValue | null>(null);
@@ -275,6 +275,13 @@ export const SignTx = ({
   React.useEffect(() => {
     getInfo();
   }, [txWitnessRequest]);
+
+  const cancelTransaction = useCallback(async () => {
+    await request?.reject(() => void 0);
+    window.close();
+  }, [request]);
+
+  useOnUnload(cancelTransaction);
 
   return (
     <>


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12115](https://input-output.atlassian.net/browse/LW-12115)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

### `beforeunload` event ❌:
- cannot `await` inside the callback
- `window.close()` doesn't work  inside the callback
- default confirmation modal is displayed if `true` is returned in the callback, with no ability to provide custom messaging (deprecated in chrome starting from version 51 …)

### `unload` event ✅:
- cannot `await` inside the callback
- `window.close()` works inside the callback

## Testing

#### Scope
- Sign/ Confirm transaction (lace + nami mode)
- Sign/ Confirm data  (lace + nami mode)

> [!IMPORTANT]  
> Since we cannot `await` in the callback, please make sure the `tx` was properly rejected before dapp window is closed.*




## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12115]: https://input-output.atlassian.net/browse/LW-12115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ