### PR TITLE
LW-13680 Add FF_OVERRIDE env variable to locally override feature flags

### DIFF
--- a/apps/browser-extension-wallet/.env.example
+++ b/apps/browser-extension-wallet/.env.example
@@ -120,3 +120,6 @@ SESSION_TIMEOUT=300000
 
 # mempool.space api
 MEMPOOLSPACE_URL=https://mempool.lw.iog.io
+
+# Local feature flags override
+FF_OVERRIDE='{"notifications-center": false}'


### PR DESCRIPTION
# Checklist

- [x] JIRA - LW-13680
- [ ] Proper tests implemented
- [ ] Screenshots added.

---

## Proposed solution

Proposed the approach of a JSON encoded variable as after WebPack build we no longer have the power to dynamically access `process.env`.

Following code
```
for (const i of [1, 2, 3, 4]) console.log('feature', i, process.env[`FEATURE_${i}`]);
console.log('feature1', process.env.FEATURE_1);
console.log('feature2', process.env.FEATURE_2);
console.log('feature3', process.env.FEATURE_3);
console.log('feature4', process.env.FEATURE_4);
```
produces following logs
```
feature 1 undefined
feature 2 undefined
feature 3 undefined
feature 4 undefined
feature1 undefined
feature2 test
feature3 undefined
feature4 false
```

Proposed parsing as `boolean` as all FF have a `boolean` value. Ref: [isFeatureFlagEnabled](https://github.com/input-output-hk/lace/blob/d2836c22de92a720d7190bd78ef8f35842fa7908/apps/browser-extension-wallet/src/providers/PostHogClientProvider/client/PostHogClient.ts#L226)

## Testing

Manually tested
