### PR TITLE
fix: fail log instead of potentially crashing [LW-12263]

### DIFF
--- a/packages/common/src/AppLogger.ts
+++ b/packages/common/src/AppLogger.ts
@@ -13,6 +13,16 @@ enum LogLevel {
 
 export type LogLevelString = keyof typeof LogLevel;
 
+// toSerializableObj will try to make the object serializable,
+// but it can still fail if object has some unsupported shape
+const tryStringify = (obj: unknown) => {
+  try {
+    return JSON.stringify(toSerializableObject(obj));
+  } catch {
+    return '<failed-to-stringify>';
+  }
+};
+
 class AppLogger implements Logger {
   private logLevel: LogLevel;
 
@@ -25,7 +35,7 @@ class AppLogger implements Logger {
 
   private convertParams(params: any[]) {
     return params.map((param) =>
-      param && typeof param === 'object' ? JSON.stringify(toSerializableObject(param)) : param
+      typeof param === 'object' && param !== null ? tryStringify(param) : toSerializableObject(param)
     );
   }
 


### PR DESCRIPTION
# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Logger can receive arbitrary objects as parameters. If it has BigInt properties within some unexpected shape, JSON.strinfify can throw and crash the application

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes
