### PR TITLE
fix: ensure BTC fee is displayed without exponential notation [LW-12718]

### DIFF
--- a/apps/browser-extension-wallet/src/views/bitcoin-mode/features/send/components/ReviewTransaction.tsx
+++ b/apps/browser-extension-wallet/src/views/bitcoin-mode/features/send/components/ReviewTransaction.tsx
@@ -10,6 +10,7 @@ import { Bitcoin } from '@lace/bitcoin';
 import { useTranslation } from 'react-i18next';
 
 const SATS_IN_BTC = 100_000_000;
+const MAXIMUM_FEE_DECIMAL = 8;
 
 interface ReviewTransactionProps {
   unsignedTransaction: Bitcoin.UnsignedTransaction;
@@ -98,7 +99,12 @@ export const ReviewTransaction: React.FC<ReviewTransactionProps> = ({
             })}
             <Flex flexDirection="column" w="$fill" alignItems="flex-end" gap="$4">
               <Text.Body.Normal weight="$medium" data-testid="output-summary-fee">
-                {Number.parseFloat((Number(feeInBtc) / SATS_IN_BTC).toFixed(8))} BTC
+                {(Number(feeInBtc) / SATS_IN_BTC).toLocaleString('en-US', {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: MAXIMUM_FEE_DECIMAL,
+                  useGrouping: false
+                })}{' '}
+                BTC
               </Text.Body.Normal>
               <Text.Body.Normal weight="$medium" data-testid="output-summary-fee-rate" className={styles.feeRateLabel}>
                 {((feeRate * SATS_IN_BTC) / 1000).toFixed(2)} sats/vB


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-12718
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

Ensure BTC fee is displayed without exponential notation

## Screenshots

<img width="685" alt="Screenshot 2025-05-14 at 12 02 05" src="https://github.com/user-attachments/assets/c9f7db85-70cf-4eb8-ae07-9dbe355f46ac" />
