### PR TITLE
feat: [lw-12558] change btc wallet icon option to orange in dropdown

### DIFF
--- a/apps/browser-extension-wallet/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/apps/browser-extension-wallet/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -53,3 +53,7 @@
 .profileDropdownTrigger {
   flex-shrink: 0;
 }
+
+.walletOptionBitcoin > div {
+  background: var(--data-orange);
+}

--- a/apps/browser-extension-wallet/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/apps/browser-extension-wallet/src/components/DropdownMenu/DropdownMenu.tsx
@@ -16,6 +16,8 @@ import { ProfileDropdown } from '@input-output-hk/lace-ui-toolkit';
 import { useWalletAvatar } from '@hooks';
 import { getUiWalletType } from '@src/utils/get-ui-wallet-type';
 import i18n from 'i18next';
+import { WalletType } from '@cardano-sdk/web-extension';
+import { useCurrentBlockchain, Blockchain } from '@src/multichain';
 
 export interface DropdownMenuProps {
   isPopup?: boolean;
@@ -29,6 +31,7 @@ const addEllipsis = (text: string, length: number) => (text.length > length ? `$
 
 export const DropdownMenu = ({ isPopup }: DropdownMenuProps): React.ReactElement => {
   const analytics = useAnalyticsContext();
+  const { blockchain } = useCurrentBlockchain();
   const {
     walletUI: { isDropdownMenuOpen = false },
     setIsDropdownMenuOpen,
@@ -50,6 +53,19 @@ export const DropdownMenu = ({ isPopup }: DropdownMenuProps): React.ReactElement
   };
 
   useEffect(() => () => setIsDropdownMenuOpen(false), [setIsDropdownMenuOpen]);
+
+  const walletType = getUiWalletType(walletDisplayInfo?.walletType);
+
+  const isBitcoinWallet = walletDisplayInfo?.walletType !== WalletType.Script && blockchain === Blockchain.Bitcoin;
+  const customBitcoinProfile = isBitcoinWallet
+    ? {
+        customProfileComponent: (
+          <span className={styles.walletOptionBitcoin}>
+            <ProfileDropdown.WalletIcon type={walletType} testId={'wallet-option-icon'} />
+          </span>
+        )
+      }
+    : undefined;
 
   return (
     <Dropdown
@@ -74,9 +90,9 @@ export const DropdownMenu = ({ isPopup }: DropdownMenuProps): React.ReactElement
                     fallbackText: walletDisplayInfo?.walletName,
                     imageSrc: activeWalletAvatar
                   }
-                : undefined
+                : customBitcoinProfile
             }
-            type={getUiWalletType(walletDisplayInfo?.walletType)}
+            type={walletType}
             id="menu"
           />
         </div>

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/DropdownMenuOverlay.module.scss
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/DropdownMenuOverlay.module.scss
@@ -223,3 +223,7 @@
     background: var(--switch-checked-bg-color) !important;
   }
 }
+
+.walletOptionBitcoin > div {
+  background: var(--data-orange);
+}

--- a/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/UserInfo.tsx
+++ b/apps/browser-extension-wallet/src/components/MainMenu/DropdownMenuOverlay/components/UserInfo.tsx
@@ -114,6 +114,18 @@ export const UserInfo = ({
   const renderWalletOption = useCallback(
     ({ wallet, lastActiveAccount: acc }: RenderWalletOptionsParams) => {
       const walletAvatar = getAvatar(wallet.walletId);
+      const walletType = getUiWalletType(wallet.type);
+
+      const isBitcoinWallet = wallet.type !== WalletType.Script && wallet.blockchainName === 'Bitcoin';
+      const customBitcoinProfile = isBitcoinWallet
+        ? {
+            customProfileComponent: (
+              <span className={styles.walletOptionBitcoin}>
+                <ProfileDropdown.WalletIcon type={walletType} testId={'wallet-option-icon'} />
+              </span>
+            )
+          }
+        : undefined;
 
       return (
         <ProfileDropdown.WalletOption
@@ -142,14 +154,14 @@ export const UserInfo = ({
               text: t('multiWallet.activated.wallet', { walletName: wallet.metadata.name })
             });
           }}
-          type={getUiWalletType(wallet.type)}
+          type={walletType}
           profile={
             walletAvatar
               ? {
                   fallbackText: fullWalletName,
                   imageSrc: walletAvatar
                 }
-              : undefined
+              : customBitcoinProfile
           }
           {...(wallet.type !== WalletType.Script &&
             wallet.blockchainName !== 'Bitcoin' && {

--- a/apps/browser-extension-wallet/src/hooks/useWalletAvatar.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletAvatar.ts
@@ -2,8 +2,9 @@ import { useLocalStorage } from '@hooks/useLocalStorage';
 import { getAssetImageUrl } from '@utils/get-asset-image-url';
 import { useWalletStore } from '@stores';
 import { useGetHandles } from '@hooks/useGetHandles';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { walletRepository } from '@lib/wallet-api-ui';
+import { useWalletManager } from './useWalletManager';
 
 interface UseWalletAvatar {
   activeWalletAvatar: string;
@@ -13,10 +14,20 @@ interface UseWalletAvatar {
 
 export const useWalletAvatar = (): UseWalletAvatar => {
   const { cardanoWallet, environmentName } = useWalletStore();
+  const [activeWalletId, setActiveWalletId] = useState<string>('');
+
+  const { getActiveWalletId } = useWalletManager();
+
+  useEffect(() => {
+    // eslint-disable-next-line promise/catch-or-return
+    getActiveWalletId().then((id) => {
+      setActiveWalletId(id);
+    });
+  }, [getActiveWalletId]);
+
   const [handle] = useGetHandles();
   const [avatars, { updateLocalStorage: setUserAvatar }] = useLocalStorage('userAvatar');
 
-  const activeWalletId = cardanoWallet?.source.wallet.walletId;
   const { accountIndex, metadata } = cardanoWallet?.source.account ?? {};
   const handleImage = handle?.profilePic;
   const activeWalletAvatar =


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-12558](https://input-output.atlassian.net/browse/LW-12558)
- [x] JIRA - [LW-12723](https://input-output.atlassian.net/browse/LW-12723)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Colour Bitcoin wallets icon in a different (orange!) visual identifier as per designs.
Adjust useWalletAvatar to detect proper active wallet id.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

<img width="1021" alt="Screenshot 2025-05-12 at 15 22 35" src="https://github.com/user-attachments/assets/df049f1d-dc7c-4e5d-a59a-351e180f9ad0" />
<img width="1018" alt="Screenshot 2025-05-12 at 15 22 26" src="https://github.com/user-attachments/assets/79b26242-034c-4bc2-8002-18440021dec9" />


[LW-12558]: https://input-output.atlassian.net/browse/LW-12558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LW-12723]: https://input-output.atlassian.net/browse/LW-12723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ