### PR TITLE
Chore/lw 11069 remove multisig key from wallet metadata

### DIFF
--- a/apps/browser-extension-wallet/src/features/delegation/components/MultiDelegationStakingPopup.tsx
+++ b/apps/browser-extension-wallet/src/features/delegation/components/MultiDelegationStakingPopup.tsx
@@ -86,7 +86,7 @@ export const MultiDelegationStakingPopup = (): JSX.Element => {
   const wallet = useCurrentWallet();
   const wallets = useObservable(walletRepository.wallets$);
 
-  const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+  const parentMultiSigAccount = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
   const signPolicy = useSignPolicy(wallet, 'staking');
 
   const sendAnalytics = useCallback(() => {
@@ -172,7 +172,7 @@ export const MultiDelegationStakingPopup = (): JSX.Element => {
         isCustomSubmitApiEnabled: getCustomSubmitApiForNetwork(environmentName).status,
         isSharedWallet,
         signPolicy,
-        sharedWalletKey: parentWalletCIP1854Account?.extendedAccountPublicKey,
+        sharedWalletKey: parentMultiSigAccount?.extendedAccountPublicKey,
         coSigners: wallet?.metadata?.coSigners,
         useRewardAccountsData,
         govToolUrl: GOV_TOOLS_URLS[environmentName],

--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -85,7 +85,7 @@ interface CreateSharedWalletParams {
   quorumRules: QuorumOptionValue;
 }
 
-interface CreateCIP1854AccountParams {
+interface CreateMultiSigAccountParams {
   accountIndex?: number;
   ownSignerWalletId: WalletId;
   sharedWalletKey: Wallet.Crypto.Bip32PublicKeyHex;
@@ -149,7 +149,7 @@ export interface UseWalletManager {
   getSharedWalletExtendedPublicKey: (passphrase: Uint8Array) => Promise<Wallet.Crypto.Bip32PublicKeyHex>;
   enableCustomNode: (network: EnvironmentTypes, value: string) => Promise<void>;
   generateSharedWalletKey: GenerateSharedWalletKeyFn;
-  createCIP1854Account: (props: CreateCIP1854AccountParams) => Promise<void>;
+  createMultiSigAccount: (props: CreateMultiSigAccountParams) => Promise<void>;
 }
 
 const clearBytes = (bytes: Uint8Array) => {
@@ -883,8 +883,8 @@ export const useWalletManager = (): UseWalletManager => {
     [getSharedWalletExtendedPublicKey]
   );
 
-  const createCIP1854Account = useCallback<UseWalletManager['createCIP1854Account']>(
-    async ({ accountIndex = 0, ownSignerWalletId, sharedWalletKey }: CreateCIP1854AccountParams): Promise<void> => {
+  const createMultiSigAccount = useCallback<UseWalletManager['createMultiSigAccount']>(
+    async ({ accountIndex = 0, ownSignerWalletId, sharedWalletKey }: CreateMultiSigAccountParams): Promise<void> => {
       await walletRepository.addAccount({
         accountIndex,
         extendedAccountPublicKey: sharedWalletKey,
@@ -1022,7 +1022,7 @@ export const useWalletManager = (): UseWalletManager => {
     getMnemonic,
     enableCustomNode,
     generateSharedWalletKey,
-    createCIP1854Account,
+    createMultiSigAccount,
     getSharedWalletExtendedPublicKey
   };
 };

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/userIdService.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/userIdService.ts
@@ -1,4 +1,4 @@
-import { WalletManagerApi, WalletRepositoryApi, WalletType } from '@cardano-sdk/web-extension';
+import { WalletManagerApi, WalletRepositoryApi } from '@cardano-sdk/web-extension';
 import { Wallet } from '@lace/cardano';
 import { BehaviorSubject, ReplaySubject, combineLatest, distinctUntilChanged } from 'rxjs';
 import { getActiveWallet, hashExtendedAccountPublicKey } from '@lib/scripts/background/util';
@@ -78,11 +78,7 @@ export class UserIdService implements UserIdServiceInterface {
     }
 
     if (!this.walletBasedUserId) {
-      const extendedAccountPublicKey =
-        active.wallet.type === WalletType.Script
-          ? active.wallet.metadata.multiSigExtendedPublicKey
-          : active.account.extendedAccountPublicKey;
-      this.walletBasedUserId = this.generateWalletBasedUserId(extendedAccountPublicKey);
+      this.walletBasedUserId = this.generateWalletBasedUserId(active.account.extendedAccountPublicKey);
 
       if (this.userTrackingType$.value !== UserTrackingType.Enhanced) {
         this.userTrackingType$.next(UserTrackingType.Enhanced);

--- a/apps/browser-extension-wallet/src/views/browser-view/components/QRPublicKeyDrawer/QRPublicKeyDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/QRPublicKeyDrawer/QRPublicKeyDrawer.tsx
@@ -1,19 +1,27 @@
 import React from 'react';
-import { InfoWallet, useSharedWalletData } from '@lace/core';
+import { InfoWallet } from '@lace/core';
 import { useTheme } from '@providers/ThemeProvider';
 import { useWalletStore } from '../../../../stores';
 import { useTranslation } from 'react-i18next';
 import styles from './QRPublicKeyDrawer.module.scss';
 import { getQRCodeOptions } from '@src/utils/qrCodeHelpers';
 import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
-import { useCurrentWallet } from '@hooks';
+import { useCurrentWallet, useWalletManager } from '@hooks';
+import { useObservable } from '@lace/common';
+import { getParentWalletCIP1854Account } from '@lib/scripts/background/util';
 
 const useWalletInformation = () => {
+  const { walletRepository } = useWalletManager();
+  const wallets = useObservable(walletRepository.wallets$);
   const wallet = useCurrentWallet();
-  const { sharedWalletKey } = useSharedWalletData(wallet);
+
+  const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+
   return useWalletStore((state) => ({
     name: state?.walletInfo?.name,
-    publicKey: state?.isSharedWallet ? sharedWalletKey : state?.cardanoWallet.source.account.extendedAccountPublicKey
+    publicKey: state?.isSharedWallet
+      ? parentWalletCIP1854Account?.extendedAccountPublicKey
+      : state?.cardanoWallet.source.account.extendedAccountPublicKey
   }));
 };
 

--- a/apps/browser-extension-wallet/src/views/browser-view/components/QRPublicKeyDrawer/QRPublicKeyDrawer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/QRPublicKeyDrawer/QRPublicKeyDrawer.tsx
@@ -15,12 +15,12 @@ const useWalletInformation = () => {
   const wallets = useObservable(walletRepository.wallets$);
   const wallet = useCurrentWallet();
 
-  const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+  const parentMultiSigAccount = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
 
   return useWalletStore((state) => ({
     name: state?.walletInfo?.name,
     publicKey: state?.isSharedWallet
-      ? parentWalletCIP1854Account?.extendedAccountPublicKey
+      ? parentMultiSigAccount?.extendedAccountPublicKey
       : state?.cardanoWallet.source.account.extendedAccountPublicKey
   }));
 };

--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/SharedWalletTransactionDetailsWrapper.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/SharedWalletTransactionDetailsWrapper.tsx
@@ -57,8 +57,8 @@ export const SharedWalletTransactionDetailsWrapper = withAddressBookContext(
     const wallets = useObservable(walletRepository.wallets$);
     const wallet = useCurrentWallet();
 
-    const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
-    const sharedWalletKey = parentWalletCIP1854Account?.extendedAccountPublicKey;
+    const parentMultiSigAccount = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+    const sharedWalletKey = parentMultiSigAccount?.extendedAccountPublicKey;
 
     const coSigners = wallet?.metadata?.coSigners;
     const signPolicy = useSignPolicy(wallet, 'payment');

--- a/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/SharedWalletTransactionDetailsWrapper.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/activity/components/SharedWalletTransactionDetailsWrapper.tsx
@@ -4,16 +4,17 @@ import {
   hasSigned,
   SharedWalletTransactionDetails,
   TxSummary,
-  useSharedWalletData,
   useSignPolicy
 } from '@lace/core';
 import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useWalletStore } from '@stores';
 import { Wallet } from '@lace/cardano';
-import { useCurrentWallet } from '@hooks';
+import { useCurrentWallet, useWalletManager } from '@hooks';
 import { AddressListType, getTransactionData } from '@views/browser/features/activity';
 import { useAddressBookContext, withAddressBookContext } from '@src/features/address-book/context';
 import { TransactionActivityDetail, TxDirection, TxDirections } from '@types';
+import { useObservable } from '@lace/common';
+import { getParentWalletCIP1854Account } from '@lib/scripts/background/util';
 
 interface SharedWalletTransactionDetailsProxyProps {
   amountTransformer: (amount: string) => string;
@@ -52,8 +53,14 @@ export const SharedWalletTransactionDetailsWrapper = withAddressBookContext(
       walletInfo,
       activityDetail
     } = useWalletStore();
+    const { walletRepository } = useWalletManager();
+    const wallets = useObservable(walletRepository.wallets$);
     const wallet = useCurrentWallet();
-    const { sharedWalletKey, coSigners } = useSharedWalletData(wallet);
+
+    const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+    const sharedWalletKey = parentWalletCIP1854Account?.extendedAccountPublicKey;
+
+    const coSigners = wallet?.metadata?.coSigners;
     const signPolicy = useSignPolicy(wallet, 'payment');
 
     const [transactionCosigners, setTransactionCosigners] = useState<CoSignersListItem[]>([]);

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -95,8 +95,8 @@ export const Footer = withAddressBookContext(
     const wallets = useObservable(walletRepository.wallets$);
     const wallet = useCurrentWallet();
 
-    const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
-    const sharedWalletKey = parentWalletCIP1854Account?.extendedAccountPublicKey;
+    const parentMultiSigAccount = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+    const sharedWalletKey = parentMultiSigAccount?.extendedAccountPublicKey;
     const policy = useSignPolicy(wallet, 'payment');
 
     const isSummaryStep = currentSection.currentSection === Sections.SUMMARY;

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SendTransactionDrawer/Footer.tsx
@@ -6,7 +6,7 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import React, { useCallback, useMemo, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, logger } from '@lace/common';
+import { Button, logger, useObservable } from '@lace/common';
 import { Wallet } from '@lace/cardano';
 import styles from './Footer.module.scss';
 import EditIcon from '@assets/icons/edit.component.svg';
@@ -25,7 +25,7 @@ import { useHandleClose } from './Header';
 import { useWalletStore } from '@src/stores';
 import { AddressFormFooter } from './AddressFormFooter';
 import { METADATA_MAX_LENGTH, sectionsConfig } from '../../constants';
-import { useCurrentWallet, useHandleResolver, useNetwork } from '@hooks';
+import { useCurrentWallet, useHandleResolver, useNetwork, useWalletManager } from '@hooks';
 import { PostHogAction, TxCreationType, TX_CREATION_TYPE_KEY } from '@providers/AnalyticsProvider/analyticsTracker';
 import { buttonIds } from '@hooks/useEnterKeyPress';
 import { AssetPickerFooter } from './AssetPickerFooter';
@@ -40,9 +40,10 @@ import { txSubmitted$ } from '@providers/AnalyticsProvider/onChain';
 import { withSignTxConfirmation } from '@lib/wallet-api-ui';
 import type { TranslationKey } from '@lace/translation';
 import { Serialization } from '@cardano-sdk/core';
-import { exportMultisigTransaction, PasswordObj, useSecrets, useSharedWalletData, useSignPolicy } from '@lace/core';
+import { exportMultisigTransaction, PasswordObj, useSecrets, useSignPolicy } from '@lace/core';
 import { WalletType } from '@cardano-sdk/web-extension';
 import { parseError } from '@src/utils/parse-error';
+import { getParentWalletCIP1854Account } from '@lib/scripts/background/util';
 
 export const nextStepBtnLabels: Partial<Record<Sections, TranslationKey>> = {
   [Sections.FORM]: 'browserView.transaction.send.footer.review',
@@ -90,8 +91,12 @@ export const Footer = withAddressBookContext(
     const { list: addressList, utils } = useAddressBookContext();
     const { updateRecord: updateAddress, deleteRecord: deleteAddress } = utils;
     const handleResolver = useHandleResolver();
+    const { walletRepository } = useWalletManager();
+    const wallets = useObservable(walletRepository.wallets$);
     const wallet = useCurrentWallet();
-    const { sharedWalletKey } = useSharedWalletData(wallet);
+
+    const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+    const sharedWalletKey = parentWalletCIP1854Account?.extendedAccountPublicKey;
     const policy = useSignPolicy(wallet, 'payment');
 
     const isSummaryStep = currentSection.currentSection === Sections.SUMMARY;

--- a/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SharedWalletSendTransactionSummary.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/send-transaction/components/SharedWalletSendTransactionSummary.tsx
@@ -30,8 +30,8 @@ const SharedWalletSendTransactionSummary = ({ rows, fee }: SharedWalletSendTrans
   const wallets = useObservable(walletRepository.wallets$);
   const wallet = useCurrentWallet();
 
-  const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
-  const sharedWalletKey = parentWalletCIP1854Account?.extendedAccountPublicKey;
+  const parentMultiSigAccount = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+  const sharedWalletKey = parentMultiSigAccount?.extendedAccountPublicKey;
 
   const coSigners = wallet?.metadata?.coSigners;
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsRemoveWallet.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsRemoveWallet.tsx
@@ -15,6 +15,7 @@ import cn from 'classnames';
 import { getWalletAccountsQtyString } from '@src/utils/get-wallet-count-string';
 import { Wallet } from '@lace/cardano';
 import { AnyWallet, WalletType } from '@cardano-sdk/web-extension';
+import * as KeyManagement from '@cardano-sdk/key-management';
 
 const { Title, Text } = Typography;
 
@@ -23,7 +24,7 @@ export const SettingsRemoveWallet = ({ popupView }: { popupView?: boolean }): Re
 
   const [isRemoveWalletAlertVisible, setIsRemoveWalletAlertVisible] = useState(false);
   const { deleteWallet, walletRepository, walletManager } = useWalletManager();
-  const { walletInfo, setDeletingWallet, isSharedWallet } = useWalletStore();
+  const { walletInfo, setDeletingWallet } = useWalletStore();
   const backgroundServices = useBackgroundServiceAPIContext();
   const analytics = useAnalyticsContext();
 
@@ -34,11 +35,10 @@ export const SettingsRemoveWallet = ({ popupView }: { popupView?: boolean }): Re
   );
 
   const hasAssociatedSharedWallet =
-    !isSharedWallet &&
-    wallets?.some(
-      ({ type, metadata }) =>
-        type === WalletType.Script &&
-        metadata.multiSigExtendedPublicKey === activeWallet?.metadata.multiSigExtendedPublicKey
+    activeWallet &&
+    activeWallet.type !== WalletType.Script &&
+    activeWallet.accounts.some(
+      ({ accountIndex, purpose }) => accountIndex === 0 && purpose === KeyManagement.KeyPurpose.MULTI_SIG
     );
 
   const toggleRemoveWalletAlert = () => {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsRemoveWallet.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsRemoveWallet.tsx
@@ -13,9 +13,7 @@ import { useAnalyticsContext } from '@providers';
 import { PostHogAction } from '@providers/AnalyticsProvider/analyticsTracker';
 import cn from 'classnames';
 import { getWalletAccountsQtyString } from '@src/utils/get-wallet-count-string';
-import { Wallet } from '@lace/cardano';
-import { AnyWallet, WalletType } from '@cardano-sdk/web-extension';
-import * as KeyManagement from '@cardano-sdk/key-management';
+import { WalletType } from '@cardano-sdk/web-extension';
 
 const { Title, Text } = Typography;
 
@@ -24,21 +22,17 @@ export const SettingsRemoveWallet = ({ popupView }: { popupView?: boolean }): Re
 
   const [isRemoveWalletAlertVisible, setIsRemoveWalletAlertVisible] = useState(false);
   const { deleteWallet, walletRepository, walletManager } = useWalletManager();
-  const { walletInfo, setDeletingWallet } = useWalletStore();
+  const { walletInfo, setDeletingWallet, isSharedWallet } = useWalletStore();
   const backgroundServices = useBackgroundServiceAPIContext();
   const analytics = useAnalyticsContext();
 
   const activeWalletId = useObservable(walletManager.activeWalletId$);
   const wallets = useObservable(walletRepository.wallets$);
-  const activeWallet = wallets?.find(
-    (w: AnyWallet<Wallet.WalletMetadata, Wallet.AccountMetadata>) => w.walletId === activeWalletId?.walletId
-  );
 
   const hasAssociatedSharedWallet =
-    activeWallet &&
-    activeWallet.type !== WalletType.Script &&
-    activeWallet.accounts.some(
-      ({ accountIndex, purpose }) => accountIndex === 0 && purpose === KeyManagement.KeyPurpose.MULTI_SIG
+    !isSharedWallet &&
+    wallets?.some(
+      (wallet) => wallet.type === WalletType.Script && wallet.ownSigners[0].walletId === activeWalletId?.walletId
     );
 
   const toggleRemoveWalletAlert = () => {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/shared-wallet/SharedWallet.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/shared-wallet/SharedWallet.tsx
@@ -48,10 +48,10 @@ export const SharedWallet = (): JSX.Element => {
       const activeWallet = wallets.find(({ walletId }) => walletId === activeWalletId);
 
       if (!activeWallet || activeWallet.type === WalletType.Script) return;
-      const parentWalletCIP1854Account = activeWallet.accounts.find(
+      const parentMultiSigAccount = activeWallet.accounts.find(
         ({ accountIndex, purpose }) => accountIndex === 0 && purpose === KeyManagement.KeyPurpose.MULTI_SIG
       );
-      setSharedWalletKey(parentWalletCIP1854Account?.extendedAccountPublicKey);
+      setSharedWalletKey(parentMultiSigAccount?.extendedAccountPublicKey);
       setActiveWalletType(activeWallet.type);
     })();
   }, [cardanoWallet.source.wallet.walletId, walletRepository]);

--- a/apps/browser-extension-wallet/src/views/browser-view/features/shared-wallet/SharedWallet.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/shared-wallet/SharedWallet.tsx
@@ -30,7 +30,7 @@ type CreateWalletParams = {
 export const SharedWallet = (): JSX.Element => {
   const analytics = useAnalyticsContext();
   const history = useHistory();
-  const { walletRepository, generateSharedWalletKey, createCIP1854Account, createInMemorySharedWallet } =
+  const { walletRepository, generateSharedWalletKey, createMultiSigAccount, createInMemorySharedWallet } =
     useWalletManager();
   const { walletInfo, cardanoWallet, environmentName } = useWalletStore();
   const { page, setBackgroundPage } = useBackgroundPage();
@@ -72,7 +72,7 @@ export const SharedWallet = (): JSX.Element => {
     if (sharedWalletKey) return sharedWalletKey;
     const activeWalletId = cardanoWallet.source.wallet.walletId;
     const key = await generateSharedWalletKey(enteredPassword);
-    await createCIP1854Account({
+    await createMultiSigAccount({
       ownSignerWalletId: activeWalletId,
       sharedWalletKey: key
     });

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingContainer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingContainer.tsx
@@ -11,7 +11,14 @@ import { isMultidelegationSupportedByDevice } from '@views/browser/features/stak
 import { useWalletStore } from '@stores';
 import { useAnalyticsContext, useCurrencyStore, useExternalLinkOpener } from '@providers';
 import { DEFAULT_STAKING_BROWSER_PREFERENCES, OutsideHandlesProvider } from '@lace/staking';
-import { useBalances, useCurrentWallet, useCustomSubmitApi, useFetchCoinPrice, useLocalStorage } from '@hooks';
+import {
+  useBalances,
+  useCurrentWallet,
+  useCustomSubmitApi,
+  useFetchCoinPrice,
+  useLocalStorage,
+  useWalletManager
+} from '@hooks';
 import {
   MULTIDELEGATION_DAPP_COMPATIBILITY_LS_KEY,
   MULTIDELEGATION_FIRST_VISIT_LS_KEY,
@@ -20,10 +27,12 @@ import {
 import { useDelegationStore } from '@src/features/delegation/stores';
 import { useWalletActivities } from '@hooks/useWalletActivities';
 import { useSubmitingState } from '@views/browser/features/send-transaction';
-import { useSecrets, useSharedWalletData, useSignPolicy } from '@lace/core';
+import { useSecrets, useSignPolicy } from '@lace/core';
 import { useRewardAccountsData } from '../hooks';
 import { config } from '@src/config';
 import { parseError } from '@src/utils/parse-error';
+import { useObservable } from '@lace/common';
+import { getParentWalletCIP1854Account } from '@lib/scripts/background/util';
 
 export const StakingContainer = (): React.ReactElement => {
   // TODO: LW-7575 Remove old staking in post-MVP of multi delegation staking.
@@ -94,8 +103,13 @@ export const StakingContainer = (): React.ReactElement => {
   }));
   const walletAddress = walletInfo.addresses?.[0].address?.toString();
   const walletName = walletInfo.name;
+  const { walletRepository } = useWalletManager();
+  const wallets = useObservable(walletRepository.wallets$);
   const wallet = useCurrentWallet();
-  const { sharedWalletKey, coSigners } = useSharedWalletData(wallet);
+
+  const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+  const sharedWalletKey = parentWalletCIP1854Account?.extendedAccountPublicKey;
+  const coSigners = wallet?.metadata?.coSigners;
   const signPolicy = useSignPolicy(wallet, 'staking');
   const { GOV_TOOLS_URLS } = config();
 

--- a/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingContainer.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/staking/components/StakingContainer.tsx
@@ -107,8 +107,8 @@ export const StakingContainer = (): React.ReactElement => {
   const wallets = useObservable(walletRepository.wallets$);
   const wallet = useCurrentWallet();
 
-  const parentWalletCIP1854Account = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
-  const sharedWalletKey = parentWalletCIP1854Account?.extendedAccountPublicKey;
+  const parentMultiSigAccount = getParentWalletCIP1854Account({ wallets, activeWallet: wallet });
+  const sharedWalletKey = parentMultiSigAccount?.extendedAccountPublicKey;
   const coSigners = wallet?.metadata?.coSigners;
   const signPolicy = useSignPolicy(wallet, 'staking');
   const { GOV_TOOLS_URLS } = config();

--- a/packages/cardano/src/wallet/lib/cardano-wallet.ts
+++ b/packages/cardano/src/wallet/lib/cardano-wallet.ts
@@ -30,7 +30,6 @@ export interface WalletMetadata {
   lockValue?: HexBlob;
   lastActiveAccountIndex?: number;
   walletAddresses?: Cardano.PaymentAddress[];
-  multiSigExtendedPublicKey?: Wallet.Crypto.Bip32PublicKeyHex;
   coSigners?: { sharedWalletKey: Wallet.Crypto.Bip32PublicKeyHex; name: string }[];
 }
 

--- a/packages/core/src/shared-wallets/hooks/use-shared-wallet-data.ts
+++ b/packages/core/src/shared-wallets/hooks/use-shared-wallet-data.ts
@@ -1,4 +1,3 @@
-import { Bip32PublicKeyHex } from '@cardano-sdk/crypto';
 import { AnyWallet } from '@cardano-sdk/web-extension';
 import { Wallet } from '@lace/cardano';
 
@@ -13,22 +12,6 @@ import {
 } from '../utils';
 
 type SigningPolicyType = 'payment' | 'staking';
-
-type Cosigner = { name: string; sharedWalletKey: Bip32PublicKeyHex };
-
-type UseSharedWalletData = {
-  coSigners?: Cosigner[];
-  name?: string;
-  sharedWalletKey?: Wallet.Crypto.Bip32PublicKeyHex | undefined;
-};
-
-export const useSharedWalletData = (
-  wallet: AnyWallet<Wallet.WalletMetadata, Wallet.AccountMetadata>,
-): UseSharedWalletData => ({
-  coSigners: wallet?.metadata?.coSigners,
-  name: wallet?.metadata?.name,
-  sharedWalletKey: wallet?.metadata?.multiSigExtendedPublicKey,
-});
 
 export const useSignPolicy = (
   wallet: AnyWallet<Wallet.WalletMetadata, Wallet.AccountMetadata>,


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-11069](https://input-output.atlassian.net/browse/LW-11069)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

- read `coSigners` data directly from the `metadata` object
- remove `multiSigExtendedPublicKey` from `metadata` object
- read shared wallet key directly from parent wallet CIP1854 account instead
- create parent wallet CIP1854 account upon shared wallet key generation

## Testing

overall shared wallet functionality should be retested (no regression expected)

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-11069]: https://input-output.atlassian.net/browse/LW-11069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ