### PR TITLE
fix: show drep key instead of stake key in sign data popup

### DIFF
--- a/apps/browser-extension-wallet/src/features/dapp/components/ConfirmData.tsx
+++ b/apps/browser-extension-wallet/src/features/dapp/components/ConfirmData.tsx
@@ -21,7 +21,7 @@ import { useAnalyticsContext } from '@providers';
 import { TX_CREATION_TYPE_KEY, TxCreationType } from '@providers/AnalyticsProvider/analyticsTracker';
 import { signingCoordinator } from '@lib/wallet-api-ui';
 import { senderToDappInfo } from '@src/utils/senderToDappInfo';
-import { useOnUnload } from './confirm-transaction/hooks';
+import { useGetOwnPubDRepKeyHash, useOnUnload } from './confirm-transaction/hooks';
 import { parseError } from '@src/utils/parse-error';
 
 const INDENT_SPACING = 2;
@@ -53,8 +53,9 @@ export const DappConfirmData = (): React.ReactElement => {
   const [dappInfo, setDappInfo] = useState<Wallet.DappInfo>();
   const analytics = useAnalyticsContext();
 
+  const { ownPubDRepKeyHash, loading: isLoadingOwnPubDRepKeyHash } = useGetOwnPubDRepKeyHash();
+
   const [formattedData, setFormattedData] = useState<{
-    address: string;
     dataToSign: string;
   }>();
 
@@ -99,9 +100,7 @@ export const DappConfirmData = (): React.ReactElement => {
   useEffect(() => {
     if (!req) return;
     const dataFromHex = fromHex(req.signContext.payload);
-    const txDataAddress = req.signContext.signWith;
     const jsonStructureOrHexString = {
-      address: txDataAddress,
       dataToSign: hasJsonStructure(dataFromHex)
         ? JSON.stringify(JSON.parse(dataFromHex), undefined, INDENT_SPACING)
         : dataFromHex
@@ -138,14 +137,14 @@ export const DappConfirmData = (): React.ReactElement => {
     <Layout pageClassname={styles.spaceBetween} title={t(sectionTitle[DAPP_VIEWS.CONFIRM_DATA])}>
       <div className={styles.container}>
         <DappInfo {...dappInfo} className={styles.dappInfo} />
-        {formattedData ? (
+        {formattedData && !isLoadingOwnPubDRepKeyHash ? (
           <>
             <div className={styles.contentSection}>
               <p className={styles.heading} data-testid="dapp-transaction-recipient-address-title">
                 {t('dapp.confirm.address.title')}
               </p>
               <pre className={styles.pre} data-testid="dapp-transaction-recipient-address">
-                {formattedData.address}
+                {ownPubDRepKeyHash}
               </pre>
             </div>
             <div className={styles.contentSection}>


### PR DESCRIPTION
# Checklist

- [ ] JIRA - [LW-13069](https://input-output.atlassian.net/browse/LW-13069)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Explain how does this PR solves the problem stated in JIRA ticket.
You can also enumerate different alternatives considered while approaching this task.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

<img width="365" alt="Screenshot 2025-06-26 at 12 38 51" src="https://github.com/user-attachments/assets/eb9f6d66-31f1-4ca1-b926-0e1329021416" />



[LW-13069]: https://input-output.atlassian.net/browse/LW-13069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ