### PR TITLE
feat(common): capture AppLogger stringify error using Sentry [LW-12263]

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -55,6 +55,7 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
+    "@sentry/react": "^8.33.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router-dom": "5.2.0"

--- a/packages/common/src/AppLogger.ts
+++ b/packages/common/src/AppLogger.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Logger } from 'ts-log';
 import { stringifyWithFallback } from '@src/ui/lib';
+import * as Sentry from '@sentry/react';
 
 enum LogLevel {
   error = 0,
@@ -27,7 +28,13 @@ class AppLogger implements Logger {
     return params.map((param) => {
       const [value, error] = stringifyWithFallback(param);
       if (error) {
-        console.error('AppLogger: Failed to stringify the log param', { error, param });
+        Sentry.captureMessage('AppLogger: Failed to stringify the log param', {
+          level: 'error',
+          extra: {
+            error,
+            param
+          }
+        });
       }
 
       return value;

--- a/packages/common/src/ui/lib/index.ts
+++ b/packages/common/src/ui/lib/index.ts
@@ -3,3 +3,4 @@ export * from './format-number';
 export * from './get-random-icon';
 export * from './text-formatters';
 export * from './get-number-unit';
+export * from './stringify-with-fallback';

--- a/packages/common/src/ui/lib/stringify-with-fallback.ts
+++ b/packages/common/src/ui/lib/stringify-with-fallback.ts
@@ -1,0 +1,13 @@
+import { toSerializableObject } from '@cardano-sdk/util';
+
+export const stringifyWithFallback = (
+  value: unknown,
+  fallbackValue = '<failed-to-stringify>'
+): [string] | [string, Error] => {
+  if (typeof value === 'string') return [value];
+  try {
+    return [JSON.stringify(toSerializableObject(value))];
+  } catch (error) {
+    return [fallbackValue, error];
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -13638,6 +13638,7 @@ __metadata:
     ts-log: ^2.2.7
     typescript: ^4.9.5
   peerDependencies:
+    "@sentry/react": ^8.33.1
     react: 17.0.2
     react-dom: 17.0.2
     react-router-dom: 5.2.0


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-12263)

---

## Proposed solution
Fix `AppLogger.convertParams` to stringify all the params, capture stringify errors in Sentry.

## Testing
N/A