### PR TITLE
LW-13951 refactor: remove Discord link from settings about page

### DIFF
--- a/apps/browser-extension-wallet/.env.defaults
+++ b/apps/browser-extension-wallet/.env.defaults
@@ -40,7 +40,6 @@ CATALYST_APP_STORE_URL=https://apps.apple.com/fr/app/catalyst-voting/id151747339
 TWITTER_URL=https://twitter.com/lace_io
 YOUTUBE_URL=https://www.youtube.com/c/Laceio
 GITHUB_URL=https://github.com/input-output-hk/lace
-DISCORD_URL=https://discord.gg/lace-1073034511664824360
 WEBSITE_URL=https://www.lace.io
 EMAIL_ADDRESS=lace@iohk.io
 HELP_URL=https://iohk.zendesk.com/hc/en-us/requests/new

--- a/apps/browser-extension-wallet/.env.developerpreview
+++ b/apps/browser-extension-wallet/.env.developerpreview
@@ -38,7 +38,6 @@ CATALYST_APP_STORE_URL=https://apps.apple.com/fr/app/catalyst-voting/id151747339
 TWITTER_URL=https://twitter.com/lace_io
 YOUTUBE_URL=https://www.youtube.com/c/Laceio
 GITHUB_URL=https://github.com/input-output-hk
-DISCORD_URL=https://discord.gg/lace-1073034511664824360
 WEBSITE_URL=https://www.lace.io
 EMAIL_ADDRESS=lace@iohk.io
 HELP_URL=https://iohk.zendesk.com/hc/en-us/requests/new

--- a/apps/browser-extension-wallet/.env.example
+++ b/apps/browser-extension-wallet/.env.example
@@ -37,7 +37,6 @@ CATALYST_APP_STORE_URL=https://apps.apple.com/fr/app/catalyst-voting/id151747339
 TWITTER_URL=https://twitter.com/lace_io
 YOUTUBE_URL=https://www.youtube.com/c/Laceio
 GITHUB_URL=https://github.com/input-output-hk
-DISCORD_URL=https://discord.gg/lace-1073034511664824360
 WEBSITE_URL=https://www.lace.io
 EMAIL_ADDRESS=lace@iohk.io
 HELP_URL=https://iohk.zendesk.com/hc/en-us/requests/new

--- a/apps/browser-extension-wallet/src/views/browser-view/components/SocialNetworks/SocialNetworkIcon.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/components/SocialNetworks/SocialNetworkIcon.tsx
@@ -9,7 +9,6 @@ import Telegram from '../../../../assets/icons/telegram-icon.component.svg';
 import GitHub from '../../../../assets/icons/github-icon.component.svg';
 import Twitter from '../../../../assets/icons/twitter-icon.component.svg';
 import Youtube from '../../../../assets/icons/youtube-icon.component.svg';
-import Discord from '../../../../assets/icons/discord-logo.component.svg';
 
 const normalizeHref = (href: string) =>
   href && !href.startsWith('https://') ? `https://${href.replace(/^\/+/, '')}` : href;
@@ -21,8 +20,7 @@ export enum SocialNetwork {
   TELEGRAM,
   GITHUB,
   TWITTER,
-  YOUTUBE,
-  DISCORD
+  YOUTUBE
 }
 
 export const iconsMap: Record<SocialNetwork, React.FC<React.SVGProps<SVGSVGElement>>> = {
@@ -32,8 +30,7 @@ export const iconsMap: Record<SocialNetwork, React.FC<React.SVGProps<SVGSVGEleme
   [SocialNetwork.TELEGRAM]: Telegram,
   [SocialNetwork.GITHUB]: GitHub,
   [SocialNetwork.TWITTER]: Twitter,
-  [SocialNetwork.YOUTUBE]: Youtube,
-  [SocialNetwork.DISCORD]: Discord
+  [SocialNetwork.YOUTUBE]: Youtube
 };
 
 export type socialNetworkIconProps = {

--- a/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsAbout.tsx
+++ b/apps/browser-extension-wallet/src/views/browser-view/features/settings/components/SettingsAbout.tsx
@@ -16,7 +16,6 @@ const socialNetworks = [
   { name: SocialNetwork.WEBSITE, href: process.env.WEBSITE_URL },
   { name: SocialNetwork.TWITTER, href: process.env.TWITTER_URL },
   { name: SocialNetwork.YOUTUBE, href: process.env.YOUTUBE_URL },
-  { name: SocialNetwork.DISCORD, href: process.env.DISCORD_URL },
   { name: SocialNetwork.GITHUB, href: process.env.GITHUB_URL }
 ];
 

--- a/apps/browser-extension-wallet/test/__mocks__/set-env-vars.js
+++ b/apps/browser-extension-wallet/test/__mocks__/set-env-vars.js
@@ -25,4 +25,3 @@ process.env.POSTHOG_DEV_TOKEN = 'test-token';
 process.env.MIN_NUMBER_OF_COSIGNERS = '2';
 process.env.TWITTER_URL = 'TWITTER_URL';
 process.env.YOUTUBE_URL = 'YOUTUBE_URL';
-process.env.DISCORD_URL = 'DISCORD_URL';

--- a/packages/core/test/__mocks__/set-env-vars.js
+++ b/packages/core/test/__mocks__/set-env-vars.js
@@ -25,4 +25,3 @@ process.env.POSTHOG_DEV_TOKEN = 'test-token';
 process.env.MIN_NUMBER_OF_COSIGNERS = '2';
 process.env.TWITTER_URL = 'TWITTER_URL';
 process.env.YOUTUBE_URL = 'YOUTUBE_URL';
-process.env.DISCORD_URL = 'DISCORD_URL';

--- a/packages/e2e-tests/src/assert/settings/SettingsPageAssert.ts
+++ b/packages/e2e-tests/src/assert/settings/SettingsPageAssert.ts
@@ -234,8 +234,6 @@ class SettingsPageAssert {
     await SettingsPage.aboutLaceWidget.twitter.icon.waitForDisplayed();
     await SettingsPage.aboutLaceWidget.youtube.element.waitForDisplayed();
     await SettingsPage.aboutLaceWidget.youtube.icon.waitForDisplayed();
-    await SettingsPage.aboutLaceWidget.discord.element.waitForDisplayed();
-    await SettingsPage.aboutLaceWidget.discord.icon.waitForDisplayed();
     await SettingsPage.aboutLaceWidget.github.element.waitForDisplayed();
     await SettingsPage.aboutLaceWidget.github.icon.waitForDisplayed();
   }

--- a/packages/e2e-tests/src/elements/settings/extendedView/AboutLaceWidget.ts
+++ b/packages/e2e-tests/src/elements/settings/extendedView/AboutLaceWidget.ts
@@ -56,10 +56,6 @@ class AboutLaceWidget {
     return new SocialComponentElement(SocialComponentEnum.Youtube);
   }
 
-  get discord() {
-    return new SocialComponentElement(SocialComponentEnum.Discord);
-  }
-
   get github() {
     return new SocialComponentElement(SocialComponentEnum.Github);
   }

--- a/packages/e2e-tests/src/elements/settings/extendedView/SocialComponentElement.ts
+++ b/packages/e2e-tests/src/elements/settings/extendedView/SocialComponentElement.ts
@@ -6,8 +6,7 @@ export enum SocialComponentEnum {
   Twitter = 'TWITTER',
   Website = 'WEBSITE',
   Github = 'GITHUB',
-  Youtube = 'YOUTUBE',
-  Discord = 'DISCORD'
+  Youtube = 'YOUTUBE'
 }
 
 export class SocialComponentElement {


### PR DESCRIPTION
Remove Discord social link from the Settings About page and update related E2E tests to reflect this change.
