### PR TITLE
fix: [lw-11911] fix negative vs positive activity amount styling

### DIFF
--- a/packages/core/src/ui/components/Activity/AssetActivityItem.tsx
+++ b/packages/core/src/ui/components/Activity/AssetActivityItem.tsx
@@ -100,16 +100,6 @@ const ActivityStatusIcon = ({ status, type }: ActivityStatusIconProps) => {
   }
 };
 
-const negativeBalanceStyling: Set<Partial<ActivityType>> = new Set([
-  TransactionActivityType.outgoing,
-  DelegationActivityType.delegationRegistration,
-  ConwayEraCertificatesTypes.Registration,
-  ConwayEraCertificatesTypes.RegisterDelegateRepresentative,
-  TransactionActivityType.self,
-  DelegationActivityType.delegation,
-  TransactionActivityType.awaitingCosignatures
-]);
-
 // TODO: Handle pluralization and i18n of assetsNumber when we will have more than Ada.
 export const AssetActivityItem = ({
   amount,
@@ -200,7 +190,7 @@ export const AssetActivityItem = ({
     assetAmountContent
   );
 
-  const isNegativeBalance = type && negativeBalanceStyling.has(type);
+  const isNegativeBalance = amount.startsWith('-');
 
   return (
     <div data-testid="asset-activity-item" onClick={onClick} className={styles.assetActivityItem}>


### PR DESCRIPTION
# Checklist

- [ ] JIRA - [LW-11911](https://input-output.atlassian.net/browse/LW-11911)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Current implementation would treat next type of activities: `delegationRegistration` | `RegistrationCertificate` | `RegisterDelegateRepresentativeCertificate` | `self` | `delegation` | `awaitingCosignatures` and `outgoing` as an activity with negative balance, thus they would have their total amount coloured in black. Changing this behaviour into `positive numbers are green, negative numbers are black, zero is black` would be more accurate.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-11911]: https://input-output.atlassian.net/browse/LW-11911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ