### PR TITLE
fix: make shared wallet key cip 5 compliant

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -146,7 +146,7 @@ export interface UseWalletManager {
   reloadWallet: () => Promise<void>;
   addAccount: (props: WalletManagerAddAccountProps) => Promise<void>;
   getMnemonic: (passphrase: Uint8Array) => Promise<string[]>;
-  getSharedWalletExtendedPublicKey: (passphrase: Uint8Array) => Promise<Wallet.Crypto.Bip32PublicKeyHex>;
+  getSharedWalletExtendedPublicKey: (passphrase: Uint8Array) => Promise<Wallet.Cardano.Cip1854ExtendedAccountPublicKey>;
   enableCustomNode: (network: EnvironmentTypes, value: string) => Promise<void>;
   generateSharedWalletKey: GenerateSharedWalletKeyFn;
   createMultiSigAccount: (props: CreateMultiSigAccountParams) => Promise<void>;
@@ -869,12 +869,18 @@ export const useWalletManager = (): UseWalletManager => {
   );
 
   const getSharedWalletExtendedPublicKey = useCallback(
-    async (passphrase?: Uint8Array) => {
+    async (passphrase?: Uint8Array): Promise<Wallet.Cardano.Cip1854ExtendedAccountPublicKey> => {
       const { wallet } = cardanoWallet.source;
       if (wallet.type === WalletType.Script) throw new Error('Xpub keys not available for shared wallet');
 
       const accountIndex = 0;
-      return await getExtendedAccountPublicKey(wallet, accountIndex, passphrase, KeyManagement.KeyPurpose.MULTI_SIG);
+      const bip32AccountPublicKey = await getExtendedAccountPublicKey(
+        wallet,
+        accountIndex,
+        passphrase,
+        KeyManagement.KeyPurpose.MULTI_SIG
+      );
+      return Wallet.Cardano.Cip1854ExtendedAccountPublicKey.fromBip32PublicKeyHex(bip32AccountPublicKey);
     },
     [cardanoWallet]
   );
@@ -909,7 +915,14 @@ export const useWalletManager = (): UseWalletManager => {
       quorumRules,
       coSigners
     }: CreateSharedWalletParams): Promise<Wallet.CardanoWallet> => {
-      const publicKeys = coSigners.map((c: CoSigner) => Wallet.Crypto.Bip32PublicKeyHex(c.sharedWalletKey));
+      const coSignersInBip32Hex = coSigners.map((c) => ({
+        ...c,
+        sharedWalletKey: Wallet.Cardano.Cip1854ExtendedAccountPublicKey.toBip32PublicKeyHex(
+          Wallet.Cardano.Cip1854ExtendedAccountPublicKey(c.sharedWalletKey)
+        )
+      }));
+
+      const publicKeys = coSignersInBip32Hex.map((c: CoSigner) => Wallet.Crypto.Bip32PublicKeyHex(c.sharedWalletKey));
 
       let scriptKind: ScriptKind;
       if (quorumRules.option === QuorumRadioOption.AllAddresses) {
@@ -935,7 +948,7 @@ export const useWalletManager = (): UseWalletManager => {
       const createScriptWalletProps: AddWalletProps<Wallet.WalletMetadata, Wallet.AccountMetadata> = {
         metadata: {
           name,
-          coSigners: coSigners.map((signer) => ({
+          coSigners: coSignersInBip32Hex.map((signer) => ({
             name: signer.name,
             sharedWalletKey: Wallet.Crypto.Bip32PublicKeyHex(signer.sharedWalletKey)
           }))

--- a/packages/core/src/shared-wallets/add-shared-wallet/creation-flow/ShareWalletDetails/utils.ts
+++ b/packages/core/src/shared-wallets/add-shared-wallet/creation-flow/ShareWalletDetails/utils.ts
@@ -1,3 +1,4 @@
+import { Wallet } from '@lace/cardano';
 import { logger } from '@lace/common';
 import type {
   NativeScript,
@@ -14,10 +15,15 @@ export const FILENAME = 'shared-wallet-config.json';
 
 const getScriptsFromCosigners = async (coSigners: CoSigner[]) =>
   await Promise.all(
-    coSigners.map(async (coSigner) => ({
-      pubkey: await getHashFromPublicKey(coSigner.sharedWalletKey, paymentScriptKeyPath),
-      tag: 'pubkey',
-    })),
+    coSigners.map(async (coSigner) => {
+      const publicKeyHex = Wallet.Cardano.Cip1854ExtendedAccountPublicKey.toBip32PublicKeyHex(
+        Wallet.Cardano.Cip1854ExtendedAccountPublicKey(coSigner.sharedWalletKey),
+      );
+      return {
+        pubkey: await getHashFromPublicKey(publicKeyHex, paymentScriptKeyPath),
+        tag: 'pubkey',
+      };
+    }),
   );
 
 // Function to map CreationFlowState to the schema JSON structure

--- a/packages/core/src/shared-wallets/add-shared-wallet/creation-flow/validateCoSigners.test.ts
+++ b/packages/core/src/shared-wallets/add-shared-wallet/creation-flow/validateCoSigners.test.ts
@@ -2,7 +2,7 @@ import { CoSignerError, CoSignerErrorKeys, CoSignerErrorName } from './AddCoSign
 import { validateCoSigners } from './validateCoSigners';
 
 const fakeSharedKey =
-  '979693650bb44f26010e9f7b3b550b0602c748d1d00981747bac5c34cf5b945fe01a39317b9b701e58ee16b5ed16aa4444704b98cc997bdd6c5a9502a8b7d70d';
+  'acct_shared_xvk1q395kywke7mufrysg33nsm6ggjxswu4g8q8ag7ks9kdyaczchtemd5d2armrfstfa32lamhxfl3sskgcmxm4zdhtvut362796ez4ecqx6vnht';
 
 describe('validateCoSigners', () => {
   test('name duplicated', () => {

--- a/packages/core/src/shared-wallets/add-shared-wallet/creation-flow/validateCoSigners.ts
+++ b/packages/core/src/shared-wallets/add-shared-wallet/creation-flow/validateCoSigners.ts
@@ -1,6 +1,6 @@
+import { Wallet } from '@lace/cardano';
 import { CoSigner, CoSignerError, CoSignerErrorKeys, CoSignerErrorName, maxCoSignerNameLength } from './AddCoSigners';
 
-const keyRegex = /^[\dA-Fa-f]{128}$/;
 export const validateCoSigners = (coSigners: CoSigner[]): CoSignerError[] => {
   let coSignersErrors: CoSignerError[] = [];
 
@@ -8,11 +8,16 @@ export const validateCoSigners = (coSigners: CoSigner[]): CoSignerError[] => {
     let keyError: CoSignerErrorKeys | undefined;
     let nameError: CoSignerErrorName | undefined;
 
-    const keyValidationResult = keyRegex.exec(sharedWalletKey);
     if (!sharedWalletKey) keyError = CoSignerErrorKeys.Required;
-    else if (!keyValidationResult) keyError = CoSignerErrorKeys.Invalid;
-    else if (coSigners.some((coSigner) => coSigner.id !== id && coSigner.sharedWalletKey === sharedWalletKey)) {
-      keyError = CoSignerErrorKeys.Duplicated;
+    else {
+      try {
+        Wallet.Cardano.Cip1854ExtendedAccountPublicKey(sharedWalletKey);
+        if (coSigners.some((coSigner) => coSigner.id !== id && coSigner.sharedWalletKey === sharedWalletKey)) {
+          keyError = CoSignerErrorKeys.Duplicated;
+        }
+      } catch {
+        keyError = CoSignerErrorKeys.Invalid;
+      }
     }
 
     if (!name) nameError = CoSignerErrorName.Required;

--- a/packages/core/src/shared-wallets/add-shared-wallet/generate-key-flow/Store/machine.ts
+++ b/packages/core/src/shared-wallets/add-shared-wallet/generate-key-flow/Store/machine.ts
@@ -1,3 +1,4 @@
+import { Wallet } from '@lace/cardano';
 import { TransitionHandler } from '../../../state-utils';
 import { PasswordErrorType } from '../EnterPassword';
 import {
@@ -65,7 +66,7 @@ export const makeStateMachine = ({ navigateToParentFlow }: MakeStateMachineParam
       return stateCopyKey({
         loading: undefined,
         passwordErrorType: undefined,
-        sharedWalletKey: action.sharedWalletKey,
+        sharedWalletKey: Wallet.Cardano.Cip1854ExtendedAccountPublicKey(action.sharedWalletKey),
         step: GenerateSharedWalletKeyStep.CopyKey,
       });
     }

--- a/packages/core/src/shared-wallets/add-shared-wallet/generate-key-flow/Store/state.ts
+++ b/packages/core/src/shared-wallets/add-shared-wallet/generate-key-flow/Store/state.ts
@@ -1,3 +1,4 @@
+import { Wallet } from '@lace/cardano';
 import { StateType, defineStateShape } from '../../../state-utils';
 import { PasswordErrorType } from '../EnterPassword';
 
@@ -28,7 +29,7 @@ export type StateEnterPassword = StateType<typeof stateEnterPassword>;
 export const stateCopyKey = makeState<{
   loading: undefined;
   passwordErrorType: undefined;
-  sharedWalletKey: string;
+  sharedWalletKey: Wallet.Cardano.Cip1854ExtendedAccountPublicKey;
   step: GenerateSharedWalletKeyStep.CopyKey;
 }>();
 export type StateCopyKey = StateType<typeof stateCopyKey>;

--- a/packages/core/src/shared-wallets/add-shared-wallet/generate-key-flow/generate-shared-wallet-key.ts
+++ b/packages/core/src/shared-wallets/add-shared-wallet/generate-key-flow/generate-shared-wallet-key.ts
@@ -1,7 +1,7 @@
 import { Wallet } from '@lace/cardano';
 import { Buffer } from 'buffer';
 
-export type GenerateSharedWalletKeyFn = (password?: string) => Promise<Wallet.Crypto.Bip32PublicKeyHex>;
+export type GenerateSharedWalletKeyFn = (password?: string) => Promise<Wallet.Cardano.Cip1854ExtendedAccountPublicKey>;
 
 export class SharedWalletKeyGenerationAuthError extends Error {
   constructor() {
@@ -10,7 +10,9 @@ export class SharedWalletKeyGenerationAuthError extends Error {
 }
 
 type GenerateSharedWalletKeyDependencies = {
-  getSharedWalletExtendedPublicKey: (passphrase?: Uint8Array) => Promise<Wallet.Crypto.Bip32PublicKeyHex>;
+  getSharedWalletExtendedPublicKey: (
+    passphrase?: Uint8Array,
+  ) => Promise<Wallet.Cardano.Cip1854ExtendedAccountPublicKey>;
 };
 
 export const makeGenerateSharedWalletKey =

--- a/packages/core/src/shared-wallets/add-shared-wallet/restore-flow/validateJson.ts
+++ b/packages/core/src/shared-wallets/add-shared-wallet/restore-flow/validateJson.ts
@@ -1,4 +1,5 @@
 /* eslint-disable unicorn/consistent-destructuring */
+import { Wallet } from '@lace/cardano';
 import { v1 as uuid } from 'uuid';
 import { z } from 'zod';
 import { FileErrorMessage, FileValidationError, PubkeyScript } from '../../../shared-wallets/types';
@@ -31,7 +32,10 @@ export const validateJson = (
         }
         const { scripts } = nativeScript;
 
-        const ownHash = await getHashFromPublicKey(sharedKey, paymentScriptKeyPath);
+        const sharedKeyInBip32PublicKeyHex = Wallet.Cardano.Cip1854ExtendedAccountPublicKey.toBip32PublicKeyHex(
+          Wallet.Cardano.Cip1854ExtendedAccountPublicKey(sharedKey),
+        );
+        const ownHash = await getHashFromPublicKey(sharedKeyInBip32PublicKeyHex, paymentScriptKeyPath);
 
         const matchedCosigner = scripts.find((script: PubkeyScript) => script.pubkey === ownHash);
 

--- a/packages/core/src/shared-wallets/flow-stories/AddSharedWalletStorybookHelper.tsx
+++ b/packages/core/src/shared-wallets/flow-stories/AddSharedWalletStorybookHelper.tsx
@@ -41,10 +41,10 @@ type AddSharedWalletFlowProps = {
 };
 
 export const sharedWalletKey =
-  '979693650bb44f26010e9f7b3b550b0602c748d1d00981747bac5c34cf5b945fe01a39317b9b701e58ee16b5ed16aa4444704b98cc997bdd6c5a9502a8b7d70d';
+  'acct_shared_xvk1q395kywke7mufrysg33nsm6ggjxswu4g8q8ag7ks9kdyaczchtemd5d2armrfstfa32lamhxfl3sskgcmxm4zdhtvut362796ez4ecqx6vnht';
 
 const generateSharedWalletKey = makeGenerateSharedWalletKey({
-  getSharedWalletExtendedPublicKey: async () => Wallet.Crypto.Bip32PublicKeyHex(sharedWalletKey),
+  getSharedWalletExtendedPublicKey: async () => Wallet.Cardano.Cip1854ExtendedAccountPublicKey(sharedWalletKey),
 });
 
 export const activeWalletName = 'My wallet';

--- a/packages/core/src/shared-wallets/transaction/CosignersList.tsx
+++ b/packages/core/src/shared-wallets/transaction/CosignersList.tsx
@@ -14,6 +14,12 @@ interface CoSignerItemProps {
 
 export const CosignersList = ({ list, title, ownSharedKey }: CoSignerItemProps) => {
   const { t } = useTranslation();
+  const ownSharedKeyInCip5 =
+    ownSharedKey && Wallet.Cardano.Cip1854ExtendedAccountPublicKey.fromBip32PublicKeyHex(ownSharedKey);
+  const listWithCip5Keys = list.map((item) => ({
+    ...item,
+    sharedWalletKey: Wallet.Cardano.Cip1854ExtendedAccountPublicKey.fromBip32PublicKeyHex(item.sharedWalletKey),
+  }));
 
   return (
     <Box testId="cosigner-list" mt="$24">
@@ -21,7 +27,7 @@ export const CosignersList = ({ list, title, ownSharedKey }: CoSignerItemProps) 
         <div data-testid="cosigner-list-header" className={styles.cosignersListHeader}>
           {title}
         </div>
-        {list.map(({ sharedWalletKey, name: cosignerName, signed }) => (
+        {listWithCip5Keys.map(({ sharedWalletKey, name: cosignerName, signed }) => (
           <Flex
             py="$0"
             px="$24"
@@ -43,7 +49,7 @@ export const CosignersList = ({ list, title, ownSharedKey }: CoSignerItemProps) 
               </div>
               <div className={styles.cosignersListItemContent}>
                 <Box w="$fill" className={styles.cosignersListItemName}>
-                  {sharedWalletKey === ownSharedKey
+                  {sharedWalletKey === ownSharedKeyInCip5
                     ? t('sharedWallets.transaction.cosignerList.you')
                     : cosignerName ?? '...'}
                 </Box>


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-11070
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Currently, shared wallet keys are displayed as Bip32 Hex string. This PR updates keys to be display in [CIP 5](https://cips.cardano.org/cip/CIP-5) bech32 formats

## Screenshots
<img width="832" alt="Screenshot 2025-03-05 at 13 41 08" src="https://github.com/user-attachments/assets/e43d7e41-e2e0-473a-8650-3ab89b5f1cf4" />

<img width="687" alt="Screenshot 2025-03-05 at 13 39 29" src="https://github.com/user-attachments/assets/823f327c-ac98-4308-a6a7-c7031211d173" />


