### PR TITLE
ci: update ubuntu action runner image to 22.04

### DIFF
--- a/.github/workflows/build-dev-preview.yml
+++ b/.github/workflows/build-dev-preview.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     name: Build + test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/chromatic-core.yml
+++ b/.github/workflows/chromatic-core.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   check-if-should-run:
     if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       requireChromaticCheck: ${{ steps.diffcheck.outputs.requireChromaticCheck }}
     steps:
@@ -34,7 +34,7 @@ jobs:
   chromatic-deployment:
     name: Chromatic Core
     needs: check-if-should-run
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         if: ${{ needs.check-if-should-run.outputs.requireChromaticCheck == 1 }}

--- a/.github/workflows/chromatic-staking.yml
+++ b/.github/workflows/chromatic-staking.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   check-if-should-run:
     if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       requireChromaticCheck: ${{ steps.diffcheck.outputs.requireChromaticCheck }}
     steps:
@@ -33,7 +33,7 @@ jobs:
   chromatic-deployment:
     name: Chromatic Staking
     needs: check-if-should-run
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         if: ${{ needs.check-if-should-run.outputs.requireChromaticCheck == 1 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   prepare:
     name: Prepare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
@@ -79,7 +79,7 @@ jobs:
 
   unitTests:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: prepare
 
     steps:
@@ -138,7 +138,7 @@ jobs:
 
   release-pkg:
     name: Release package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: prepare
 
     steps:
@@ -336,7 +336,7 @@ jobs:
   if-core-changed:
     name: When core changed
     if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       requireChromaticCheck: ${{ steps.diffcheck.outputs.requireChromaticCheck }}
     steps:
@@ -356,7 +356,7 @@ jobs:
   chromaticCore:
     name: >
       Run Chromatic check: Core
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - prepare
       - if-core-changed
@@ -419,7 +419,7 @@ jobs:
   if-staking-changed:
     name: When staking change
     if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       requireChromaticCheck: ${{ steps.diffcheck.outputs.requireChromaticCheck }}
     steps:
@@ -439,7 +439,7 @@ jobs:
   chromaticStaking:
     name: >
       Run Chromatic check: Staking
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - prepare
       - if-staking-changed

--- a/.github/workflows/e2e-tests-linux-split.yml
+++ b/.github/workflows/e2e-tests-linux-split.yml
@@ -32,7 +32,6 @@ on:
         options:
           - self-hosted
           - ubuntu-22.04
-          - ubuntu-20.04
           - ubuntu-latest
       smoke_only:
         type: boolean

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   sonarcloud:
     name: SonarCloud Code Analysis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01

https://github.com/actions/runner-images/issues/11101