### PR TITLE
fix(extension): add safe handling for video stream cleanup [LW-12719]

### DIFF
--- a/apps/browser-extension-wallet/src/views/bitcoin-mode/features/multi-wallet/restore-wallet/steps/ScanShieldedMessage.tsx
+++ b/apps/browser-extension-wallet/src/views/bitcoin-mode/features/multi-wallet/restore-wallet/steps/ScanShieldedMessage.tsx
@@ -58,8 +58,10 @@ export const ScanShieldedMessage: VFC = () => {
   const [deviceId, setDeviceId] = useState<MediaDeviceInfo['deviceId'] | null>();
 
   const endVideoTracks = () => {
-    streamRef.current.getVideoTracks().forEach((t) => t.stop());
-    streamRef.current = null;
+    if (streamRef.current) {
+      streamRef.current.getVideoTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
   };
 
   const handleDeviceChange = async (value: MediaDeviceInfo['deviceId']) => {
@@ -109,6 +111,8 @@ export const ScanShieldedMessage: VFC = () => {
     };
     setScanState('waiting');
     getVideoStream();
+
+    return endVideoTracks;
   }, [
     deviceId,
     analytics,

--- a/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/steps/ScanShieldedMessage.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/multi-wallet/restore-wallet/steps/ScanShieldedMessage.tsx
@@ -58,8 +58,10 @@ export const ScanShieldedMessage: VFC = () => {
   const [deviceId, setDeviceId] = useState<MediaDeviceInfo['deviceId'] | null>();
 
   const endVideoTracks = () => {
-    streamRef.current.getVideoTracks().forEach((t) => t.stop());
-    streamRef.current = null;
+    if (streamRef.current) {
+      streamRef.current.getVideoTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
   };
 
   const handleDeviceChange = async (value: MediaDeviceInfo['deviceId']) => {
@@ -109,6 +111,8 @@ export const ScanShieldedMessage: VFC = () => {
     };
     setScanState('waiting');
     getVideoStream();
+
+    return endVideoTracks;
   }, [
     deviceId,
     analytics,


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-12719)

---

## Proposed solution
Fix streams cleanup by ensuring that the stream ref still exists. (Firefox implements MediaStream differently)

## Testing
Restore the paper wallet and see that console errors have disappeared.