### PR TITLE
LW-13248 Add not met pledge banner

### DIFF
--- a/packages/staking/src/features/overview/StakingNotificationBanners/StakingNotificationBanners.tsx
+++ b/packages/staking/src/features/overview/StakingNotificationBanners/StakingNotificationBanners.tsx
@@ -49,6 +49,16 @@ export const StakingNotificationBanners = ({ popupView, notifications }: Staking
         description={t('overview.banners.pendingPortfolioModification.message')}
       />
     ),
+    pledgeNotMet: (
+      <Banner
+        popupView={popupView}
+        withIcon
+        customIcon={<WarningTriangleIcon />}
+        message={t('overview.banners.pledgeNotMet.title')}
+        description={t('overview.banners.pledgeNotMet.message')}
+        onBannerClick={onPoolRetiredOrSaturatedBannerClick}
+      />
+    ),
     poolRetiredOrSaturated: (
       <Banner
         popupView={popupView}

--- a/packages/staking/src/features/overview/StakingNotificationBanners/getCurrentStakingNotifications.ts
+++ b/packages/staking/src/features/overview/StakingNotificationBanners/getCurrentStakingNotifications.ts
@@ -1,7 +1,7 @@
 import type { StakingNotificationType } from './types';
 import type { AssetActivityListProps } from '@lace/core';
 import { CurrentPortfolioStakePool, isPortfolioDrifted } from '../../store';
-import { hasPendingDelegationTransaction, hasSaturatedOrRetiredPools } from '../helpers';
+import { hasPendingDelegationTransaction, hasPledgeNotMetPools, hasSaturatedOrRetiredPools } from '../helpers';
 
 type GetCurrentStakingNotificationsParams = {
   walletActivities: AssetActivityListProps[];
@@ -21,5 +21,6 @@ export const getCurrentStakingNotifications = ({
   return [
     isPortfolioDrifted(currentPortfolio) ? 'portfolioDrifted' : undefined,
     hasSaturatedOrRetiredPools(currentPortfolio) ? 'poolRetiredOrSaturated' : undefined,
+    hasPledgeNotMetPools(currentPortfolio) ? 'pledgeNotMet' : undefined,
   ].filter(Boolean) as StakingNotificationType[];
 };

--- a/packages/staking/src/features/overview/StakingNotificationBanners/types.ts
+++ b/packages/staking/src/features/overview/StakingNotificationBanners/types.ts
@@ -1,5 +1,6 @@
 export type StakingNotificationType =
   | 'pendingFirstDelegation'
   | 'pendingPortfolioModification'
+  | 'pledgeNotMet'
   | 'portfolioDrifted'
   | 'poolRetiredOrSaturated';

--- a/packages/staking/src/features/overview/helpers/hasPledgeNotMet.ts
+++ b/packages/staking/src/features/overview/helpers/hasPledgeNotMet.ts
@@ -1,0 +1,6 @@
+import { CurrentPortfolioStakePool } from '../../store';
+
+export const hasPledgeNotMetPools = (currentPortfolio: CurrentPortfolioStakePool[]) =>
+  currentPortfolio.some(({ stakePool }) =>
+    stakePool.metrics?.livePledge ? stakePool.metrics.livePledge < stakePool.pledge : false
+  );

--- a/packages/staking/src/features/overview/helpers/index.ts
+++ b/packages/staking/src/features/overview/helpers/index.ts
@@ -1,4 +1,5 @@
 export { hasMinimumFundsToDelegate } from './hasMinimumFundsToDelegate';
 export { hasPendingDelegationTransaction } from './hasPendingDelegationTransaction';
+export { hasPledgeNotMetPools } from './hasPledgeNotMet';
 export { mapPortfolioToDisplayData } from './mapPortfolioToDisplayData';
 export { hasSaturatedOrRetiredPools } from './hasSaturatedOrRetiredPools';

--- a/packages/translation/src/lib/translations/staking/en.json
+++ b/packages/translation/src/lib/translations/staking/en.json
@@ -168,6 +168,8 @@
   "overview.banners.pendingFirstDelegation.title": "Your staking transaction has been submitted",
   "overview.banners.pendingPortfolioModification.message": "In case of changing pools you will continue to receive rewards from your former stake pool(s) for two epochs",
   "overview.banners.pendingPortfolioModification.title": "You are modifying your staking portfolio",
+  "overview.banners.pledgeNotMet.message": "Your stake in this pool is not earning rewards. Review and update your delegation",
+  "overview.banners.pledgeNotMet.title": "Warning: Delegated pool pledge not met",
   "overview.banners.portfolioDrifted.message": "Make sure to rebalance your staking ratios if you want to match your preferences",
   "overview.banners.portfolioDrifted.title": "Your current delegation portfolio has shifted",
   "overview.banners.saturatedOrRetiredPool.message": "Please make sure to choose other pool(s) to avoid losing rewards",


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-13248
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution

To mitigate the feature gap of BF bulk stake pools API missing the live pledge, added a banner to warn the user in case they are delegating to pools not meeting the pledge.
This covers a missing feature anyway.

## Testing

Manually tested. Probably needs QA and product validation.

## Screenshots

<img width="1633" height="1361" alt="image" src="https://github.com/user-attachments/assets/61885388-6080-415d-94af-3a7a12bbcd86" />
