### PR TITLE
fix: [lw-12355] fix search bar visibility in assets page

### DIFF
--- a/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetsPortfolio/AssetPortfolioContent.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/assets/components/AssetsPortfolio/AssetPortfolioContent.tsx
@@ -68,7 +68,7 @@ export const AssetPortfolioContent = ({
 
   return (
     <>
-      {assetList?.length > MIN_ASSETS_COUNT_FOR_SEARCH && (
+      {totalAssets > MIN_ASSETS_COUNT_FOR_SEARCH && (
         <div className={styles.searchBoxContainer}>
           <SearchBox
             placeholder={t('browserView.assets.searchPlaceholder')}


### PR DESCRIPTION
# Checklist

- [ ] JIRA - [LW-12355](https://input-output.atlassian.net/browse/LW-12355)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

By default search bar is hidden if number of `assets < 10` (hardcoded on the ui). Since assets list is paginated now, we need to adjust that logic to check for total amount of assets instead.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12355]: https://input-output.atlassian.net/browse/LW-12355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ