### PR TITLE
ci: check npmScope in yarnrc before file update

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -9,7 +9,6 @@ inputs:
     description: 'GitHub Token'
     required: true
 
-
 runs:
   using: 'composite'
   steps:
@@ -21,10 +20,24 @@ runs:
 
     - name: Configure Yarn to use GitHub Packages
       run: |
-        echo "npmScopes:" >> ~/.yarnrc.yml
-        echo "  input-output-hk:" >> ~/.yarnrc.yml
-        echo "    npmRegistryServer: \"https://npm.pkg.github.com\"" >> ~/.yarnrc.yml
-        echo "    npmAuthToken: \"${{ inputs.GITHUB_TOKEN }}\"" >> ~/.yarnrc.yml
+        SCOPE="input-output-hk"
+        FILE="$HOME/.yarnrc.yml"
+        if grep -q "npmScopes:" "$FILE"; then
+          if ! grep -q "$SCOPE:" "$FILE"; then
+            echo "  $SCOPE:" >> "$FILE"
+            echo "    npmRegistryServer: \"https://npm.pkg.github.com\"" >> "$FILE"
+            echo "    npmAuthToken: \"${{ inputs.GITHUB_TOKEN }}\"" >> "$FILE"
+            echo "Added $SCOPE to $FILE"
+          else
+            echo "$SCOPE already present in $FILE"
+          fi
+        else
+          echo "npmScopes:" >> "$FILE"
+          echo "  $SCOPE:" >> "$FILE"
+          echo "    npmRegistryServer: \"https://npm.pkg.github.com\"" >> "$FILE"
+          echo "    npmAuthToken: \"${{ inputs.GITHUB_TOKEN }}\"" >> "$FILE"
+          echo "Added npmScopes and $SCOPE to $FILE"
+        fi
       shell: bash
 
     - name: Node modules cache


### PR DESCRIPTION
Make sure that we do not add to .yarnrc.yml npmScopes if already exists, otherwise we observe YAMLException like this one:

```
YAMLException: duplicated mapping key at line 5, column -142:
    npmScopes:
    ^
    at generateError (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:126542:10)
    at throwError (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:126548:9)
    at storeMappingPair (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:126710:7)
    at readBlockMapping (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:127473:9)
    at composeNode (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:127734:12)
    at readDocument (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:127894:3)
    at loadDocuments (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:12[79](https://github.com/input-output-hk/lace/actions/runs/13773591940/job/38517671335#step:3:82)50:5)
    at load (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:127971:19)
    at safeLoad (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:127993:10)
    at parse (/home/runner/_work/_tool/node/20.12.2/x64/lib/node_modules/yarn/lib/cli.js:64242:18)
```