### PR TITLE
fix: reload activities on network switch [lw-13103 ]

### DIFF
--- a/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
+++ b/apps/browser-extension-wallet/src/hooks/useWalletManager.ts
@@ -1137,6 +1137,7 @@ export const useWalletManager = (): UseWalletManager => {
     if (activeBlockchain === 'bitcoin') {
       if (activeBitcoinWallet) {
         await bitcoinWalletManager.activate(activeBitcoinWallet, true);
+        window.location.reload();
       }
     } else if (activeWallet) {
       await walletManager.activate(activeWallet, true);


### PR DESCRIPTION
# Checklist

- [x] JIRA - [LW-13103](https://input-output.atlassian.net/browse/LW-13103)
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Problem

Issue does not happen for cardano wallet because of the way we construct `isLoaded` state in `/apps/browser-extension-wallet/src/views/browser-view/routes/index.tsx`, where we actually check for some state properties. Instead we display blank page with loader, and once all the data is there, we switch to the actual activities page, which is rendered with a fresh state of local variables.
Proper fix would be:
-  to align `/apps/browser-extension-wallet/src/views/browser-view/routes/index.tsx` and `apps/browser-extension-wallet/src/views/bitcoin-mode/BitcoinBrowserViewRoutes.tsx` in terms of the way we calculate loading state.
- potentially to refactor btc wallet to have observable properties in place of some methods we use to retrieve wallet state data.

## Proposed solution
- use `window.location.reload()` as an acceptable workaround to refresh wallet state while switching between networks.

## Testing

Describe here, how the new implementation can be tested.
Provide link or briefly describe User Acceptance Criteria/Tests that need to be met

## Screenshots

Attach screenshots here if implementation involves some UI changes


[LW-13103]: https://input-output.atlassian.net/browse/LW-13103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ