### PR TITLE
fix: [lw-12046] show detailed tx submit errors

### DIFF
--- a/apps/browser-extension-wallet/src/components/ResultMessage/ResultMessage.module.scss
+++ b/apps/browser-extension-wallet/src/components/ResultMessage/ResultMessage.module.scss
@@ -57,4 +57,15 @@
       width: size_unit(11);
     }
   }
+
+  &.fullWidth {
+    width: 100%;
+    .description {
+      max-width: 100%;
+      width: 100%;
+    }
+    .vertical {
+      width: 100%;
+    }
+  }
 }

--- a/apps/browser-extension-wallet/src/components/ResultMessage/ResultMessage.tsx
+++ b/apps/browser-extension-wallet/src/components/ResultMessage/ResultMessage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import errorImg from '../../assets/icons/exclamation-circle.svg';
 import successImg from '../../assets/icons/clock-icon.svg';
 import styles from './ResultMessage.module.scss';
+import cn from 'classnames';
 
 type Status = 'success' | 'error';
 
@@ -15,15 +16,17 @@ export interface ResultMessageProps {
   title?: React.ReactNode;
   description?: React.ReactNode;
   customBgImg?: string;
+  fullWidth?: boolean;
 }
 
 export const ResultMessage = ({
   status = 'success',
   title,
   description,
-  customBgImg
+  customBgImg,
+  fullWidth
 }: ResultMessageProps): React.ReactElement => (
-  <div className={styles.content} data-testid="result-message-content">
+  <div className={cn(styles.content, { [styles.fullWidth]: fullWidth })} data-testid="result-message-content">
     <img
       className={styles.img}
       src={customBgImg ?? bgImg[status]}

--- a/apps/browser-extension-wallet/src/features/delegation/components/MultiDelegationStakingPopup.tsx
+++ b/apps/browser-extension-wallet/src/features/delegation/components/MultiDelegationStakingPopup.tsx
@@ -30,6 +30,7 @@ import { useSharedWalletData } from '@hooks/useSharedWalletData';
 import { SignPolicy, useSecrets } from '@lace/core';
 import { useRewardAccountsData } from '@src/views/browser-view/features/staking/hooks';
 import { config } from '@src/config';
+import { parseError } from '@src/utils/parse-error';
 
 export const MultiDelegationStakingPopup = (): JSX.Element => {
   const { t } = useTranslation();
@@ -168,7 +169,8 @@ export const MultiDelegationStakingPopup = (): JSX.Element => {
         sharedWalletKey,
         coSigners,
         useRewardAccountsData,
-        govToolUrl: GOV_TOOLS_URLS[environmentName]
+        govToolUrl: GOV_TOOLS_URLS[environmentName],
+        parseError
       }}
     >
       <ContentLayout

--- a/apps/browser-extension-wallet/src/utils/parse-error.ts
+++ b/apps/browser-extension-wallet/src/utils/parse-error.ts
@@ -1,0 +1,7 @@
+export const parseError = (maybeError: unknown): Error => {
+  if (maybeError instanceof Error) {
+    return maybeError;
+  }
+  const errorMessage = typeof maybeError === 'string' ? maybeError : 'Unknown error';
+  return new Error(errorMessage);
+};

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/CoinInput/useSelectedCoins.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/Form/CoinInput/useSelectedCoins.tsx
@@ -99,7 +99,7 @@ export const useSelectedCoins = ({
         return COIN_SELECTION_ERRORS.BUNDLE_AMOUNT_IS_EMPTY;
       }
       // Display an error with the tx itself
-      if (builtTxError) return builtTxError;
+      if (builtTxError) return builtTxError instanceof Error ? builtTxError.message : builtTxError;
       // eslint-disable-next-line consistent-return
       return undefined;
     },

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -244,6 +244,10 @@ export const Footer = withAddressBookContext(
           await inMemoryWallet.submitTx(signedTx);
         } catch (error) {
           logger.error('TX submit error', error);
+          setBuiltTxData({
+            ...builtTxData,
+            error: error instanceof Error ? error?.message : (error ?? '').toString()
+          });
           throw error;
         }
         txSubmitted$.next({

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -42,6 +42,7 @@ import type { TranslationKey } from '@lace/translation';
 import { Serialization } from '@cardano-sdk/core';
 import { exportMultisigTransaction, PasswordObj, useSecrets } from '@lace/core';
 import { WalletType } from '@cardano-sdk/web-extension';
+import { parseError } from '@src/utils/parse-error';
 
 export const nextStepBtnLabels: Partial<Record<Sections, TranslationKey>> = {
   [Sections.FORM]: 'browserView.transaction.send.footer.review',
@@ -208,7 +209,7 @@ export const Footer = withAddressBookContext(
           logger.error('Shared wallet TX sign error', error);
           setBuiltTxData({
             ...builtTxData,
-            error: error instanceof Error ? error?.message : (error ?? '').toString()
+            error: parseError(error)
           });
           throw error;
         }
@@ -224,7 +225,7 @@ export const Footer = withAddressBookContext(
             logger.error('Shared wallet TX submit error', error);
             setBuiltTxData({
               ...builtTxData,
-              error: error instanceof Error ? error?.message : (error ?? '').toString()
+              error: parseError(error)
             });
             throw error;
           }
@@ -246,7 +247,7 @@ export const Footer = withAddressBookContext(
           logger.error('TX submit error', error);
           setBuiltTxData({
             ...builtTxData,
-            error: error instanceof Error ? error?.message : (error ?? '').toString()
+            error: parseError(error)
           });
           throw error;
         }

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -239,9 +239,10 @@ export const Footer = withAddressBookContext(
 
         setBuiltTxData({ ...builtTxData, collectedEnoughSharedWalletTxSignatures });
       } else {
-        const signedTx = await builtTxData.tx.sign();
+        let signedTx;
 
         try {
+          signedTx = await builtTxData.tx.sign();
           await inMemoryWallet.submitTx(signedTx);
         } catch (error) {
           logger.error('TX submit error', error);

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -206,6 +206,10 @@ export const Footer = withAddressBookContext(
           }
         } catch (error) {
           logger.error('Shared wallet TX sign error', error);
+          setBuiltTxData({
+            ...builtTxData,
+            error: error instanceof Error ? error?.message : (error ?? '').toString()
+          });
           throw error;
         }
 
@@ -218,6 +222,10 @@ export const Footer = withAddressBookContext(
             await inMemoryWallet.submitTx(sharedWalletTx.toCbor());
           } catch (error) {
             logger.error('Shared wallet TX submit error', error);
+            setBuiltTxData({
+              ...builtTxData,
+              error: error instanceof Error ? error?.message : (error ?? '').toString()
+            });
             throw error;
           }
         } else {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ResultMessage } from '@components/ResultMessage';
 import { useAnalyticsContext } from '@providers';
@@ -14,6 +14,7 @@ interface TransactionFailProps {
 }
 
 export const TransactionFail = ({ showCustomApiBanner = false }: TransactionFailProps): React.ReactElement => {
+  const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const { t } = useTranslation();
   const analytics = useAnalyticsContext();
   const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
@@ -50,7 +51,12 @@ export const TransactionFail = ({ showCustomApiBanner = false }: TransactionFail
             {showCustomApiBanner && <WarningBanner message={t('drawer.failure.customSubmitApiWarning')} />}
             {typeof error === 'object' && error.message && (
               <Box w="$fill">
-                <SummaryExpander title={t('browserView.transaction.fail.error-details.label')} plain>
+                <SummaryExpander
+                  onClick={() => setIsSummaryOpen(!isSummaryOpen)}
+                  open={isSummaryOpen}
+                  title={t('browserView.transaction.fail.error-details.label')}
+                  plain
+                >
                   <TransactionSummary.Other
                     label={error.name || t('browserView.transaction.fail.error-details.error-name-fallback')}
                     text={error.message}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
@@ -7,6 +7,7 @@ import styles from './TransactionSuccessView.module.scss';
 import { useAnalyticsSendFlowTriggerPoint, useBuiltTxState } from '../store';
 import { WarningBanner } from '@lace/common';
 import { useWalletStore } from '@src/stores';
+import { Box, SummaryExpander, TransactionSummary } from '@input-output-hk/lace-ui-toolkit';
 
 interface TransactionFailProps {
   showCustomApiBanner?: boolean;
@@ -18,6 +19,7 @@ export const TransactionFail = ({ showCustomApiBanner = false }: TransactionFail
   const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
   const { isSharedWallet } = useWalletStore();
   const { builtTxData } = useBuiltTxState();
+  const { error } = builtTxData || {};
 
   useEffect(() => {
     analytics.sendEventToPostHog(
@@ -35,20 +37,27 @@ export const TransactionFail = ({ showCustomApiBanner = false }: TransactionFail
     <div data-testid="tx-fail-container" className={styles.successTxContainer}>
       <ResultMessage
         status="error"
-        title={
-          <>
-            <div data-testid="send-error-title">{t('browserView.transaction.fail.oopsSomethingWentWrong')}</div>
-          </>
-        }
+        fullWidth
+        title={<div data-testid="send-error-title">{t('browserView.transaction.fail.oopsSomethingWentWrong')}</div>}
         description={
           <>
             <div data-testid="send-error-description">
-              {builtTxData?.error || t('browserView.transaction.fail.problemSubmittingYourTransaction')}
+              {t('browserView.transaction.fail.problemSubmittingYourTransaction')}
             </div>
-            <div data-testid="send-error-description2" className={styles.message}>
+            <div data-testid="send-error-description2" className={styles.errorMessage}>
               {t('browserView.transaction.fail.clickBackAndTryAgain')}
             </div>
             {showCustomApiBanner && <WarningBanner message={t('drawer.failure.customSubmitApiWarning')} />}
+            {typeof error === 'object' && error.message && (
+              <Box w="$fill">
+                <SummaryExpander title={t('browserView.transaction.fail.error-details.label')} plain>
+                  <TransactionSummary.Other
+                    label={error.name || t('browserView.transaction.fail.error-details.error-name-fallback')}
+                    text={error.message}
+                  />
+                </SummaryExpander>
+              </Box>
+            )}
           </>
         }
       />

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionFail.tsx
@@ -4,7 +4,7 @@ import { ResultMessage } from '@components/ResultMessage';
 import { useAnalyticsContext } from '@providers';
 import { PostHogAction, TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
 import styles from './TransactionSuccessView.module.scss';
-import { useAnalyticsSendFlowTriggerPoint } from '../store';
+import { useAnalyticsSendFlowTriggerPoint, useBuiltTxState } from '../store';
 import { WarningBanner } from '@lace/common';
 import { useWalletStore } from '@src/stores';
 
@@ -17,6 +17,7 @@ export const TransactionFail = ({ showCustomApiBanner = false }: TransactionFail
   const analytics = useAnalyticsContext();
   const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
   const { isSharedWallet } = useWalletStore();
+  const { builtTxData } = useBuiltTxState();
 
   useEffect(() => {
     analytics.sendEventToPostHog(
@@ -42,7 +43,7 @@ export const TransactionFail = ({ showCustomApiBanner = false }: TransactionFail
         description={
           <>
             <div data-testid="send-error-description">
-              {t('browserView.transaction.fail.problemSubmittingYourTransaction')}
+              {builtTxData?.error || t('browserView.transaction.fail.problemSubmittingYourTransaction')}
             </div>
             <div data-testid="send-error-description2" className={styles.message}>
               {t('browserView.transaction.fail.clickBackAndTryAgain')}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.module.scss
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/TransactionSuccessView.module.scss
@@ -12,3 +12,7 @@
 .message {
   margin-bottom: 34px;
 }
+
+.errorMessage {
+  margin-bottom: 20px;
+}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/UnauthorizedTransaction.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/UnauthorizedTransaction.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ResultMessage } from '@components/ResultMessage';
 import { useAnalyticsContext } from '@providers';
@@ -8,6 +8,7 @@ import { useAnalyticsSendFlowTriggerPoint, useBuiltTxState } from '../store';
 import { Box, SummaryExpander, TransactionSummary } from '@input-output-hk/lace-ui-toolkit';
 
 export const UnauthorizedTransaction = (): React.ReactElement => {
+  const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const { t } = useTranslation();
   const analytics = useAnalyticsContext();
   const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
@@ -39,7 +40,12 @@ export const UnauthorizedTransaction = (): React.ReactElement => {
             <div data-testid="send-error-description2">{t('browserView.transaction.fail.clickBackAndTryAgain')}</div>
             {typeof error === 'object' && error.message && (
               <Box w="$fill">
-                <SummaryExpander title={t('browserView.transaction.fail.error-details.label')} plain>
+                <SummaryExpander
+                  onClick={() => setIsSummaryOpen(!isSummaryOpen)}
+                  open={isSummaryOpen}
+                  title={t('browserView.transaction.fail.error-details.label')}
+                  plain
+                >
                   <TransactionSummary.Other
                     label={error.name || t('browserView.transaction.fail.error-details.error-name-fallback')}
                     text={error.message}

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/UnauthorizedTransaction.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/UnauthorizedTransaction.tsx
@@ -4,12 +4,15 @@ import { ResultMessage } from '@components/ResultMessage';
 import { useAnalyticsContext } from '@providers';
 import { PostHogAction, TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
 import styles from './TransactionSuccessView.module.scss';
-import { useAnalyticsSendFlowTriggerPoint } from '../store';
+import { useAnalyticsSendFlowTriggerPoint, useBuiltTxState } from '../store';
+import { Box, SummaryExpander, TransactionSummary } from '@input-output-hk/lace-ui-toolkit';
 
 export const UnauthorizedTransaction = (): React.ReactElement => {
   const { t } = useTranslation();
   const analytics = useAnalyticsContext();
   const { triggerPoint } = useAnalyticsSendFlowTriggerPoint();
+  const { builtTxData } = useBuiltTxState();
+  const { error } = builtTxData || {};
 
   useEffect(() => {
     analytics.sendEventToPostHog(PostHogAction.SendSomethingWentWrongView, {
@@ -23,6 +26,7 @@ export const UnauthorizedTransaction = (): React.ReactElement => {
   return (
     <div data-testid="tx-fail-container" className={styles.successTxContainer}>
       <ResultMessage
+        fullWidth
         status="error"
         title={
           <>
@@ -33,6 +37,16 @@ export const UnauthorizedTransaction = (): React.ReactElement => {
           <>
             <div data-testid="send-error-description">{t('browserView.transaction.fail.unauthorizedTransaction')}</div>
             <div data-testid="send-error-description2">{t('browserView.transaction.fail.clickBackAndTryAgain')}</div>
+            {typeof error === 'object' && error.message && (
+              <Box w="$fill">
+                <SummaryExpander title={t('browserView.transaction.fail.error-details.label')} plain>
+                  <TransactionSummary.Other
+                    label={error.name || t('browserView.transaction.fail.error-details.error-name-fallback')}
+                    text={error.message}
+                  />
+                </SummaryExpander>
+              </Box>
+            )}
           </>
         }
       />

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/types.ts
@@ -42,7 +42,7 @@ export interface BuiltTxData {
   };
   importedSharedWalletTx?: Serialization.Transaction;
   collectedEnoughSharedWalletTxSignatures?: boolean;
-  error?: string;
+  error?: string | Error;
   reachedMaxAmountList?: (string | Wallet.Cardano.AssetId)[];
 }
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/sign-message/SignMessageDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/sign-message/SignMessageDrawer.tsx
@@ -4,7 +4,7 @@ import { useSignMessageState } from './useSignMessageState';
 import { useDrawerConfiguration } from './useDrawerConfiguration';
 import { WalletOwnAddressDropdown, Password as PasswordInput, useSecrets, shortenWalletOwnAddress } from '@lace/core';
 import { TextArea, PostHogAction, toast, useAutoFocus } from '@lace/common';
-import { Flex, Text } from '@input-output-hk/lace-ui-toolkit';
+import { Box, Flex, SummaryExpander, Text, TransactionSummary } from '@input-output-hk/lace-ui-toolkit';
 import { useTranslation } from 'react-i18next';
 import { useAnalyticsContext } from '@providers';
 import styles from './SignMessageDrawer.module.scss';
@@ -22,6 +22,7 @@ export const SignMessageDrawer: React.FC = () => {
     isSigningInProgress,
     signatureObject,
     error,
+    errorObj,
     hardwareWalletError,
     isHardwareWallet,
     performSigning,
@@ -32,6 +33,7 @@ export const SignMessageDrawer: React.FC = () => {
   const [message, setMessage] = useState('');
   const [shouldShowPasswordPrompt, setShouldShowPasswordPrompt] = useState(false);
   const [showHardwareSigningError, setShowHardwareSigningError] = useState(false);
+  const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   // Create a ref to access password without creating dependencies
   const passwordRef = useRef(password);
   passwordRef.current = password;
@@ -176,6 +178,7 @@ export const SignMessageDrawer: React.FC = () => {
       className={styles.hardwareErrorContainer}
     >
       <ResultMessage
+        fullWidth
         status="error"
         title={
           <div data-testid="sign-message-error-title">{t('browserView.transaction.fail.oopsSomethingWentWrong')}</div>
@@ -188,6 +191,21 @@ export const SignMessageDrawer: React.FC = () => {
             <div data-testid="sign-message-error-description2" className={styles.message}>
               {t('browserView.transaction.fail.clickBackAndTryAgain')}
             </div>
+            {typeof errorObj === 'object' && errorObj.message && (
+              <Box w="$fill">
+                <SummaryExpander
+                  onClick={() => setIsSummaryOpen(!isSummaryOpen)}
+                  open={isSummaryOpen}
+                  title={t('browserView.transaction.fail.error-details.label')}
+                  plain
+                >
+                  <TransactionSummary.Other
+                    label={errorObj.name || t('browserView.transaction.fail.error-details.error-name-fallback')}
+                    text={errorObj.message}
+                  />
+                </SummaryExpander>
+              </Box>
+            )}
           </>
         }
       />

--- a/apps/browser-extension-wallet/src/views/browser-view/features/sign-message/useSignMessageState.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/sign-message/useSignMessageState.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-useless-undefined */
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useWalletStore } from '@stores';
@@ -9,12 +10,14 @@ import { HexBlob } from '@cardano-sdk/util';
 import { Password } from '@input-output-hk/lace-ui-toolkit';
 import { useAnalyticsContext } from '@providers';
 import { useSecrets } from '@lace/core';
+import { parseError } from '@src/utils/parse-error';
 
 interface SignMessageState {
   usedAddresses: { address: string; id: number }[];
   isSigningInProgress: boolean;
   signatureObject: Cip30DataSignature | undefined;
   error: string;
+  errorObj?: Error;
   hardwareWalletError: string;
   isHardwareWallet: boolean;
   performSigning: (address: string, message: string, password: Partial<Password>) => void;
@@ -30,6 +33,7 @@ export const useSignMessageState = (): SignMessageState => {
   const [isSigningInProgress, setIsSigningInProgress] = useState(false);
   const [signature, setSignature] = useState<Cip30DataSignature>();
   const [error, setError] = useState<string>('');
+  const [errorObj, setErrorObj] = useState<Error | undefined>();
   const [hardwareWalletError, setHardwareWalletError] = useState<string>('');
 
   const addresses = useObservable(inMemoryWallet?.addresses$);
@@ -38,6 +42,7 @@ export const useSignMessageState = (): SignMessageState => {
     setIsSigningInProgress(false);
     setError('');
     setHardwareWalletError('');
+    setErrorObj(undefined);
   }, []);
 
   const performSigning = useCallback(
@@ -45,6 +50,7 @@ export const useSignMessageState = (): SignMessageState => {
       setIsSigningInProgress(true);
       setError('');
       setHardwareWalletError('');
+      setErrorObj(undefined);
       try {
         const payload = HexBlob.fromBytes(new TextEncoder().encode(message));
         isHardwareWallet
@@ -63,6 +69,7 @@ export const useSignMessageState = (): SignMessageState => {
         setSignature(signatureGenerated);
       } catch (signingError: unknown) {
         logger.error('Error signing message:', signingError);
+        setErrorObj(parseError(signingError));
         if (
           isHardwareWallet &&
           typeof signingError === 'object' &&
@@ -81,7 +88,7 @@ export const useSignMessageState = (): SignMessageState => {
         setIsSigningInProgress(false);
       }
     },
-    [inMemoryWallet, isHardwareWallet, t, analytics, clearSecrets]
+    [isHardwareWallet, analytics, clearSecrets, inMemoryWallet, t]
   );
 
   const usedAddresses =
@@ -95,6 +102,7 @@ export const useSignMessageState = (): SignMessageState => {
     isSigningInProgress,
     signatureObject: signature,
     error,
+    errorObj,
     hardwareWalletError,
     isHardwareWallet,
     performSigning,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingContainer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingContainer.tsx
@@ -23,6 +23,7 @@ import { useSubmitingState } from '@views/browser/features/send-transaction';
 import { SignPolicy, useSecrets } from '@lace/core';
 import { useRewardAccountsData } from '../hooks';
 import { config } from '@src/config';
+import { parseError } from '@src/utils/parse-error';
 
 export const StakingContainer = (): React.ReactElement => {
   // TODO: LW-7575 Remove old staking in post-MVP of multi delegation staking.
@@ -150,7 +151,8 @@ export const StakingContainer = (): React.ReactElement => {
           sharedWalletKey,
           coSigners,
           useRewardAccountsData,
-          govToolUrl: GOV_TOOLS_URLS[environmentName]
+          govToolUrl: GOV_TOOLS_URLS[environmentName],
+          parseError
         }}
       >
         <StakingSkeleton multiDelegationEnabled={multiDelegationEnabled}>

--- a/packages/staking/src/features/Drawer/HwDeviceFail.tsx
+++ b/packages/staking/src/features/Drawer/HwDeviceFail.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/no-multi-comp */
+import { Box, SummaryExpander, TransactionSummary } from '@input-output-hk/lace-ui-toolkit';
 import { Button } from '@lace/common';
 import cn from 'classnames';
 import React from 'react';
@@ -14,15 +15,33 @@ type HwDeviceFailProps = {
 
 export const HwDeviceFail = ({ popupView }: HwDeviceFailProps): React.ReactElement => {
   const { t } = useTranslation();
+  const { txError } = useDelegationPortfolioStore((store) => ({
+    txError: store.txError,
+  }));
 
   return (
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     <div className={cn(styles.container, styles.fail, { [styles.popupView!]: popupView })}>
       <div className={cn(styles.containerFail, styles.staking)}>
         <ResultMessage
+          fullWidth
           status="error"
           title={t('drawer.failure.deviceUpdate.title')}
-          description={t('drawer.failure.deviceUpdate.subTitle')}
+          description={
+            <>
+              {t('drawer.failure.deviceUpdate.subTitle')}
+              {typeof txError === 'object' && txError.message && (
+                <Box w="$fill">
+                  <SummaryExpander title={t('browserView.transaction.fail.error-details.label')} plain>
+                    <TransactionSummary.Other
+                      label={txError.name || t('browserView.transaction.fail.error-details.error-name-fallback')}
+                      text={txError.message}
+                    />
+                  </SummaryExpander>
+                </Box>
+              )}
+            </>
+          }
         />
       </div>
     </div>

--- a/packages/staking/src/features/Drawer/HwDeviceFail.tsx
+++ b/packages/staking/src/features/Drawer/HwDeviceFail.tsx
@@ -2,7 +2,7 @@
 import { Box, SummaryExpander, TransactionSummary } from '@input-output-hk/lace-ui-toolkit';
 import { Button } from '@lace/common';
 import cn from 'classnames';
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOutsideHandles } from '../outside-handles-provider';
 import { useDelegationPortfolioStore } from '../store';
@@ -14,6 +14,7 @@ type HwDeviceFailProps = {
 };
 
 export const HwDeviceFail = ({ popupView }: HwDeviceFailProps): React.ReactElement => {
+  const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const { t } = useTranslation();
   const { txError } = useDelegationPortfolioStore((store) => ({
     txError: store.txError,
@@ -32,7 +33,12 @@ export const HwDeviceFail = ({ popupView }: HwDeviceFailProps): React.ReactEleme
               {t('drawer.failure.deviceUpdate.subTitle')}
               {typeof txError === 'object' && txError.message && (
                 <Box w="$fill">
-                  <SummaryExpander title={t('browserView.transaction.fail.error-details.label')} plain>
+                  <SummaryExpander
+                    onClick={() => setIsSummaryOpen(!isSummaryOpen)}
+                    open={isSummaryOpen}
+                    title={t('browserView.transaction.fail.error-details.label')}
+                    plain
+                  >
                     <TransactionSummary.Other
                       label={txError.name || t('browserView.transaction.fail.error-details.error-name-fallback')}
                       text={txError.message}

--- a/packages/staking/src/features/Drawer/ResultMessage.module.scss
+++ b/packages/staking/src/features/Drawer/ResultMessage.module.scss
@@ -57,4 +57,15 @@
       width: size_unit(11);
     }
   }
+
+  &.fullWidth {
+    width: 100%;
+    .description {
+      max-width: 100%;
+      width: 100%;
+    }
+    .vertical {
+      width: 100%;
+    }
+  }
 }

--- a/packages/staking/src/features/Drawer/ResultMessage.tsx
+++ b/packages/staking/src/features/Drawer/ResultMessage.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import cn from 'classnames';
 import React from 'react';
 import ExclamationSmall from './exclamation-circle-small.svg';
 import Exclamation from './exclamation-circle.svg';
@@ -22,6 +24,7 @@ export interface ResultMessageProps {
   title: React.ReactNode;
   description: React.ReactNode;
   popupView?: boolean;
+  fullWidth?: boolean;
 }
 
 export const ResultMessage = ({
@@ -29,11 +32,12 @@ export const ResultMessage = ({
   title,
   description,
   popupView,
+  fullWidth,
 }: ResultMessageProps): React.ReactElement => {
   const Icon = popupView ? popupViewIconByStatus[status] : iconByStatus[status];
 
   return (
-    <div className={styles.content} data-testid="result-message-content">
+    <div className={cn(styles.content, { [styles.fullWidth!]: fullWidth })} data-testid="result-message-content">
       <Icon className={styles.img} data-testid="result-message-img" />
       <div className={styles.vertical}>
         <h4 className={styles.title} data-testid="result-message-title">

--- a/packages/staking/src/features/Drawer/SignConfirmation.tsx
+++ b/packages/staking/src/features/Drawer/SignConfirmation.tsx
@@ -85,6 +85,7 @@ export const SignConfirmationFooter = (): ReactElement => {
     isSharedWallet,
     sharedWalletKey,
     signPolicy,
+    parseError,
   } = useOutsideHandles();
   const { currentPortfolio, portfolioMutators } = useDelegationPortfolioStore((store) => ({
     currentPortfolio: store.currentPortfolio,
@@ -135,7 +136,7 @@ export const SignConfirmationFooter = (): ReactElement => {
         cleanPasswordInput();
         portfolioMutators.executeCommand({
           data: {
-            error: error instanceof Error ? error.message : (error || '').toString(),
+            error: parseError(error),
           },
           type: 'DrawerFailure',
         });
@@ -143,13 +144,14 @@ export const SignConfirmationFooter = (): ReactElement => {
       }
     }
   }, [
+    analytics,
     setSubmitingTxState,
     signAndSubmitTransaction,
     cleanPasswordInput,
-    analytics,
     setIsRestaking,
     currentPortfolio.length,
     portfolioMutators,
+    parseError,
   ]);
 
   return (

--- a/packages/staking/src/features/Drawer/SignConfirmation.tsx
+++ b/packages/staking/src/features/Drawer/SignConfirmation.tsx
@@ -133,7 +133,12 @@ export const SignConfirmationFooter = (): ReactElement => {
         setSubmitingTxState({ isPasswordValid: false, isSubmitingTx: false });
       } else {
         cleanPasswordInput();
-        portfolioMutators.executeCommand({ type: 'DrawerFailure' });
+        portfolioMutators.executeCommand({
+          data: {
+            error: error instanceof Error ? error.message : (error || '').toString(),
+          },
+          type: 'DrawerFailure',
+        });
         setSubmitingTxState({ isSubmitingTx: false });
       }
     }

--- a/packages/staking/src/features/Drawer/TransactionFail.tsx
+++ b/packages/staking/src/features/Drawer/TransactionFail.tsx
@@ -15,6 +15,7 @@ type TransactionFailProps = {
 };
 
 export const TransactionFail = ({ popupView }: TransactionFailProps): React.ReactElement => {
+  const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const { t } = useTranslation();
   const { isCustomSubmitApiEnabled } = useOutsideHandles();
   const { txError } = useDelegationPortfolioStore((store) => ({
@@ -39,7 +40,12 @@ export const TransactionFail = ({ popupView }: TransactionFailProps): React.Reac
               )}
               {typeof txError === 'object' && txError.message && (
                 <Box w="$fill">
-                  <SummaryExpander title={t('browserView.transaction.fail.error-details.label')} plain>
+                  <SummaryExpander
+                    onClick={() => setIsSummaryOpen(!isSummaryOpen)}
+                    open={isSummaryOpen}
+                    title={t('browserView.transaction.fail.error-details.label')}
+                    plain
+                  >
                     <TransactionSummary.Other
                       label={txError.name || t('browserView.transaction.fail.error-details.error-name-fallback')}
                       text={txError.message}

--- a/packages/staking/src/features/Drawer/TransactionFail.tsx
+++ b/packages/staking/src/features/Drawer/TransactionFail.tsx
@@ -66,6 +66,7 @@ export const TransactionFailFooter = ({ popupView }: TransactionFailProps): Reac
     walletStoreInMemoryWallet: inMemoryWallet,
     walletManagerExecuteWithPassword: executeWithPassword,
     isMultidelegationSupportedByDevice,
+    parseError,
   } = useOutsideHandles();
   // TODO implement analytics for the new flow
   const analytics = {
@@ -120,7 +121,12 @@ export const TransactionFailFooter = ({ popupView }: TransactionFailProps): Reac
       setIsLoading(false);
 
       if (error instanceof Error && error.message === 'MULTIDELEGATION_NOT_SUPPORTED') {
-        portfolioMutators.executeCommand({ type: 'HwSkipToDeviceFailure' });
+        portfolioMutators.executeCommand({
+          data: {
+            error: parseError(error),
+          },
+          type: 'HwSkipToDeviceFailure',
+        });
       }
     }
   };

--- a/packages/staking/src/features/Drawer/TransactionFail.tsx
+++ b/packages/staking/src/features/Drawer/TransactionFail.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-multi-comp */
 import { WalletType } from '@cardano-sdk/web-extension';
-import { Box } from '@input-output-hk/lace-ui-toolkit';
+import { Box, SummaryExpander, TransactionSummary } from '@input-output-hk/lace-ui-toolkit';
 import { Button, WarningBanner } from '@lace/common';
 import cn from 'classnames';
 import React, { useCallback, useState } from 'react';
@@ -28,12 +28,23 @@ export const TransactionFail = ({ popupView }: TransactionFailProps): React.Reac
         <ResultMessage
           status="error"
           title={t('drawer.failure.title')}
+          fullWidth
           description={
             <>
-              <div>{txError || t('drawer.failure.subTitle')}</div>
+              <div>{t('drawer.failure.subTitle')}</div>
               {isCustomSubmitApiEnabled && (
                 <Box mt="$32">
                   <WarningBanner message={t('drawer.failure.customSubmitApiWarning')} />
+                </Box>
+              )}
+              {typeof txError === 'object' && txError.message && (
+                <Box w="$fill">
+                  <SummaryExpander title={t('browserView.transaction.fail.error-details.label')} plain>
+                    <TransactionSummary.Other
+                      label={txError.name || t('browserView.transaction.fail.error-details.error-name-fallback')}
+                      text={txError.message}
+                    />
+                  </SummaryExpander>
                 </Box>
               )}
             </>

--- a/packages/staking/src/features/Drawer/TransactionFail.tsx
+++ b/packages/staking/src/features/Drawer/TransactionFail.tsx
@@ -17,6 +17,9 @@ type TransactionFailProps = {
 export const TransactionFail = ({ popupView }: TransactionFailProps): React.ReactElement => {
   const { t } = useTranslation();
   const { isCustomSubmitApiEnabled } = useOutsideHandles();
+  const { txError } = useDelegationPortfolioStore((store) => ({
+    txError: store.txError,
+  }));
 
   return (
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -27,7 +30,7 @@ export const TransactionFail = ({ popupView }: TransactionFailProps): React.Reac
           title={t('drawer.failure.title')}
           description={
             <>
-              <div>{t('drawer.failure.subTitle')}</div>
+              <div>{txError || t('drawer.failure.subTitle')}</div>
               {isCustomSubmitApiEnabled && (
                 <Box mt="$32">
                   <WarningBanner message={t('drawer.failure.customSubmitApiWarning')} />

--- a/packages/staking/src/features/Drawer/confirmation/StakePoolConfirmationFooter.tsx
+++ b/packages/staking/src/features/Drawer/confirmation/StakePoolConfirmationFooter.tsx
@@ -26,6 +26,7 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
     delegationStoreDelegationTxBuilder: delegationTxBuilder,
     isMultidelegationSupportedByDevice,
     walletManagerExecuteWithPassword,
+    parseError,
   } = useOutsideHandles();
   const { isBuildingTx, stakingError } = useStakingStore();
   const [isConfirmingTx, setIsConfirmingTx] = useState(false);
@@ -76,15 +77,26 @@ export const StakePoolConfirmationFooter = ({ popupView }: StakePoolConfirmation
       portfolioMutators.executeCommand({ type: 'HwSkipToSuccess' });
     } catch (error: any) {
       if (error.message === 'MULTIDELEGATION_NOT_SUPPORTED') {
-        portfolioMutators.executeCommand({ type: 'HwSkipToDeviceFailure' });
+        portfolioMutators.executeCommand({
+          data: {
+            error: parseError(error),
+          },
+          type: 'HwSkipToDeviceFailure',
+        });
       }
-      portfolioMutators.executeCommand({ type: 'HwSkipToFailure' });
+      portfolioMutators.executeCommand({
+        data: {
+          error: parseError(error),
+        },
+        type: 'HwSkipToFailure',
+      });
     } finally {
       setIsConfirmingTx(false);
     }
   }, [
     currentPortfolio.length,
     isHardwareWallet,
+    parseError,
     portfolioMutators,
     setIsRestaking,
     signAndSubmitTransaction,

--- a/packages/staking/src/features/outside-handles-provider/types.ts
+++ b/packages/staking/src/features/outside-handles-provider/types.ts
@@ -112,4 +112,5 @@ export type OutsideHandlesContextValue = {
     poolIdToRewardAccountsMap: Map<string, Wallet.Cardano.RewardAccountInfo[]>;
   };
   govToolUrl: string;
+  parseError: (maybeError: unknown) => Error;
 };

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/commands.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/commands.ts
@@ -105,6 +105,9 @@ export type DiscardChangingPreferences = {
 
 export type DrawerFailure = {
   type: 'DrawerFailure';
+  data: {
+    error: string;
+  };
 };
 
 export type ManageDelegationFromDetails = {

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/commands.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/commands.ts
@@ -106,7 +106,7 @@ export type DiscardChangingPreferences = {
 export type DrawerFailure = {
   type: 'DrawerFailure';
   data: {
-    error: string;
+    error: Error;
   };
 };
 

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/commands.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/commands.ts
@@ -120,10 +120,16 @@ export type HwSkipToSuccess = {
 
 export type HwSkipToFailure = {
   type: 'HwSkipToFailure';
+  data: {
+    error: Error;
+  };
 };
 
 export type HwSkipToDeviceFailure = {
   type: 'HwSkipToDeviceFailure';
+  data: {
+    error: Error;
+  };
 };
 
 export type SetSort = {

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/processExpandedViewCases.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/processExpandedViewCases.ts
@@ -307,11 +307,13 @@ export const processExpandedViewCases: Handler = (params) =>
               AddStakePools: handler<AddStakePools, StatePortfolioManagement, StateBrowsePools>(({ state }) => ({
                 ...state,
                 ...atomicStateMutators.addPoolsFromPreferences({ state }),
+                txError: undefined,
               })),
               CancelDrawer: handler<CancelDrawer, StatePortfolioManagement, StateOverview>(({ state }) => ({
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.Overview }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerContinue: handler<DrawerContinue, StatePortfolioManagement, StatePortfolioManagement>(
                 ({ state }) => ({
@@ -346,6 +348,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.Overview }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerBack: handler<DrawerBack, StatePortfolioManagement, StatePortfolioManagement>(({ state }) => ({
                 ...state,
@@ -385,6 +388,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.Overview }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerBack: handler<DrawerBack, StatePortfolioManagement, StatePortfolioManagement>(({ state }) => ({
                 ...state,
@@ -397,9 +401,10 @@ export const processExpandedViewCases: Handler = (params) =>
                 })
               ),
               DrawerFailure: handler<DrawerFailure, StatePortfolioManagement, StatePortfolioManagement>(
-                ({ state }) => ({
+                ({ state, command: { data } }) => ({
                   ...state,
                   activeDrawerStep: DrawerManagementStep.Failure,
+                  txError: data.error,
                 })
               ),
             },
@@ -412,6 +417,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.Overview }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
             },
             params.command.type,
@@ -423,6 +429,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.Overview }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerContinue: handler<DrawerContinue, StatePortfolioManagement, StatePortfolioManagement>(
                 ({ state }) => ({
@@ -447,6 +454,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.Overview }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerBack: handler<DrawerBack, StatePortfolioManagement, StatePortfolioManagement>(({ state }) => ({
                 ...state,
@@ -478,6 +486,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 selections: state.pendingSelectedPortfolio,
               }),
               pendingSelectedPortfolio: undefined,
+              txError: undefined,
             };
           }),
           DiscardChangingPreferences: handler<DiscardChangingPreferences, StateChangingPreferences, StateBrowsePools>(
@@ -485,6 +494,7 @@ export const processExpandedViewCases: Handler = (params) =>
               ...state,
               activeDelegationFlow: DelegationFlow.BrowsePools,
               pendingSelectedPortfolio: undefined,
+              txError: undefined,
             })
           ),
         },
@@ -498,11 +508,13 @@ export const processExpandedViewCases: Handler = (params) =>
               AddStakePools: handler<AddStakePools, StateNewPortfolio, StateBrowsePools>(({ state }) => ({
                 ...state,
                 ...atomicStateMutators.addPoolsFromPreferences({ state }),
+                txError: undefined,
               })),
               CancelDrawer: handler<CancelDrawer, StateNewPortfolio, StateBrowsePools>(({ state }) => ({
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.BrowsePools }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerContinue: handler<DrawerContinue, StateNewPortfolio, StateNewPortfolio>(({ state }) => ({
                 ...state,
@@ -534,6 +546,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.BrowsePools }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerBack: handler<DrawerBack, StateNewPortfolio, StateNewPortfolio>(({ state }) => ({
                 ...state,
@@ -567,6 +580,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.BrowsePools }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerBack: handler<DrawerBack, StateNewPortfolio, StateNewPortfolio>(({ state }) => ({
                 ...state,
@@ -576,10 +590,13 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 activeDrawerStep: DrawerManagementStep.Success,
               })),
-              DrawerFailure: handler<DrawerContinue, StateNewPortfolio, StateNewPortfolio>(({ state }) => ({
-                ...state,
-                activeDrawerStep: DrawerManagementStep.Failure,
-              })),
+              DrawerFailure: handler<DrawerFailure, StateNewPortfolio, StateNewPortfolio>(
+                ({ state, command: { data } }) => ({
+                  ...state,
+                  activeDrawerStep: DrawerManagementStep.Failure,
+                  txError: data.error,
+                })
+              ),
             },
             params.command.type,
             DrawerManagementStep.Sign
@@ -591,6 +608,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.BrowsePools }),
                 draftPortfolio: undefined,
                 selectedPortfolio: [],
+                txError: undefined,
               })),
             },
             params.command.type,
@@ -602,6 +620,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.BrowsePools }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerContinue: handler<DrawerContinue, StateNewPortfolio, StateNewPortfolio>(({ state }) => ({
                 ...state,
@@ -624,6 +643,7 @@ export const processExpandedViewCases: Handler = (params) =>
                 ...state,
                 ...atomicStateMutators.cancelDrawer({ state, targetFlow: DelegationFlow.BrowsePools }),
                 draftPortfolio: undefined,
+                txError: undefined,
               })),
               DrawerBack: handler<DrawerBack, StateNewPortfolio, StateNewPortfolio>(({ state }) => ({
                 ...state,

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/processExpandedViewCases.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/processExpandedViewCases.ts
@@ -361,15 +361,17 @@ export const processExpandedViewCases: Handler = (params) =>
                 })
               ),
               HwSkipToDeviceFailure: handler<HwSkipToDeviceFailure, StatePortfolioManagement, StatePortfolioManagement>(
-                ({ state }) => ({
+                ({ state, command: { data } }) => ({
                   ...state,
                   activeDrawerStep: DrawerManagementStep.HwDeviceFailure,
+                  txError: data.error,
                 })
               ),
               HwSkipToFailure: handler<HwSkipToFailure, StatePortfolioManagement, StatePortfolioManagement>(
-                ({ state }) => ({
+                ({ state, command: { data } }) => ({
                   ...state,
                   activeDrawerStep: DrawerManagementStep.Failure,
+                  txError: data.error,
                 })
               ),
               HwSkipToSuccess: handler<HwSkipToSuccess, StatePortfolioManagement, StatePortfolioManagement>(
@@ -438,9 +440,10 @@ export const processExpandedViewCases: Handler = (params) =>
                 })
               ),
               HwSkipToDeviceFailure: handler<HwSkipToDeviceFailure, StatePortfolioManagement, StatePortfolioManagement>(
-                ({ state }) => ({
+                ({ state, command: { data } }) => ({
                   ...state,
                   activeDrawerStep: DrawerManagementStep.HwDeviceFailure,
+                  txError: data.error,
                 })
               ),
             },
@@ -557,15 +560,19 @@ export const processExpandedViewCases: Handler = (params) =>
                 activeDrawerStep: DrawerManagementStep.Sign,
               })),
               HwSkipToDeviceFailure: handler<HwSkipToDeviceFailure, StateNewPortfolio, StateNewPortfolio>(
-                ({ state }) => ({
+                ({ state, command: { data } }) => ({
                   ...state,
                   activeDrawerStep: DrawerManagementStep.HwDeviceFailure,
+                  txError: data.error,
                 })
               ),
-              HwSkipToFailure: handler<HwSkipToFailure, StateNewPortfolio, StateNewPortfolio>(({ state }) => ({
-                ...state,
-                activeDrawerStep: DrawerManagementStep.Failure,
-              })),
+              HwSkipToFailure: handler<HwSkipToFailure, StateNewPortfolio, StateNewPortfolio>(
+                ({ state, command: { data } }) => ({
+                  ...state,
+                  activeDrawerStep: DrawerManagementStep.Failure,
+                  txError: data.error,
+                })
+              ),
               HwSkipToSuccess: handler<HwSkipToSuccess, StateNewPortfolio, StateNewPortfolio>(({ state }) => ({
                 ...state,
                 activeDrawerStep: DrawerManagementStep.Success,
@@ -627,9 +634,10 @@ export const processExpandedViewCases: Handler = (params) =>
                 activeDrawerStep: DrawerManagementStep.Success,
               })),
               HwSkipToDeviceFailure: handler<HwSkipToDeviceFailure, StatePortfolioManagement, StatePortfolioManagement>(
-                ({ state }) => ({
+                ({ state, command: { data } }) => ({
                   ...state,
                   activeDrawerStep: DrawerManagementStep.HwDeviceFailure,
+                  txError: data.error,
                 })
               ),
             },

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/types.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/types.ts
@@ -90,6 +90,7 @@ export type StateOverview = MakeState<{
   draftPortfolio: undefined;
   pendingSelectedPortfolio: undefined;
   viewedStakePool: undefined;
+  txError: undefined;
 }>;
 
 export type StateActivity = MakeState<{
@@ -98,6 +99,7 @@ export type StateActivity = MakeState<{
   draftPortfolio: undefined;
   pendingSelectedPortfolio: undefined;
   viewedStakePool: undefined;
+  txError: undefined;
 }>;
 
 export type StateCurrentPoolDetails = MakeState<{
@@ -106,6 +108,7 @@ export type StateCurrentPoolDetails = MakeState<{
   draftPortfolio: undefined;
   pendingSelectedPortfolio: undefined;
   viewedStakePool: StakePoolWithLogo;
+  txError: undefined;
 }>;
 
 export type StatePortfolioManagement = MakeState<{
@@ -114,6 +117,7 @@ export type StatePortfolioManagement = MakeState<{
   draftPortfolio: DraftPortfolioStakePool[];
   pendingSelectedPortfolio: undefined;
   viewedStakePool: undefined;
+  txError?: string;
 }>;
 
 export type StateBrowsePools = MakeState<{
@@ -122,6 +126,7 @@ export type StateBrowsePools = MakeState<{
   draftPortfolio: undefined;
   pendingSelectedPortfolio: undefined;
   viewedStakePool: undefined;
+  txError: undefined;
 }>;
 
 export type StatePoolDetails = MakeState<{
@@ -130,6 +135,7 @@ export type StatePoolDetails = MakeState<{
   draftPortfolio: undefined;
   pendingSelectedPortfolio: undefined;
   viewedStakePool: StakePoolWithLogo;
+  txError: undefined;
 }>;
 
 export type StateNewPortfolio = MakeState<{
@@ -138,6 +144,7 @@ export type StateNewPortfolio = MakeState<{
   draftPortfolio: DraftPortfolioStakePool[];
   pendingSelectedPortfolio: undefined;
   viewedStakePool: undefined;
+  txError?: string;
 }>;
 
 export type StateChangingPreferences = MakeState<{
@@ -146,6 +153,7 @@ export type StateChangingPreferences = MakeState<{
   draftPortfolio: undefined;
   pendingSelectedPortfolio: DraftPortfolioStakePool[];
   viewedStakePool: undefined;
+  txError?: string;
 }>;
 
 export type State =

--- a/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/types.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/stateMachine/types.ts
@@ -117,7 +117,7 @@ export type StatePortfolioManagement = MakeState<{
   draftPortfolio: DraftPortfolioStakePool[];
   pendingSelectedPortfolio: undefined;
   viewedStakePool: undefined;
-  txError?: string;
+  txError?: Error;
 }>;
 
 export type StateBrowsePools = MakeState<{
@@ -144,7 +144,7 @@ export type StateNewPortfolio = MakeState<{
   draftPortfolio: DraftPortfolioStakePool[];
   pendingSelectedPortfolio: undefined;
   viewedStakePool: undefined;
-  txError?: string;
+  txError?: Error;
 }>;
 
 export type StateChangingPreferences = MakeState<{
@@ -153,7 +153,7 @@ export type StateChangingPreferences = MakeState<{
   draftPortfolio: undefined;
   pendingSelectedPortfolio: DraftPortfolioStakePool[];
   viewedStakePool: undefined;
-  txError?: string;
+  txError?: Error;
 }>;
 
 export type State =

--- a/packages/staking/src/features/store/delegationPortfolioStore/useDelegationPortfolioStore.ts
+++ b/packages/staking/src/features/store/delegationPortfolioStore/useDelegationPortfolioStore.ts
@@ -31,6 +31,7 @@ const defaultState: DelegationPortfolioState = {
   selectedPortfolio: [],
   sortField: DEFAULT_SORT_OPTIONS.field,
   sortOrder: DEFAULT_SORT_OPTIONS.order,
+  txError: undefined,
   view: undefined,
   viewedStakePool: undefined,
 };

--- a/packages/translation/src/lib/translations/browser-extension-wallet/en.json
+++ b/packages/translation/src/lib/translations/browser-extension-wallet/en.json
@@ -471,6 +471,8 @@
   "browserView.topNavigationBar.walletStatus.walletSyncing": "Wallet syncing",
   "browserView.transaction.fail.clickBackAndTryAgain": "Click \"Back\" and try again.",
   "browserView.transaction.fail.oopsSomethingWentWrong": "Oops! Something went wrong",
+  "browserView.transaction.fail.error-details.label": "Show issue details",
+  "browserView.transaction.fail.error-details.error-name-fallback": "Error",
   "browserView.transaction.fail.problemSubmittingYourTransaction": "There was a problem submitting your transaction.",
   "browserView.transaction.fail.theTransactionHasNotBeenProceedPleasetryagain": "There was a problem submitting your transaction. Click 'Back to transaction summary' and try again",
   "browserView.transaction.fail.unauthorizedTransaction": "The transaction was not authorized.",


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12046](https://input-output.atlassian.net/browse/LW-12046)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Store errors thrown during tx submission in the related hooks/utils and reuse them later in the errors screen.

## Testing

- send flow
- staking flow

## Screenshots

### send
<img width="400" alt="Screenshot 2025-03-03 at 12 45 55" src="https://github.com/user-attachments/assets/27916fa6-1f34-42fb-b5e2-359c92987a30" />
<img width="400" alt="Screenshot 2025-03-03 at 12 46 01" src="https://github.com/user-attachments/assets/bb65d5d0-bc9f-457f-9530-56396782c96f" />

### staking
<img width="400" alt="Screenshot 2025-03-03 at 12 59 41" src="https://github.com/user-attachments/assets/84da7c36-cc55-441c-9c50-241b1a5feb39" />
<img width="400" alt="Screenshot 2025-03-03 at 12 59 48" src="https://github.com/user-attachments/assets/85b6dc1b-6bd9-4785-b133-0ba7dfb20fbf" />


[LW-12046]: https://input-output.atlassian.net/browse/LW-12046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ