### PR TITLE
feat: [lw-12102] log runtime extension events and version mismatch

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
@@ -26,6 +26,7 @@ export const backgroundServiceProperties: RemoteApiProperties<BackgroundService>
   getBackgroundStorage: RemoteApiPropertyType.MethodReturningPromise,
   setBackgroundStorage: RemoteApiPropertyType.MethodReturningPromise,
   resetStorage: RemoteApiPropertyType.MethodReturningPromise,
+  getAppVersion: RemoteApiPropertyType.MethodReturningPromise,
   backendFailures$: RemoteApiPropertyType.HotObservable,
   unhandledError$: RemoteApiPropertyType.HotObservable
 };

--- a/apps/browser-extension-wallet/src/lib/scripts/background/onUpdate.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/onUpdate.ts
@@ -8,6 +8,7 @@ type UpdateType = 'downgrade' | 'update';
 
 // migrations
 const checkMigrationsOnUpdate = async (details: Runtime.OnInstalledDetailsType) => {
+  logger.info('[onUpdate] checking migration state:', details.reason, details.previousVersion);
   if (details.reason === 'update' || details.reason === 'install') {
     // Initialize migration state with not-loaded
     await initMigrationState();
@@ -22,11 +23,13 @@ const compareVersions = (v1 = '', v2 = '') => v1.localeCompare(v2, undefined, { 
 
 // extension updates announcements
 const displayReleaseAnnouncements = async ({ reason }: Runtime.OnInstalledDetailsType) => {
+  logger.info('[onUpdate] checking for updates:', reason);
   const { version: currentVersion } = runtime.getManifest();
 
   const { aboutExtension } = (await storage.local.get(ABOUT_EXTENSION_KEY)) || {};
   const previousVersion = aboutExtension?.version;
 
+  logger.info('[onUpdate] checking for updates:', previousVersion, currentVersion);
   if (reason === 'update' && currentVersion !== previousVersion) {
     const updateType: UpdateType = compareVersions(currentVersion, previousVersion) < 0 ? 'downgrade' : 'update';
 
@@ -34,7 +37,7 @@ const displayReleaseAnnouncements = async ({ reason }: Runtime.OnInstalledDetail
       [ABOUT_EXTENSION_KEY]: { version: currentVersion, acknowledged: false, reason: updateType } as ExtensionUpdateData
     });
 
-    logger.info('extension got updated due to reason:', updateType);
+    logger.info('[onUpdate] extension got updated due to reason:', updateType);
   }
 };
 
@@ -44,7 +47,7 @@ if (!runtime.onInstalled.hasListener(displayReleaseAnnouncements))
 if (!runtime.onInstalled.hasListener(checkMigrationsOnUpdate)) runtime.onInstalled.addListener(checkMigrationsOnUpdate);
 
 const updateToVersionCallback = (details: Runtime.OnUpdateAvailableDetailsType) => {
-  logger.info(`updating to version ${details.version}`);
+  logger.info(`[onUpdate] updating to version ${details.version}`);
   if (runtime.onUpdateAvailable.hasListener(updateToVersionCallback)) {
     runtime.onUpdateAvailable.removeListener(updateToVersionCallback);
   }

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/utilityServices.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/utilityServices.ts
@@ -231,7 +231,7 @@ const unhandledError$ = merge(
   )
 );
 
-const getAppVersion = async () => await runtime.getManifest().version;
+const getAppVersion = async () => await process.env.APP_VERSION;
 
 exposeApi<BackgroundService>(
   {

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/utilityServices.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/utilityServices.ts
@@ -231,6 +231,8 @@ const unhandledError$ = merge(
   )
 );
 
+const getAppVersion = async () => await runtime.getManifest().version;
+
 exposeApi<BackgroundService>(
   {
     api$: of({
@@ -249,6 +251,7 @@ exposeApi<BackgroundService>(
         await clearBackgroundStorage();
         await webStorage.local.set({ MIGRATION_STATE: { state: 'up-to-date' } as MigrationState });
       },
+      getAppVersion,
       backendFailures$,
       unhandledError$
     }),

--- a/apps/browser-extension-wallet/src/lib/scripts/types/background-service.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/background-service.ts
@@ -108,6 +108,7 @@ export type BackgroundService = {
   getBackgroundStorage: () => Promise<BackgroundStorage>;
   clearBackgroundStorage: typeof clearBackgroundStorage;
   resetStorage: () => Promise<void>;
+  getAppVersion: () => Promise<string>;
   backendFailures$: BehaviorSubject<number>;
   unhandledError$: Observable<UnhandledError>;
 };

--- a/apps/browser-extension-wallet/src/popup.tsx
+++ b/apps/browser-extension-wallet/src/popup.tsx
@@ -65,7 +65,7 @@ const App = (): React.ReactElement => {
                             <AddressesDiscoveryOverlay>
                               <NamiMigrationGuard>
                                 <BackgroundPageProvider>
-                                  {mode === 'nami' ? <NamiPopup /> : <PopupView />}
+                                  <AppVersionGuard>{mode === 'nami' ? <NamiPopup /> : <PopupView />}</AppVersionGuard>
                                 </BackgroundPageProvider>
                               </NamiMigrationGuard>
                             </AddressesDiscoveryOverlay>

--- a/apps/browser-extension-wallet/src/popup.tsx
+++ b/apps/browser-extension-wallet/src/popup.tsx
@@ -27,6 +27,7 @@ import { runtime, storage } from 'webextension-polyfill';
 import { NamiMigrationGuard } from './features/nami-migration/NamiMigrationGuard';
 import { createNonBackgroundMessenger } from '@cardano-sdk/web-extension';
 import { logger } from '@lace/common';
+import { AppVersionGuard } from './utils/AppVersionGuard';
 
 const App = (): React.ReactElement => {
   const [mode, setMode] = useState<'lace' | 'nami'>();

--- a/apps/browser-extension-wallet/src/utils/AppVersionGuard/AppVersionGuard.tsx
+++ b/apps/browser-extension-wallet/src/utils/AppVersionGuard/AppVersionGuard.tsx
@@ -1,0 +1,21 @@
+import { useBackgroundServiceAPIContext } from '@providers';
+import React, { useEffect } from 'react';
+
+export const AppVersionGuard = ({ children }: { children: React.ReactNode }): React.ReactElement => {
+  const backgroundServices = useBackgroundServiceAPIContext();
+
+  useEffect(() => {
+    const getAppVersion = async () => {
+      const appVersionSW = await backgroundServices.getAppVersion();
+      const appVersionUI = `${process.env.APP_VERSION}`;
+
+      if (appVersionSW !== appVersionUI) {
+        throw new Error(`App version mismatch: SW: ${appVersionSW}, UI: ${appVersionUI}`);
+      }
+    };
+
+    getAppVersion();
+  }, [backgroundServices]);
+
+  return <>{children}</>;
+};

--- a/apps/browser-extension-wallet/src/utils/AppVersionGuard/index.ts
+++ b/apps/browser-extension-wallet/src/utils/AppVersionGuard/index.ts
@@ -1,0 +1,1 @@
+export * from './AppVersionGuard';

--- a/apps/browser-extension-wallet/src/views/browser-view/index.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/index.tsx
@@ -28,6 +28,7 @@ import '../../lib/scripts/keep-alive-ui';
 import { PostHogClientProvider } from '@providers/PostHogClientProvider';
 import { AddressesDiscoveryOverlay } from 'components/AddressesDiscoveryOverlay';
 import { NamiMigrationGuard } from '@src/features/nami-migration/NamiMigrationGuard';
+import { AppVersionGuard } from '@src/utils/AppVersionGuard';
 
 const App = (): React.ReactElement => (
   <BackgroundServiceAPIProvider>
@@ -46,7 +47,9 @@ const App = (): React.ReactElement => (
                             <DataCheckContainer appMode={APP_MODE_BROWSER}>
                               <AddressesDiscoveryOverlay>
                                 <NamiMigrationGuard>
-                                  <BrowserViewRoutes />
+                                  <AppVersionGuard>
+                                    <BrowserViewRoutes />
+                                  </AppVersionGuard>
                                 </NamiMigrationGuard>
                               </AddressesDiscoveryOverlay>
                             </DataCheckContainer>


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12102](https://input-output.atlassian.net/browse/LW-12102)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

- Add console logs for all runtime.on* events in [onUpdate.ts](https://github.com/input-output-hk/lace/blob/main/apps/browser-extension-wallet/src/lib/scripts/background/onUpdate.ts)
- On each UI load, compare application version with the one from the service worker
  - Expose new background api method to get application version
  - Log sentry error if version doesn’t match with the one from UI process

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12102]: https://input-output.atlassian.net/browse/LW-12102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ