### PR TITLE
chore: update sonarcloud action

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Sonarcloud's action `SonarSource/sonarcloud-github-action@master` has been deprecated and sonarcloud scans started to fail: https://github.com/input-output-hk/lace/actions/runs/13267269440/job/37037775502?pr=1704

Check deprecation warning here: https://github.com/SonarSource/sonarcloud-github-action