### PR TITLE
feat: add error handling to the activity infinite scroll [LW-12392]

### DIFF
--- a/apps/browser-extension-wallet/src/features/activity/components/Activity.tsx
+++ b/apps/browser-extension-wallet/src/features/activity/components/Activity.tsx
@@ -28,7 +28,9 @@ export const Activity = (): React.ReactElement => {
     analytics.sendEventToPostHog(PostHogAction.ActivityActivityActivityRowClick);
   }, [analytics]);
 
-  const { walletActivities, mightHaveMore, loadedTxLength, loadMore } = useWalletActivitiesPaginated({ sendAnalytics });
+  const { walletActivities, mightHaveMore, loadedTxLength, loadMore, retry, error } = useWalletActivitiesPaginated({
+    sendAnalytics
+  });
 
   const debouncedLoadMore = useMemo(() => debounce(loadMore, loadMoreDebounce), [loadMore]);
 
@@ -59,6 +61,8 @@ export const Activity = (): React.ReactElement => {
             lists={walletActivities}
             scrollableTarget="contentLayout"
             dataLength={loadedTxLength}
+            loadingError={error}
+            retryLoading={retry}
           />
         )}
         {walletActivities?.length === 0 && (

--- a/apps/browser-extension-wallet/src/hooks/useWalletActivities.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletActivities.ts
@@ -6,7 +6,7 @@ import noop from 'lodash/noop';
 import { mapWalletActivities } from '@src/stores/slices';
 import { Wallet } from '@lace/cardano';
 import { AssetActivityListProps, useItemsPageSize } from '@lace/core';
-import { useTxHistoryLoader } from './useTxHistoryLoader';
+import { UseTxHistoryLoader, useTxHistoryLoader } from './useTxHistoryLoader';
 import { useAsyncSwitchMap } from '@hooks/useAsyncSwitchMap';
 
 type UseWalletActivitiesProps = {
@@ -58,11 +58,12 @@ export const useWalletActivities = ({
   };
 };
 
-export type WalletActivitiesPaginated = Pick<WalletActivities, 'walletActivities'> & {
-  loadMore: () => void;
-  mightHaveMore: boolean;
-  loadedTxLength?: number;
-};
+export type WalletActivitiesPaginated = Pick<WalletActivities, 'walletActivities'> &
+  Pick<UseTxHistoryLoader, 'error' | 'retry'> & {
+    loadMore: () => void;
+    mightHaveMore: boolean;
+    loadedTxLength?: number;
+  };
 
 export const useWalletActivitiesPaginated = ({
   sendAnalytics
@@ -85,7 +86,7 @@ export const useWalletActivitiesPaginated = ({
 
   const pageSize = useItemsPageSize();
 
-  const { loadMore: txHistoryLoaderLoadMore, loadedHistory } = useTxHistoryLoader(pageSize);
+  const { loadMore: txHistoryLoaderLoadMore, retry, error, loadedHistory } = useTxHistoryLoader(pageSize);
 
   const fetchActivitiesProps = useMemo(
     () => ({
@@ -168,6 +169,8 @@ export const useWalletActivitiesPaginated = ({
     walletActivities,
     mightHaveMore: loadedHistory?.mightHaveMore,
     loadedTxLength: loadedHistory?.transactions?.slice(0, currentPage * pageSize).length,
-    loadMore
+    loadMore,
+    retry,
+    error
   };
 };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityLayout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/ActivityLayout.tsx
@@ -29,7 +29,9 @@ export const ActivityLayout = (): ReactElement => {
     analytics.sendEventToPostHog(PostHogAction.ActivityActivityActivityRowClick);
   }, [analytics]);
 
-  const { walletActivities, mightHaveMore, loadedTxLength, loadMore } = useWalletActivitiesPaginated({ sendAnalytics });
+  const { walletActivities, mightHaveMore, loadedTxLength, loadMore, retry, error } = useWalletActivitiesPaginated({
+    sendAnalytics
+  });
   const total = useObservable(inMemoryWallet.balance.utxo.total$);
 
   const titles = {
@@ -103,6 +105,8 @@ export const ActivityLayout = (): ReactElement => {
               lists={walletActivities}
               scrollableTarget={LACE_APP_ID}
               dataLength={loadedTxLength}
+              loadingError={error}
+              retryLoading={retry}
             />
           )}
           {walletActivities?.length === 0 && (

--- a/packages/core/src/ui/assets/icons/refresh.component.svg
+++ b/packages/core/src/ui/assets/icons/refresh.component.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 4V9H4.58152M19.9381 11C19.446 7.05369 16.0796 4 12 4C8.64262 4 5.76829 6.06817 4.58152 9M4.58152 9H9M20 20V15H19.4185M19.4185 15C18.2317 17.9318 15.3574 20 12 20C7.92038 20 4.55399 16.9463 4.06189 13M19.4185 15H15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/core/src/ui/components/Activity/AssetActivityList.module.scss
+++ b/packages/core/src/ui/components/Activity/AssetActivityList.module.scss
@@ -104,3 +104,11 @@
     margin-bottom: size_unit(0.5);
   }
 }
+
+// strengthening the selector specificity
+.retryButtonIcon.retryButtonIcon.retryButtonIcon {
+  path {
+    fill: none;
+    stroke: currentColor;
+  }
+}

--- a/packages/core/src/ui/components/Activity/GroupedAssetActivityList.tsx
+++ b/packages/core/src/ui/components/Activity/GroupedAssetActivityList.tsx
@@ -5,6 +5,8 @@ import InfiniteScroll from 'react-infinite-scroll-component';
 import { AssetActivityList, AssetActivityListProps } from './AssetActivityList';
 import styles from './AssetActivityList.module.scss';
 import isNumber from 'lodash/isNumber';
+import * as UIToolkit from '@input-output-hk/lace-ui-toolkit';
+import { useTranslation } from 'react-i18next';
 
 const { Text } = Typography;
 
@@ -35,6 +37,8 @@ export interface GroupedAssetActivityListProps {
   loadMore: () => void;
   hasMore: boolean;
   loadFirstChunk?: boolean;
+  loadingError?: Error | null;
+  retryLoading?: () => void;
 }
 export const GroupedAssetActivityList = ({
   lists,
@@ -45,8 +49,11 @@ export const GroupedAssetActivityList = ({
   isDrawerView,
   loadMore,
   hasMore,
-  loadFirstChunk
+  loadFirstChunk,
+  loadingError,
+  retryLoading
 }: GroupedAssetActivityListProps): React.ReactElement => {
+  const { t } = useTranslation();
   const next = useCallback(() => {
     loadMore();
   }, [loadMore]);
@@ -57,12 +64,18 @@ export const GroupedAssetActivityList = ({
   }, []);
 
   const loader = useMemo(
-    () => (
-      <div data-testid="infinite-scroll-skeleton">
-        <Skeleton active avatar />
-      </div>
-    ),
-    []
+    () =>
+      loadingError ? (
+        <UIToolkit.Flex mb="$32" gap="$8" flexDirection="column" alignItems="center" testId="next-page-loading-error">
+          <UIToolkit.Text.Body.Large>{t('core.activity.loaderError.message')}</UIToolkit.Text.Body.Large>
+          <UIToolkit.Button.CallToAction label={t('core.activity.loaderError.buttonLabel')} onClick={retryLoading} />
+        </UIToolkit.Flex>
+      ) : (
+        <div data-testid="infinite-scroll-skeleton">
+          <Skeleton active avatar />
+        </div>
+      ),
+    [loadingError, retryLoading, t]
   );
 
   return (

--- a/packages/core/src/ui/components/Activity/GroupedAssetActivityList.tsx
+++ b/packages/core/src/ui/components/Activity/GroupedAssetActivityList.tsx
@@ -7,6 +7,7 @@ import styles from './AssetActivityList.module.scss';
 import isNumber from 'lodash/isNumber';
 import * as UIToolkit from '@input-output-hk/lace-ui-toolkit';
 import { useTranslation } from 'react-i18next';
+import { ReactComponent as RefreshIcon } from '../../assets/icons/refresh.component.svg';
 
 const { Text } = Typography;
 
@@ -66,9 +67,22 @@ export const GroupedAssetActivityList = ({
   const loader = useMemo(
     () =>
       loadingError ? (
-        <UIToolkit.Flex mb="$32" gap="$8" flexDirection="column" alignItems="center" testId="next-page-loading-error">
-          <UIToolkit.Text.Body.Large>{t('core.activity.loaderError.message')}</UIToolkit.Text.Body.Large>
-          <UIToolkit.Button.CallToAction label={t('core.activity.loaderError.buttonLabel')} onClick={retryLoading} />
+        <UIToolkit.Flex
+          mb="$96"
+          mt="$32"
+          gap="$24"
+          flexDirection="column"
+          alignItems="center"
+          testId="next-page-loading-error"
+        >
+          <UIToolkit.Text.Body.Normal weight="$medium">
+            {t('core.activity.loaderError.message')}
+          </UIToolkit.Text.Body.Normal>
+          <UIToolkit.Button.Secondary
+            icon={<RefreshIcon className={styles.retryButtonIcon} />}
+            label={t('core.activity.loaderError.buttonLabel')}
+            onClick={retryLoading}
+          />
         </UIToolkit.Flex>
       ) : (
         <div data-testid="infinite-scroll-skeleton">

--- a/packages/translation/src/lib/translations/core/en.json
+++ b/packages/translation/src/lib/translations/core/en.json
@@ -1,4 +1,6 @@
 {
+  "core.activity.loaderError.message": "Failed to load more activity",
+  "core.activity.loaderError.buttonLabel": "Retry",
   "core.activityDetails.address": "Address",
   "core.activityDetails.AuthorizeCommitteeHotCertificate": "Authorize Committee",
   "core.activityDetails.certificate": "Certificate",


### PR DESCRIPTION
# Checklist

- [x] JIRA - [\<link>](https://input-output.atlassian.net/browse/LW-12392)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

- catching error in the observable responsible for fetching data
- displaying a message and retry button in place of skeleton if an error occured

## Testing

Try different ways of switching to offline vs loading activity. Switch to offline:
- before loading lace
- before entering activity
- after initial load of activity
- after a few scrolls
- after switching back to online

## Screenshots

![image](https://github.com/user-attachments/assets/25a80c3e-edeb-412e-ae3b-9ffc66ca4d3c)
