### PR TITLE
fix(extension): reading background storage when it does not exist yet [LW-12498]

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/onStorageChange.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/onStorageChange.ts
@@ -17,17 +17,17 @@ const hasStorageChangeForKey = <T extends keyof ExtensionStorage>(
 ): changes is Record<T, ExtensionStorageChange<T>> => key in changes;
 
 const handleBackgroundStorageChange = (changes: ExtensionStorageChange<'BACKGROUND_STORAGE'>) => {
-  if (changes.newValue.logLevel && changes.oldValue?.logLevel !== changes.newValue?.logLevel) {
+  if (changes.newValue?.logLevel && changes.oldValue?.logLevel !== changes.newValue.logLevel) {
     commonLogger.setLogLevel(changes.newValue.logLevel);
   }
 
-  if (changes.newValue.featureFlags) {
+  if (changes.newValue?.featureFlags) {
     // this FF is not network specific, we always pick the mainnet value
     const networkMagic = Wallet.Cardano.NetworkMagics.Mainnet;
     const oldLoggerSentryIntegrationEnabled =
       changes.oldValue?.featureFlags?.[networkMagic]?.['send-console-errors-to-sentry'];
     const newLoggerSentryIntegrationEnabled =
-      changes.newValue?.featureFlags?.[networkMagic]?.['send-console-errors-to-sentry'];
+      changes.newValue.featureFlags?.[networkMagic]?.['send-console-errors-to-sentry'];
 
     if (newLoggerSentryIntegrationEnabled !== oldLoggerSentryIntegrationEnabled) {
       commonLogger.setSentryIntegrationEnabled(newLoggerSentryIntegrationEnabled || false);


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-12498)

---

## Proposed solution
Address the situation when the `BACKGROUND_STORAGE` key has not yet been created. This went uncaptured due to strict mode issues.

## Testing
The error should no longer appear in the console.
