### PR TITLE
build: separate content scripts build to exclude sentry plugin [LW-13599]

### DIFF
--- a/apps/browser-extension-wallet/package.json
+++ b/apps/browser-extension-wallet/package.json
@@ -27,10 +27,11 @@
   "scripts": {
     "build": "run-s cleanup:dist build:project",
     "build:app": "NODE_OPTIONS='--openssl-legacy-provider' run -T webpack --config webpack.app.${WEBPACK_ENV:-prod}.js --progress",
+    "build:cs": "NODE_OPTIONS='--openssl-legacy-provider' run -T webpack --config webpack.cs.${WEBPACK_ENV:-prod}.js --progress",
     "build:dev": "WEBPACK_ENV=dev yarn build",
     "build:firefox": "BROWSER=firefox yarn build",
     "build:firefox:dev": "WEBPACK_ENV=dev yarn build:firefox",
-    "build:project": "run-p build:sw build:app",
+    "build:project": "run-p build:sw build:app build:cs",
     "build:sw": "NODE_OPTIONS='--openssl-legacy-provider' run -T webpack --config webpack.sw.${WEBPACK_ENV:-prod}.js --progress",
     "cleanup": "run-p cleanup:*",
     "cleanup:dist": "rm -rf dist",

--- a/apps/browser-extension-wallet/webpack.common.app.js
+++ b/apps/browser-extension-wallet/webpack.common.app.js
@@ -26,8 +26,6 @@ module.exports = () =>
     entry: {
       popup: withMaybeSentry(path.join(__dirname, 'src/index-popup.tsx')),
       options: withMaybeSentry(path.join(__dirname, 'src/index-options.tsx')),
-      content: path.join(__dirname, 'src/lib/scripts/background/content.ts'),
-      inject: path.join(__dirname, 'src/lib/scripts/background/inject.ts'),
       dappConnector: withMaybeSentry(path.join(__dirname, 'src/index-dapp-connector.tsx')),
       ['trezor-content-script']: path.join(__dirname, 'src/lib/scripts/trezor/trezor-content-script.ts'),
       ['trezor-usb-permissions']: withMaybeSentry(

--- a/apps/browser-extension-wallet/webpack.common.cs.js
+++ b/apps/browser-extension-wallet/webpack.common.cs.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const { merge } = require('webpack-merge');
+const commonConfig = require('./webpack.common');
+
+require('dotenv-defaults').config({
+  path: './.env',
+  encoding: 'utf8',
+  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
+});
+
+module.exports = () =>
+  merge(commonConfig(), {
+    entry: {
+      content: path.join(__dirname, 'src/lib/scripts/background/content.ts'),
+      inject: path.join(__dirname, 'src/lib/scripts/background/inject.ts')
+    },
+    output: {
+      path: path.join(__dirname, 'dist/app'),
+      filename: '[name].js',
+      // the following setting is required for SRI to work:
+      crossOriginLoading: 'anonymous'
+    },
+    experiments: {
+      syncWebAssembly: true
+    }
+  });

--- a/apps/browser-extension-wallet/webpack.cs.dev.js
+++ b/apps/browser-extension-wallet/webpack.cs.dev.js
@@ -1,0 +1,11 @@
+const { merge } = require('webpack-merge');
+
+const commonDevConfig = require('./webpack.common.dev');
+const commonCsConfig = require('./webpack.common.cs');
+require('dotenv-defaults').config({
+  path: './.env',
+  encoding: 'utf8',
+  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
+});
+
+module.exports = (env) => merge(commonDevConfig({ devServerPort: 3001 })(env), commonCsConfig());

--- a/apps/browser-extension-wallet/webpack.cs.prod.js
+++ b/apps/browser-extension-wallet/webpack.cs.prod.js
@@ -1,0 +1,27 @@
+const { merge } = require('webpack-merge');
+const commonProdConfig = require('./webpack.common.prod');
+const commonCsConfig = require('./webpack.common.cs');
+
+require('dotenv-defaults').config({
+  path: './.env',
+  encoding: 'utf8',
+  defaults: process.env.BUILD_DEV_PREVIEW === 'true' ? './.env.developerpreview' : './.env.defaults'
+});
+
+module.exports = () =>
+  merge(commonProdConfig(), commonCsConfig(), {
+    optimization: {
+      splitChunks: {
+        maxSize: 4000000,
+        cacheGroups: {
+          vendors: {
+            test: /[/\\]node_modules[/\\]/,
+            enforce: true,
+            priority: -20,
+            chunks: 'async',
+            reuseExistingChunk: true
+          }
+        }
+      }
+    }
+  });


### PR DESCRIPTION
Sentry release tracking pollutes global scope by declaring 'e' variable, which can cause conflicts with dapp code when used in the injected script.

We were NOT using sentry in the content scripts, so this has no functional effect. The reason that this code was injected is because we were using the same webpack build configuration for both: Lace app scripts and content scripts. Webpack plugins extend compiler behavior globally (applies to all entrypoints).

Fixes #1988 

# Checklist

- [x] JIRA - LW-13599
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Didn't find a way to apply the plugin for select entrypoints only.
Extract content script entrypoints into a new webpack configuration and build them separately.

## Testing

See #1988 

