### PR TITLE
fix: relax validation of disallowedCategories of dapp-explorer feature flag payload [LW-12163]

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/types/feature-flags.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/feature-flags.ts
@@ -1,7 +1,8 @@
 import { Cardano } from '@cardano-sdk/core';
-import { z, ZodIssueCode } from 'zod';
+import { z } from 'zod';
 import { DeepRequired } from 'utility-types';
 import { JsonType } from 'posthog-js';
+import { commonSchema, dappExplorerSchema } from '@providers/PostHogClientProvider/schema';
 
 export enum ExperimentName {
   CREATE_PAPER_WALLET = 'create-paper-wallet',
@@ -20,80 +21,15 @@ export type FeatureFlags = {
 
 export type FeatureFlagsByNetwork = Record<Cardano.NetworkMagics, FeatureFlags>;
 
-const parseJsonPreprocessor = (value: unknown, ctx: z.RefinementCtx) => {
-  if (typeof value === 'string') {
-    try {
-      return JSON.parse(value);
-    } catch (error) {
-      ctx.addIssue({
-        code: ZodIssueCode.custom,
-        message: (error as Error).message
-      });
-    }
-  }
-
-  return value;
-};
-
 // currently schema.parse() method returns partially valid type - all properties are optional
 // so we use extra types with DeepRequired, these types can be removed after Lace uses strict null checks
-
-export enum NetworkName {
-  preview = 'preview',
-  preprod = 'preprod',
-  mainnet = 'mainnet',
-  sanchonet = 'sanchonet'
-}
-
-export const networksEnumSchema = z.enum(Object.values(NetworkName) as [NetworkName, ...NetworkName[]]);
-export type NetworksEnumSchema = z.infer<typeof networksEnumSchema>;
-
-const commonSchema = z.object({
-  allowedNetworks: z.array(networksEnumSchema)
-});
 export type FeatureFlagCommonSchema = DeepRequired<z.infer<typeof commonSchema>>;
-
-// has to be aligned with the response from GET `/dapps/categories`
-// @see https://apis-portal.dappradar.com/full-api-reference#get-/dapps/categories
-export const dappCategoriesEnumSchema = z.enum([
-  'games',
-  'defi',
-  'collectibles',
-  'marketplaces',
-  'high-risk',
-  'gambling',
-  'exchanges',
-  'social',
-  'other'
-]);
-export type DappCategoriesEnumSchema = z.infer<typeof dappCategoriesEnumSchema>;
-
-const dappExplorerSchema = commonSchema.merge(
-  z.object({
-    disallowedDapps: z.object({
-      legalIssues: z.array(z.number()),
-      connectivityIssues: z.array(z.number())
-    }),
-    disallowedCategories: z.object({
-      legalIssues: z.array(dappCategoriesEnumSchema)
-    })
-  })
-);
 export type FeatureFlagDappExplorerSchema = DeepRequired<z.infer<typeof dappExplorerSchema>>;
-
-export const featureFlagSchema = {
-  common: z.preprocess(parseJsonPreprocessor, commonSchema),
-  dappExplorer: z.preprocess(parseJsonPreprocessor, dappExplorerSchema)
-};
-
-type FeatureFlagCommonPayload = {
-  allowedNetworks: ('preview' | 'preprod' | 'mainnet' | 'sanchonet')[];
-};
 
 // Using `false` as a fallback type for the payload, as it can be optional, and we (sadly) don't have
 // strict null checks enabled so `false` is a replacement for `undefined` in this case
 // eslint-disable-next-line @typescript-eslint/ban-types
-type FeatureFlagPayload<T extends Record<string, unknown> = {}> = (FeatureFlagCommonPayload & T) | false;
+type FeatureFlagPayload<T extends Record<string, unknown> = {}> = (FeatureFlagCommonSchema & T) | false;
 
 type FeatureFlagCustomPayloads = {
   [ExperimentName.DAPP_EXPLORER]: FeatureFlagPayload<FeatureFlagDappExplorerSchema>;

--- a/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/PostHogClient.ts
+++ b/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/PostHogClient.ts
@@ -30,13 +30,11 @@ import {
   FeatureFlagCommonSchema,
   FeatureFlagDappExplorerSchema,
   FeatureFlagPayloads,
-  featureFlagSchema,
   FeatureFlagsByNetwork,
-  NetworksEnumSchema,
-  networksEnumSchema,
   FeatureFlags,
   RawFeatureFlagPayloads
 } from '@lib/scripts/types/feature-flags';
+import { featureFlagSchema, networksEnumSchema, NetworksEnumSchema } from '../schema';
 
 const isNetworkOfExpectedSchema = (n: string): n is NetworksEnumSchema => networksEnumSchema.safeParse(n).success;
 

--- a/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/config.ts
+++ b/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/config.ts
@@ -3,9 +3,9 @@ import {
   ExperimentName,
   FeatureFlagPayloads,
   FeatureFlags,
-  FeatureFlagsByNetwork,
-  NetworkName
+  FeatureFlagsByNetwork
 } from '@lib/scripts/types/feature-flags';
+import { NetworkName } from '@providers/PostHogClientProvider/schema';
 
 export const POSTHOG_ENABLED = process.env.USE_POSTHOG_ANALYTICS === 'true';
 export const POSTHOG_OPTED_OUT_EVENTS_DISABLED = process.env.USE_POSTHOG_ANALYTICS_FOR_OPTED_OUT === 'false';

--- a/apps/browser-extension-wallet/src/providers/PostHogClientProvider/schema.ts
+++ b/apps/browser-extension-wallet/src/providers/PostHogClientProvider/schema.ts
@@ -1,0 +1,47 @@
+import { z, ZodIssueCode } from 'zod';
+
+const parseJsonPreprocessor = (value: unknown, ctx: z.RefinementCtx) => {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      ctx.addIssue({
+        code: ZodIssueCode.custom,
+        message: (error as Error).message
+      });
+    }
+  }
+
+  return value;
+};
+
+export enum NetworkName {
+  preview = 'preview',
+  preprod = 'preprod',
+  mainnet = 'mainnet',
+  sanchonet = 'sanchonet'
+}
+
+export const networksEnumSchema = z.enum(Object.values(NetworkName) as [NetworkName, ...NetworkName[]]);
+export type NetworksEnumSchema = z.infer<typeof networksEnumSchema>;
+
+export const commonSchema = z.object({
+  allowedNetworks: z.array(networksEnumSchema)
+});
+
+export const dappExplorerSchema = commonSchema.merge(
+  z.object({
+    disallowedDapps: z.object({
+      legalIssues: z.array(z.number()),
+      connectivityIssues: z.array(z.number())
+    }),
+    disallowedCategories: z.object({
+      legalIssues: z.array(z.string())
+    })
+  })
+);
+
+export const featureFlagSchema = {
+  common: z.preprocess(parseJsonPreprocessor, commonSchema),
+  dappExplorer: z.preprocess(parseJsonPreprocessor, dappExplorerSchema)
+};

--- a/apps/browser-extension-wallet/src/views/browser-view/features/dapp/explorer/components/SimpleView/SimpleViewFilters/CategoryChip/mapper.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/dapp/explorer/components/SimpleView/SimpleViewFilters/CategoryChip/mapper.tsx
@@ -10,7 +10,6 @@ import ArrowChartUp from '../../../../../../../../../assets/icons/arrow-chart-up
 import ArrowsOppositeDirection from '../../../../../../../../../assets/icons/arrows-opposite-direction.component.svg';
 import Ticket from '../../../../../../../../../assets/icons/ticket-icon.component.svg';
 import Persons from '../../../../../../../../../assets/icons/persons.component.svg';
-import { dappCategoriesEnumSchema } from '@lib/scripts/types/feature-flags';
 
 const mapOfCategoryToIcon: Record<DefaultCategory, React.ComponentType> = {
   [DefaultCategory.All]: ShowAll,
@@ -26,7 +25,7 @@ const mapOfCategoryToIcon: Record<DefaultCategory, React.ComponentType> = {
 };
 
 const isOneOfDefaultCategories = (category: string): category is DefaultCategory =>
-  dappCategoriesEnumSchema.safeParse(category).success || category === DefaultCategory.All;
+  Object.keys(mapOfCategoryToIcon).includes(category) || category === DefaultCategory.All;
 
 export const mapCategory = (category: string): React.ReactNode => {
   // eslint-disable-next-line unicorn/no-null


### PR DESCRIPTION
# Checklist

- [x] JIRA - [\<link>](https://input-output.atlassian.net/browse/LW-12163)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

- Removed allowed categories to be provided by the `disallowedCategories` property of the `dapp-explorer` FF payload
- Slightly reorganised code by moving schema validation logic to the PostHogClient space where it is actually used
