### PR TITLE
fix: [lw-12705] clear error states on confirm modal close in dapp popup

### DIFF
--- a/packages/nami/src/ui/app/pages/dapp-connector/signData.tsx
+++ b/packages/nami/src/ui/app/pages/dapp-connector/signData.tsx
@@ -265,6 +265,7 @@ export const SignData = ({ dappConnector, account }: Readonly<Props>) => {
           }
         }}
         onCloseBtn={() => {
+          setError('');
           capture(Events.DappConnectorDappDataCancelClick);
         }}
         onConfirm={async status => {

--- a/packages/nami/src/ui/app/pages/dapp-connector/signTx.tsx
+++ b/packages/nami/src/ui/app/pages/dapp-connector/signTx.tsx
@@ -621,6 +621,7 @@ export const SignTx = ({
         openHWFlow={openHWFlow}
         walletType={walletType}
         onCloseBtn={() => {
+          setIsLoading(l => ({ ...l, error: '' }));
           capture(Events.DappConnectorDappTxCancelClick);
         }}
         secretsUtil={secretsUtil}


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12705](https://input-output.atlassian.net/browse/LW-12705)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Sign btn is blocked in case error is thrown while signing the tx. We could:
- either still allow user to sign the tx in case there is an error
- or clear error states when confirmation popup is closed (**wend with this approach for now**)

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-12705]: https://input-output.atlassian.net/browse/LW-12705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ