### PR TITLE
fix: [lw-12562] fix label position for invalid number input

### DIFF
--- a/apps/browser-extension-wallet/src/views/bitcoin-mode/features/send/components/SendStepOne.tsx
+++ b/apps/browser-extension-wallet/src/views/bitcoin-mode/features/send/components/SendStepOne.tsx
@@ -101,7 +101,7 @@ export const SendStepOne: React.FC<SendStepOneProps> = ({
     () => recommendedFees.find((f) => f.key === selectedFeeKey),
     [recommendedFees, selectedFeeKey]
   );
-  const [customFee, setCustomFee] = useState<string>('');
+  const [customFee, setCustomFee] = useState<string>('0');
   const [customFeeError, setCustomFeeError] = useState<string | undefined>();
   const [isValidAddress, setIsValidAddress] = useState<boolean>(false);
   const [invalidAddressError, setInvalidAddressError] = useState<string | undefined>();
@@ -181,6 +181,10 @@ export const SendStepOne: React.FC<SendStepOneProps> = ({
     if (disallowedKeys.includes(e.key) || (e.key === 'ArrowDown' && targetValue <= 0)) {
       e.preventDefault();
     }
+  };
+
+  const onCustomFeeBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    setCustomFee(e.target.value || '0');
   };
 
   return (
@@ -281,6 +285,8 @@ export const SendStepOne: React.FC<SendStepOneProps> = ({
                 }}
                 inputMode="decimal"
                 pattern="[0-9]*[.]?[0-9]*"
+                onBlur={onCustomFeeBlur}
+                filledLabelOnFocus
               />
               {customFeeError && <InputError error={customFeeError} isPopupView={isPopupView} />}
             </Box>

--- a/packages/common/src/ui/components/Form/Input/Input.tsx
+++ b/packages/common/src/ui/components/Form/Input/Input.tsx
@@ -13,6 +13,7 @@ export type inputProps = {
   invalid?: boolean;
   focus?: boolean;
   labelClassName?: string;
+  filledLabelOnFocus?: boolean;
 } & InputProps;
 
 export const Input = ({
@@ -23,10 +24,12 @@ export const Input = ({
   value,
   focus,
   labelClassName = '',
+  filledLabelOnFocus,
   ...props
 }: inputProps): React.ReactElement => {
   const inputRef = useRef(null);
   const [localVal, setLocalVal] = useState<string>('');
+  const [isFocused, setIsFocused] = useState<boolean>(focus ?? false);
   const onValChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setLocalVal(e?.target?.value ?? '');
     onChange?.(e);
@@ -36,6 +39,16 @@ export const Input = ({
     setLocalVal(value ?? '');
   }, [value]);
 
+  const onFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+    setIsFocused(true);
+    props.onFocus?.(event);
+  };
+
+  const onBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    setIsFocused(false);
+    props.onBlur?.(event);
+  };
+
   useAutoFocus(inputRef, focus);
 
   return (
@@ -44,7 +57,14 @@ export const Input = ({
       onChange={onValChange}
       {...(label && {
         prefix: (
-          <div className={cn(styles.label, { [styles.filled]: localVal }, labelClassName)} data-testid="input-label">
+          <div
+            className={cn(
+              styles.label,
+              { [styles.filled]: localVal || (filledLabelOnFocus && isFocused) },
+              labelClassName
+            )}
+            data-testid="input-label"
+          >
             {label}
           </div>
         )
@@ -54,9 +74,11 @@ export const Input = ({
       {...props}
       className={cn(styles.input, {
         ...(props.className && { [props.className]: props.className }),
-        [styles.withLabel]: localVal && label,
+        [styles.withLabel]: (localVal || (filledLabelOnFocus && isFocused)) && label,
         [styles.invalid]: invalid
       })}
+      onFocus={onFocus}
+      onBlur={onBlur}
     />
   );
 };


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12562](https://input-output.atlassian.net/browse/LW-12562)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

### TL;DR:
We do not have specific number input implemented in lace. There is a way to achieve proper behaviour by specifying input type as `number`.

#### Problem:
Default behaviour implemented in `antd` lib would pass empty value into the `onChange` event handler in case user enter not valid decimal number, eg: `0.`. As a result, label would cover entered value.

#### Workaround: 
Always set label to be filled (on top) in case input is focused, and reset to 0 on blur.

## Testing

Please recheck other inputs focus/blur states.

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12562]: https://input-output.atlassian.net/browse/LW-12562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ