### PR TITLE
fix: [lw-12396] make all summary expanders controlled in dapp connector

### DIFF
--- a/packages/core/src/ui/components/DappAddressSections/DappAddressSection.tsx
+++ b/packages/core/src/ui/components/DappAddressSections/DappAddressSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { truncate, addEllipsis } from '@lace/common';
 import { Wallet } from '@lace/cardano';
 import { Cardano, AssetInfoWithAmount } from '@cardano-sdk/core';
@@ -126,11 +126,18 @@ export const DappAddressSection = ({
   addressToNameMap
 }: DappAddressSectionProps): React.ReactElement => {
   const { t } = useTranslation();
+  const [isSummaryOpen, setIsSummaryOpen] = useState(false);
 
   const itemsCountCopy = t('core.dappTransaction.items');
 
   return (
-    <SummaryExpander title={title} disabled={!isEnabled} testId={`dapp-transaction-${addressType}-section-expander`}>
+    <SummaryExpander
+      onClick={() => setIsSummaryOpen(!isSummaryOpen)}
+      open={isSummaryOpen}
+      title={title}
+      disabled={!isEnabled}
+      testId={`dapp-transaction-${addressType}-section-expander`}
+    >
       {[...groupedAddresses.entries()].map(([address, addressData]) => {
         const addressName = addressToNameMap?.get(address);
 

--- a/packages/core/src/ui/components/DappTransactionHeader/DappTransactionHeader.tsx
+++ b/packages/core/src/ui/components/DappTransactionHeader/DappTransactionHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Typography } from 'antd';
 
 import styles from './DappTransactionHeader.module.scss';
@@ -27,13 +27,19 @@ export interface DappTransactionHeaderProps {
 
 export const DappTransactionHeader = ({ transactionType, name }: DappTransactionHeaderProps): React.ReactElement => {
   const { t } = useTranslation();
+  const [isSummaryOpen, setIsSummaryOpen] = useState(false);
 
   return (
     <div data-testid="transaction-type-container">
       {transactionType && (
         <TransactionType label={t('core.dappTransaction.transaction')} transactionType={transactionType} />
       )}
-      <SummaryExpander title={t('core.dappTransaction.origin')} testId="dapp-transaction-origin-expander">
+      <SummaryExpander
+        onClick={() => setIsSummaryOpen(!isSummaryOpen)}
+        open={isSummaryOpen}
+        title={t('core.dappTransaction.origin')}
+        testId="dapp-transaction-origin-expander"
+      >
         <Card.Outlined className={styles.dappInfoContainer}>
           <Text className={styles.dappInfo}>
             <span data-testid="dapp-transaction-origin">{name}</span>


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12396](https://input-output.atlassian.net/browse/LW-12396)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

SummaryExpander expects open prop to be passed in order to define the direction of the chevron it renders.

## Testing

check DoD section in the jira ticket.

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12396]: https://input-output.atlassian.net/browse/LW-12396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ