### PR TITLE
Remove key from manifest for Edge Web Store publish

### DIFF
--- a/.github/actions/build/app/action.yml
+++ b/.github/actions/build/app/action.yml
@@ -112,7 +112,9 @@ runs:
 
     - name: Prepare MS Edge
       if: ${{ inputs.BROWSER_TARGET == 'chromium' }}
-      run: 'sed -i "s/\"key\": \"[^\"]*\",//" manifest.json'
+      run: |
+        jq 'del(.key)' manifest.json | jq -c . > manifest.tmp.json
+        mv manifest.tmp.json manifest.json
       shell: bash
       working-directory: ${{ inputs.DIR }}/dist
 


### PR DESCRIPTION
For Edge Web Store submission we need to remove the `key` property from the manifest.json file.
