### PR TITLE
fix: [lw-12354] fix reward history pagination on staking tab

### DIFF
--- a/packages/core/src/ui/components/Activity/GroupedAssetActivityList.tsx
+++ b/packages/core/src/ui/components/Activity/GroupedAssetActivityList.tsx
@@ -25,7 +25,7 @@ export interface GroupedAssetActivityListProps {
   lists: AssetActivityListProps[];
   scrollableTarget: string;
   endMessage?: React.ReactNode;
-  dataLength?: number;
+  dataLength: number;
   withTitle?: {
     title: string;
     onClick?: () => void;
@@ -67,7 +67,7 @@ export const GroupedAssetActivityList = ({
 
   return (
     <InfiniteScroll
-      dataLength={dataLength ?? 0}
+      dataLength={dataLength}
       endMessage={endMessage}
       scrollableTarget={scrollableTarget}
       next={next}

--- a/packages/core/src/ui/components/Activity/__tests__/GroupedAssetActivityList.test.tsx
+++ b/packages/core/src/ui/components/Activity/__tests__/GroupedAssetActivityList.test.tsx
@@ -17,6 +17,7 @@ const activityItem: AssetActivityItemProps = {
 
 describe('Testing GroupedAssetActivityList component', () => {
   const props: GroupedAssetActivityListProps = {
+    dataLength: 2,
     hasMore: false,
     scrollableTarget: 'scrollableTarget',
     loadMore: async () => await void 0,

--- a/packages/staking/src/features/activity/RewardsHistory.tsx
+++ b/packages/staking/src/features/activity/RewardsHistory.tsx
@@ -35,6 +35,7 @@ export const RewardsHistory = ({ groupedRewardsActivities, walletActivitiesStatu
           loadMore={loadMoreData}
           lists={paginatedLists}
           scrollableTarget={LACE_APP_ID}
+          dataLength={paginatedLists.length}
           loadFirstChunk
         />
       </Skeleton>


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12354](https://input-output.atlassian.net/browse/LW-12354)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

`dataLength` prop should be explicitly provided for `GroupedAssetActivityList` component.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12354]: https://input-output.atlassian.net/browse/LW-12354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ