### PR TITLE
fix: add unload handler to prevent bfcache

### DIFF
--- a/apps/browser-extension-wallet/src/assets/html/load-app.js
+++ b/apps/browser-extension-wallet/src/assets/html/load-app.js
@@ -7,3 +7,8 @@ window.addEventListener(
   },
   { once: true }
 );
+
+// this should prevent https://web.dev/articles/bfcache
+window.onunload = () => {
+  console.log('unload');
+};

--- a/apps/browser-extension-wallet/src/assets/html/load-dapp-connector.js
+++ b/apps/browser-extension-wallet/src/assets/html/load-dapp-connector.js
@@ -7,3 +7,8 @@ window.addEventListener(
   },
   { once: true }
 );
+
+// this should prevent https://web.dev/articles/bfcache
+window.onunload = () => {
+  console.log('unload');
+};

--- a/apps/browser-extension-wallet/src/assets/html/load-popup.js
+++ b/apps/browser-extension-wallet/src/assets/html/load-popup.js
@@ -7,3 +7,8 @@ window.addEventListener(
   },
   { once: true }
 );
+
+// this should prevent https://web.dev/articles/bfcache
+window.onunload = () => {
+  console.log('unload');
+};


### PR DESCRIPTION
We got user report where Lace appears to be loading indefinitely. User shared console logs that indicate a potential cause being https://developer.mozilla.org/en-US/docs/Glossary/bfcache

bfcache appears to break extension messaging

# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

fix: add unload handler to prevent bfcache

## Testing

🤷 

## Screenshots

![image](https://github.com/user-attachments/assets/886485c9-1c4e-4e74-b6a3-502b5a768175)

