### PR TITLE
fix: [lw-12338] remove end message from activities tab in nami mode

### DIFF
--- a/packages/nami/src/ui/app/components/historyViewer.tsx
+++ b/packages/nami/src/ui/app/components/historyViewer.tsx
@@ -65,7 +65,7 @@ const HistoryViewer = () => {
               fontWeight="bold"
               color="gray.400"
             >
-              Use a Cardano explorer to see full transaction history.
+              ... nothing more
             </Box>
           ) : (
             <Box textAlign="center">

--- a/packages/translation/src/lib/translations/browser-extension-wallet/en.json
+++ b/packages/translation/src/lib/translations/browser-extension-wallet/en.json
@@ -837,7 +837,6 @@
   "unlock.input.placeholder": "Password",
   "unlock.sectionTitle": "Welcome back!",
   "walletActivity.sectionTitle": "Activity",
-  "walletActivity.endMessage": "Use a Cardano explorer to see full transaction history.",
   "walletSetup.backModal.iUnderstandGoBack": "Cancel",
   "walletSetup.backModal.ohOkLetsContinue": "Got it",
   "walletSetup.backModal.youllHaveToStartAgain": "You'll have to start again",


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12338](https://input-output.atlassian.net/browse/LW-12338)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Previously activities feed was limited to 10 txs, but since https://input-output.atlassian.net/browse/LW-12099 brings full activities feed back (but now paginated), we can now tell for sure that we've reached the end of the list and show previously replaceded `... nothing more` message.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots


<img width="361" alt="Screenshot 2025-02-18 at 08 41 47" src="https://github.com/user-attachments/assets/ed13b13b-34d9-46be-9bfc-1c42fcee0794" />


[LW-12338]: https://input-output.atlassian.net/browse/LW-12338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ