### PR TITLE
fix(extension): add window focus change detection to lace tab activity check [LW-13679]

### DIFF
--- a/apps/browser-extension-wallet/src/lib/scripts/background/session/is-lace-tab-active.ts
+++ b/apps/browser-extension-wallet/src/lib/scripts/background/session/is-lace-tab-active.ts
@@ -8,6 +8,12 @@ const windowRemoved$ = fromEventPattern<WindowId>(
   (handler) => windows.onRemoved.addListener(handler),
   (handler) => windows.onRemoved.removeListener(handler)
 );
+
+const windowFocusChanged$ = fromEventPattern<WindowId>(
+  (handler) => windows.onFocusChanged.addListener(handler),
+  (handler) => windows.onFocusChanged.removeListener(handler)
+);
+
 const tabUpdated$ = fromEventPattern(
   (handler) => tabs.onUpdated.addListener(handler),
   (handler) => tabs.onUpdated.removeListener(handler),
@@ -30,7 +36,7 @@ const getExtensionTabUrlPattern = () => {
   return `${url.origin}/*`;
 };
 
-export const isLaceTabActive$ = merge(windowRemoved$, tabUpdated$, tabActivated$).pipe(
+export const isLaceTabActive$ = merge(windowRemoved$, tabUpdated$, tabActivated$, windowFocusChanged$).pipe(
   switchMap(() =>
     from(
       catchAndBrandExtensionApiError(


### PR DESCRIPTION


⸻

Solution
	•	The SW should also monitor the windowFocusChanged$ event.
	•	When the window regains focus, the event will fire, the observable
	emits true if the tab is still open	which tells the UI it is safe to resume communication.

# Checklist

- [x] JIRA - https://input-output.atlassian.net/browse/LW-13679
- [ ] Proper tests implemented
- [] Screenshots added.

---

## Proposed solution

	1.	The Service Worker (SW) exposes an observable isLaceTabActive$, which reports changes when: •	a window is closed •	a tab is updated (URL changes) •	a tab is activated (user switches tabs)
	2.	The UI subscribes to this observable.
	3.	After ~30 seconds of inactivity, Chrome suspends the SW due to lack of focus.
	4.	When the UI resubscribes to isLaceTabActive$ after the SW was suspended: 
	- The observable restarts with its startWith value (false).
	- Because the SW was suspended, no tab events (from step 1) have fired, so nothing updates the observable.
	- As a result, the UI keeps seeing false and shows “Blockchain out of sync.”
	6.	Returning to the tab does not fix the issue because no event is triggered to flip isLaceTabActive$ back to true.
	7.	Clicking the menus works because trigger navigation changes so the tab.onUpdated event fires, which updates isLaceTabActive$ to true.

## Testing

Manual testing

## Screenshots


