### PR TITLE
refactor: improve error handling of extension tab api interactions

### DIFF
--- a/apps/browser-extension-wallet/src/components/Layout/MainLayout.tsx
+++ b/apps/browser-extension-wallet/src/components/Layout/MainLayout.tsx
@@ -52,7 +52,7 @@ export const MainLayout = ({
     getAboutExtensionData();
   }, [getAboutExtensionData]);
 
-  const onUpdateAknowledge = useCallback(async () => {
+  const onUpdateAcknowledge = useCallback(async () => {
     const data = { version, acknowledged: true, reason };
     await storage.local.set({
       [ABOUT_EXTENSION_KEY]: data
@@ -72,7 +72,7 @@ export const MainLayout = ({
       </div>
       <Announcement
         visible={showAnnouncement && version && !acknowledged}
-        onConfirm={onUpdateAknowledge}
+        onConfirm={onUpdateAcknowledge}
         version={version}
         reason={reason}
       />

--- a/apps/browser-extension-wallet/src/features/dapp/components/ConfirmData.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/ConfirmData.tsx
@@ -65,8 +65,14 @@ export const DappConfirmData = (): React.ReactElement => {
 
   useEffect(() => {
     const subscription = signingCoordinator.signDataRequest$.pipe(take(1)).subscribe(async (r) => {
-      setDappInfo(await senderToDappInfo(r.signContext.sender));
       setSignDataRequest(r);
+      try {
+        setDappInfo(await senderToDappInfo(r.signContext.sender));
+      } catch (error) {
+        logger.error(error);
+        void r.reject('Could not get DApp info');
+        redirectToSignFailure();
+      }
     });
 
     const api = exposeApi<Pick<UserPromptService, 'readyToSignData'>>(
@@ -86,7 +92,7 @@ export const DappConfirmData = (): React.ReactElement => {
       subscription.unsubscribe();
       api.shutdown();
     };
-  }, [setSignDataRequest]);
+  }, [redirectToSignFailure, setSignDataRequest]);
 
   useEffect(() => {
     if (!req) return;

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/hooks.ts
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/hooks.ts
@@ -151,7 +151,8 @@ export const useCreateMintedAssetList = ({
 
 export const useDisallowSignTx = (
   req: TransactionWitnessRequest<Wallet.WalletMetadata, Wallet.AccountMetadata>
-): ((close?: boolean) => Promise<void>) => useCallback(async (close) => await disallowSignTx(req, close), [req]);
+): ((close?: boolean, reason?: string) => Promise<void>) =>
+  useCallback(async (close, reason) => await disallowSignTx(req, close, reason), [req]);
 
 export const useAllowSignTx = (
   req: TransactionWitnessRequest<Wallet.WalletMetadata, Wallet.AccountMetadata>

--- a/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/utils.ts
+++ b/apps/browser-extension-wallet/src/features/dapp/components/confirm-transaction/utils.ts
@@ -27,10 +27,11 @@ export const readyToSign = (): void => {
 
 export const disallowSignTx = async (
   req: TransactionWitnessRequest<Wallet.WalletMetadata, Wallet.AccountMetadata>,
-  close = false
+  close = false,
+  reason = 'User declined to sign'
 ): Promise<void> => {
   try {
-    await req?.reject('User declined to sign');
+    await req?.reject(reason);
   } finally {
     close && window.close();
   }

--- a/apps/browser-extension-wallet/src/features/nami-migration/migration-tool/cross-extension-messaging/lace-migration-client.extension.ts
+++ b/apps/browser-extension-wallet/src/features/nami-migration/migration-tool/cross-extension-messaging/lace-migration-client.extension.ts
@@ -7,6 +7,7 @@ import { NAMI_EXTENSION_ID } from './lace/environment';
 import { createLaceMigrationOpenListener } from './lace/create-lace-migration-open-listener';
 import { LACE_EXTENSION_ID } from './nami/environment';
 import { logger } from '@lace/common';
+import { catchAndBrandExtensionApiError } from '@utils/catch-and-brand-extension-api-error';
 
 type CheckMigrationStatus = () => Promise<MigrationState>;
 
@@ -42,6 +43,14 @@ export const handleNamiRequests = (): void => {
   runtime.onMessageExternal.addListener(createLaceMigrationPingListener(NAMI_EXTENSION_ID));
   logger.debug('[NAMI MIGRATION] createLaceMigrationOpenListener');
   runtime.onMessageExternal.addListener(
-    createLaceMigrationOpenListener(NAMI_EXTENSION_ID, LACE_EXTENSION_ID, tabs.create)
+    createLaceMigrationOpenListener(NAMI_EXTENSION_ID, LACE_EXTENSION_ID, ({ url }) =>
+      catchAndBrandExtensionApiError(
+        tabs.create({ url }),
+        `[NAMI MIGRATION] laceMigrationOpenListener failed to create tab with url ${url}`,
+        {
+          reThrow: false
+        }
+      )
+    )
   );
 };

--- a/apps/browser-extension-wallet/src/features/nami-migration/migration-tool/cross-extension-messaging/lace/create-lace-migration-open-listener.ts
+++ b/apps/browser-extension-wallet/src/features/nami-migration/migration-tool/cross-extension-messaging/lace/create-lace-migration-open-listener.ts
@@ -8,7 +8,11 @@ export const createLaceMigrationOpenListener =
     logger.debug('[NAMI MIGRATION] createLaceMigrationOpenListener', message, sender);
     if (message === NamiMessages.open && sender.id === namiExtensionId) {
       // First close all open lace tabs
-      await closeAllLaceOrNamiTabs();
+      try {
+        await closeAllLaceOrNamiTabs();
+      } catch (error) {
+        logger.error('[NAMI MIGRATION] createLaceMigrationOpenListener: failed to close all windows', error);
+      }
       createTab({ url: `chrome-extension://${laceExtensionId}/app.html` });
     }
   };

--- a/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts
@@ -47,7 +47,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
         return cancelOnTabClose(tab);
       } catch (error) {
         logger.error(error);
-        return Promise.reject(new ApiError(APIErrorCode.InternalError, 'Unable to sign transaction'));
+        throw new ApiError(APIErrorCode.InternalError, 'Unable to sign transaction');
       }
     },
     DEBOUNCE_THROTTLE,
@@ -62,8 +62,7 @@ export const confirmationCallback: walletCip30.CallbackConfirmation = {
         return cancelOnTabClose(tab);
       } catch (error) {
         logger.error(error);
-        // eslint-disable-next-line unicorn/no-useless-undefined
-        return Promise.reject(new ApiError(APIErrorCode.InternalError, 'Unable to sign data'));
+        throw new ApiError(APIErrorCode.InternalError, 'Unable to sign data');
       }
     },
     DEBOUNCE_THROTTLE,

--- a/apps/browser-extension-wallet/src/lib/scripts/background/session/is-lace-tab-active.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/session/is-lace-tab-active.ts
@@ -1,6 +1,7 @@
 import { LACE_EXTENSION_ID } from '@src/features/nami-migration/migration-tool/cross-extension-messaging/nami/environment';
 import { distinctUntilChanged, from, fromEventPattern, map, merge, share, startWith, switchMap } from 'rxjs';
 import { Tabs, tabs, windows } from 'webextension-polyfill';
+import { catchAndBrandExtensionApiError } from '@utils/catch-and-brand-extension-api-error';
 
 type WindowId = number;
 
@@ -21,10 +22,13 @@ const tabActivated$ = fromEventPattern<Tabs.OnActivatedActiveInfoType>(
 export const isLaceTabActive$ = merge(windowRemoved$, tabUpdated$, tabActivated$).pipe(
   switchMap(() =>
     from(
-      tabs.query({
-        active: true,
-        url: `chrome-extension://${LACE_EXTENSION_ID}/*`
-      })
+      catchAndBrandExtensionApiError(
+        tabs.query({
+          active: true,
+          url: `chrome-extension://${LACE_EXTENSION_ID}/*`
+        }),
+        'Failed to query for currently active lace tab'
+      )
     )
   ),
   map((activeLaceTabs) => activeLaceTabs.length > 0),

--- a/apps/browser-extension-wallet/src/utils/catch-and-brand-extension-api-error.ts
+++ b/apps/browser-extension-wallet/src/utils/catch-and-brand-extension-api-error.ts
@@ -1,0 +1,24 @@
+import { logger } from '@lace/common';
+
+class ExtensionApiError extends Error {}
+
+type CatchAndBrandExtensionApiErrorOptions = {
+  reThrow?: boolean;
+};
+
+export const catchAndBrandExtensionApiError = async <T>(
+  promise: Promise<T>,
+  errorMessage: string,
+  { reThrow = true }: CatchAndBrandExtensionApiErrorOptions = {}
+  // eslint-disable-next-line consistent-return
+): Promise<T> => {
+  try {
+    return await promise;
+  } catch (error) {
+    const message = `${errorMessage} due to: ${error}`;
+    logger.error(`[WebExtension API error] ${message}`);
+    if (reThrow) {
+      throw new ExtensionApiError(errorMessage);
+    }
+  }
+};

--- a/apps/browser-extension-wallet/src/utils/senderToDappInfo.ts
+++ b/apps/browser-extension-wallet/src/utils/senderToDappInfo.ts
@@ -3,12 +3,16 @@ import { Wallet } from '@lace/cardano';
 import { getRandomIcon } from '@lace/common';
 import uniqueId from 'lodash/uniqueId';
 import { tabs, Runtime } from 'webextension-polyfill';
+import { catchAndBrandExtensionApiError } from '@utils/catch-and-brand-extension-api-error';
 
 export const senderToDappInfo = async (sender: Runtime.MessageSender): Promise<Wallet.DappInfo> => {
   if (!sender.tab?.id) throw new Error('Unknown sender tab id');
   // Tab info might've changed. It used to fail e2e tests when using data from 'sender.tab'.
   // It would be better if SDK waited for tab to load before emitting events with sender.
-  const tab = await tabs.get(sender.tab?.id);
+  const tab = await catchAndBrandExtensionApiError(
+    tabs.get(sender.tab?.id),
+    `Failed to get tab data of a DApp with url ${sender.url}`
+  );
   return {
     url: senderOrigin(sender),
     logo: tab.favIconUrl || getRandomIcon({ id: uniqueId(), size: 40 }),

--- a/apps/browser-extension-wallet/src/views/browser-view/components/TopUpWallet/TopUpWalletButton.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/TopUpWallet/TopUpWalletButton.tsx
@@ -1,10 +1,9 @@
-import { tabs } from 'webextension-polyfill';
 import { AdaComponentTransparent, Button } from '@input-output-hk/lace-ui-toolkit';
 import React, { useRef, useState } from 'react';
 import { TopUpWalletDialog } from './TopUpWalletDialog';
 import { useTranslation } from 'react-i18next';
 import { BANXA_LACE_URL } from './config';
-import { useAnalyticsContext } from '@providers';
+import { useAnalyticsContext, useExternalLinkOpener } from '@providers';
 import { PostHogAction } from '@lace/common';
 
 export const TopUpWalletButton = (): React.ReactElement => {
@@ -12,6 +11,7 @@ export const TopUpWalletButton = (): React.ReactElement => {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
   const analytics = useAnalyticsContext();
+  const openExternalLink = useExternalLinkOpener();
 
   return (
     <>
@@ -35,7 +35,7 @@ export const TopUpWalletButton = (): React.ReactElement => {
         triggerRef={dialogTriggerReference}
         onConfirm={() => {
           analytics.sendEventToPostHog(PostHogAction.TokenBuyAdaDisclaimerContinueClick);
-          tabs.create({ url: BANXA_LACE_URL });
+          openExternalLink(BANXA_LACE_URL);
           setOpen(false);
         }}
       />

--- a/apps/browser-extension-wallet/src/views/browser-view/components/TopUpWallet/TopUpWalletDialog.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/TopUpWallet/TopUpWalletDialog.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Box, Dialog, Text, TextLink } from '@input-output-hk/lace-ui-toolkit';
 import styles from './TopUpWallet.module.scss';
 import { useTranslation } from 'react-i18next';
-import { tabs } from 'webextension-polyfill';
 import { BANXA_HOMEPAGE_URL } from './config';
+import { useExternalLinkOpener } from '@providers';
 
 interface TopUpWalletDialogProps {
   open: boolean;
@@ -18,9 +18,10 @@ export const TopUpWalletDialog = ({
   triggerRef
 }: TopUpWalletDialogProps): React.ReactElement => {
   const { t } = useTranslation();
-  const handleOpenTabBanxaHomepage = useCallback(() => {
-    tabs.create({ url: BANXA_HOMEPAGE_URL });
-  }, []);
+  const openExternalLink = useExternalLinkOpener();
+  const handleOpenTabBanxaHomepage = () => {
+    openExternalLink(BANXA_HOMEPAGE_URL);
+  };
 
   return (
     <Dialog.Root open={open} setOpen={onCancel} zIndex={1000} onCloseAutoFocusRef={triggerRef}>

--- a/packages/nami/src/ui/app/pages/dapp-connector/signData.tsx
+++ b/packages/nami/src/ui/app/pages/dapp-connector/signData.tsx
@@ -24,6 +24,7 @@ import {
   DappConnector,
   useDappOutsideHandles,
 } from '../../../../features/dapp-outside-handles-provider';
+import { logger } from '@lace/common';
 
 interface Props {
   dappConnector: DappConnector;
@@ -87,23 +88,28 @@ export const SignData = ({ dappConnector, account }: Readonly<Props>) => {
     }
   };
 
+  const cancelTransaction = useCallback(async () => {
+    await request?.reject(() => void 0);
+    window.close();
+  }, [request]);
+
   const loadData = async () => {
-    const { dappInfo, request } = await dappConnector.getSignDataRequest();
-    getPayload(request.data.payload);
-    getAddress(request.data.address);
-    setDappInfo(dappInfo);
-    setRequest(request);
-    setIsLoading(false);
+    try {
+      const { dappInfo, request } = await dappConnector.getSignDataRequest();
+      getPayload(request.data.payload);
+      getAddress(request.data.address);
+      setDappInfo(dappInfo);
+      setRequest(request);
+      setIsLoading(false);
+    } catch (error) {
+      logger.error('Failed to get SignData request data', error);
+      void cancelTransaction();
+    }
   };
 
   React.useEffect(() => {
     loadData();
   }, []);
-
-  const cancelTransaction = useCallback(async () => {
-    await request?.reject(() => void 0);
-    window.close();
-  }, [request]);
 
   useOnUnload(cancelTransaction);
 


### PR DESCRIPTION
# Checklist

- [x] JIRA - [\<link>](https://input-output.atlassian.net/browse/LW-12118)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

- created a helper that 
  - catch extension API errors
  - log them
  - re-throw as `ExtensionApiError` with a localised message - Sentry will categorise those errors separately
- wrapped all relevant `tabs` API usages with that helper + some other APIs
- improved error handling in
  - DApp connector's sign data flow - it shows an error screen when e.g. requesting DApp closed
  - DApp connector's transaction flow - it shows an error screen when e.g. requesting DApp closed

## Testing

- Full automated e2e
- sanity testing of:
  - dapp connector
    - requesting access + ensure no "only once" regression
    - transaction
    - sign data
  - discarding other open lace tabs when the active wallet is a HW
    - discarded tab disappears from task manager and when activated it shows spinner
  - logging an error message to the console ([link](https://github.com/input-output-hk/lace/pull/1732/files#diff-3ada8e89d0c1f17d03fffe0afea55b1a2eb96973d6f5ee0a456a3d76aa08a674R18))
  - pairing trezor
  - banxa opening external links

