### PR TITLE
fix: implement ping-pong mechanism to keep service worker alive

### DIFF
--- a/apps/browser-extension-wallet/src/dapp-connector.tsx
+++ b/apps/browser-extension-wallet/src/dapp-connector.tsx
@@ -4,6 +4,7 @@ import { render } from 'react-dom';
 import { DappConnectorView } from '@routes';
 import { StoreProvider } from '@stores';
 import '@lib/i18n';
+import '@lib/scripts/keep-alive-ui';
 import 'antd/dist/antd.css';
 import { CurrencyStoreProvider } from '@providers/currency';
 import { DatabaseProvider, AppSettingsProvider, AnalyticsProvider, ExternalLinkOpenerProvider } from '@providers';

--- a/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/config.ts
@@ -30,7 +30,8 @@ export const backgroundServiceProperties: RemoteApiProperties<BackgroundService>
   resetStorage: RemoteApiPropertyType.MethodReturningPromise,
   getAppVersion: RemoteApiPropertyType.MethodReturningPromise,
   backendFailures$: RemoteApiPropertyType.HotObservable,
-  unhandledError$: RemoteApiPropertyType.HotObservable
+  unhandledError$: RemoteApiPropertyType.HotObservable,
+  ping: RemoteApiPropertyType.MethodReturningPromise
 };
 
 const { BLOCKFROST_CONFIGS, BLOCKFROST_RATE_LIMIT_CONFIG, SESSION_TIMEOUT } = config();

--- a/apps/browser-extension-wallet/src/lib/scripts/background/services/utilityServices.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/services/utilityServices.ts
@@ -319,7 +319,8 @@ export const exposeBackgroundService = (wallet$: Observable<ActiveWallet>): void
         },
         getAppVersion,
         backendFailures$,
-        unhandledError$
+        unhandledError$,
+        ping: async () => 'pong' as const
       }),
       baseChannel: BaseChannels.BACKGROUND_ACTIONS,
       properties: backgroundServiceProperties

--- a/apps/browser-extension-wallet/src/lib/scripts/types/background-service.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/types/background-service.ts
@@ -112,6 +112,7 @@ export type BackgroundService = {
   getAppVersion: () => Promise<string>;
   backendFailures$: BehaviorSubject<number>;
   unhandledError$: Observable<UnhandledError>;
+  ping: () => Promise<'pong'>;
 };
 
 export type WalletMode = {

--- a/apps/browser-extension-wallet/src/popup.tsx
+++ b/apps/browser-extension-wallet/src/popup.tsx
@@ -7,6 +7,7 @@ import { StoreProvider } from '@stores';
 import { CurrencyStoreProvider } from '@providers/currency';
 import { AppSettingsProvider, DatabaseProvider, ThemeProvider, AnalyticsProvider } from '@providers';
 import '@lib/i18n';
+import '@lib/scripts/keep-alive-ui';
 import 'antd/dist/antd.css';
 import './styles/index.scss';
 import 'normalize.css';


### PR DESCRIPTION
The service worker was becoming inactive when browser tabs lost focus. Implemented a more reliable ping-pong mechanism that sends regular ping messages from all UI contexts to the background service, preventing the browser from considering the service worker inactive.

# Checklist

- [ ] JIRA - \<link>
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Explain how does this PR solves the problem stated in JIRA ticket.
You can also enumerate different alternatives considered while approaching this task.

## Testing

Untested

## Screenshots

Attach screenshots here if implementation involves some UI changes
