### PR TITLE
fix(extension): limit stored tx history size [LW-12227]

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/wallet.ts
@@ -50,6 +50,7 @@ import { migrateCollectionStore, migrateWalletStores, shouldAttemptWalletStoresM
 import { isLacePopupOpen$, createUserSessionTracker, isLaceTabActive$ } from './session';
 import { TrackerSubject } from '@cardano-sdk/util-rxjs';
 import { ExperimentName, FeatureFlags } from '../types/feature-flags';
+import { TX_HISTORY_LIMIT_SIZE } from '@utils/constants';
 
 export const dAppConnectorActivity$ = new Subject<void>();
 const pollController$ = new TrackerSubject(
@@ -335,6 +336,13 @@ const storesFactory: StoresFactory = {
         // and we are sure that it's working well
       }
     }
+
+    const transactions = await firstValueFrom(extensionStores.transactions.getAll().pipe(defaultIfEmpty([])));
+
+    if (transactions.length > TX_HISTORY_LIMIT_SIZE) {
+      await firstValueFrom(extensionStores.transactions.setAll(transactions.slice(-TX_HISTORY_LIMIT_SIZE)));
+    }
+
     return extensionStores;
   }
 };

--- a/apps/browser-extension-wallet/src/stores/slices/wallet-activities-slice.ts
+++ b/apps/browser-extension-wallet/src/stores/slices/wallet-activities-slice.ts
@@ -42,6 +42,7 @@ import { rewardHistoryTransformer } from '@src/views/browser-view/features/activ
 import { isKeyHashAddress } from '@cardano-sdk/wallet';
 import { ObservableWalletState } from '@hooks/useWalletState';
 import { IBlockchainProvider } from './blockchain-provider-slice';
+import { TX_HISTORY_LIMIT_SIZE } from '@utils/constants';
 
 export interface FetchWalletActivitiesProps {
   fiatCurrency: CurrencyInfo;
@@ -140,8 +141,7 @@ const mapWalletActivities = memoize(
       Pick<IBlockchainProvider, 'inputResolver'> &
       Pick<WalletInfoSlice, 'isSharedWallet'>
   ) => {
-    const TX_LIMIT_SIZE = 10;
-    const txHistorySlice = transactions.history.slice(-TX_LIMIT_SIZE);
+    const txHistorySlice = transactions.history.slice(-TX_HISTORY_LIMIT_SIZE);
     const epochRewardsMapper = (earnedEpoch: Wallet.Cardano.EpochNo, rewards: Reward[]): ExtendedActivityProps => {
       const REWARD_SPENDABLE_DELAY_EPOCHS = 2;
       const spendableEpoch = (earnedEpoch + REWARD_SPENDABLE_DELAY_EPOCHS) as Wallet.Cardano.EpochNo;

--- a/apps/browser-extension-wallet/src/utils/constants.ts
+++ b/apps/browser-extension-wallet/src/utils/constants.ts
@@ -9,6 +9,8 @@ export const CARDANO_COIN_SYMBOL: { [key in Wallet.Cardano.NetworkId]: ADASymbol
   [Wallet.Cardano.NetworkId.Testnet]: 'tADA'
 };
 
+export const TX_HISTORY_LIMIT_SIZE = 10;
+
 export const cardanoCoin: Wallet.CoinId = {
   id: '1',
   name: 'Cardano',


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-12227)

---

## Proposed solution
Limit stored tx history size.

## Testing
1. Restore wallet using Lace version >= 1.18.2
2. Update Lace to version in `main` branch
3. Call `await chrome.storage.local.get()` and see how many transactions are stored
4. Update Lace to version in this branch
5. Redo step 3 and see only 10 transactions
