### PR TITLE
feat: add preview/preprod label for Midnight network [LW-14081]

### DIFF
--- a/v1/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupSelectBlockchain.tsx
+++ b/v1/packages/core/src/ui/components/WalletSetupRevamp/WalletSetupSelectBlockchain.tsx
@@ -17,6 +17,7 @@ type BlockchainSelection = Blockchain | 'Midnight';
 interface BlockchainOption {
   value: BlockchainSelection;
   title: string;
+  subtitle?: string;
   description: string;
   icon: React.FC<React.SVGProps<SVGSVGElement>>;
   testId: string;
@@ -41,6 +42,7 @@ const getBlockchainOptions = (t: TFunction): BlockchainOption[] => [
   {
     value: 'Midnight',
     title: t('core.WalletSetupSelectBlockchain.midnight'),
+    subtitle: t('core.WalletSetupSelectBlockchain.midnight.networkLabel'),
     description: t('core.WalletSetupSelectBlockchain.midnight.description'),
     icon: MidnightIcon,
     testId: 'midnight-blockchain-card',
@@ -113,6 +115,9 @@ export const WalletSetupSelectBlockchain = ({
     return option.badge;
   };
 
+  const getSubtitle = (option: BlockchainOption): string | undefined =>
+    option.value === 'Midnight' && midnightDisabled ? undefined : option.subtitle;
+
   const handleSelect = (value: BlockchainSelection) => {
     if (isOptionDisabled(value)) return;
 
@@ -151,6 +156,7 @@ export const WalletSetupSelectBlockchain = ({
           const disabled = isOptionDisabled(option.value);
           const badge = getDisabledBadge(option);
           const description = getDisabledDescription(option);
+          const subtitle = getSubtitle(option);
 
           return (
             <Card.Outlined
@@ -171,8 +177,9 @@ export const WalletSetupSelectBlockchain = ({
                 />
                 <Flex flexDirection="column" gap="$8">
                   <Flex gap="$8" alignItems="center" justifyContent="center">
-                    <Text.Body.Large weight="$bold" data-testid={`${option.value.toLowerCase()}-option-title`}>
-                      {option.title}
+                    <Text.Body.Large data-testid={`${option.value.toLowerCase()}-option-title`}>
+                      <span style={{ fontWeight: 'bold' }}>{option.title}</span>
+                      {subtitle && ` ${subtitle}`}
                     </Text.Body.Large>
                     {badge && (
                       <div

--- a/v1/packages/translation/src/lib/translations/core/en.json
+++ b/v1/packages/translation/src/lib/translations/core/en.json
@@ -688,6 +688,7 @@
   "core.WalletSetupSelectBlockchain.midnight.disabledReason": "At this moment only one Midnight wallet is supported. Please remove the existing wallet if you want to create a new one.",
   "core.WalletSetupSelectBlockchain.defaultBadge": "Default",
   "core.WalletSetupSelectBlockchain.newBadge": "New",
+  "core.WalletSetupSelectBlockchain.midnight.networkLabel": "(Preview/PreProd networks)",
   "core.walletSetupReuseRecoveryPhrase.title": "Reuse your Recovery Phrase?",
   "core.walletSetupReuseRecoveryPhrase.description": "Do you wish to use the same passphrase as the wallet below, or wish to create a new one?",
   "core.walletSetupReuseRecoveryPhrase.reuse": "Reuse",

--- a/v1/packages/translation/src/lib/translations/core/es.json
+++ b/v1/packages/translation/src/lib/translations/core/es.json
@@ -688,6 +688,7 @@
   "core.WalletSetupSelectBlockchain.midnight.disabledReason": "En este momento solo se admite una billetera Midnight. Elimina la billetera existente si deseas crear una nueva.",
   "core.WalletSetupSelectBlockchain.defaultBadge": "Predeterminado",
   "core.WalletSetupSelectBlockchain.newBadge": "Nuevo",
+  "core.WalletSetupSelectBlockchain.midnight.networkLabel": "(Redes Preview/PreProd)",
   "core.walletSetupReuseRecoveryPhrase.title": "¿Reutilizar su frase de recuperación?",
   "core.walletSetupReuseRecoveryPhrase.description": "¿Desea usar la misma frase de recuperación que la billetera a continuación, o desea crear una nueva?",
   "core.walletSetupReuseRecoveryPhrase.reuse": "Reutilizar",


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-14081)
- [ ] Proper tests implemented
- [x] Screenshots added.

---

## Proposed solution
This PR introduces an additional label for the Midnight network during onboarding. When the Midnight wallet is already onboarded, the label is not displayed (as per the screenshot below).

## Screenshots

<img width="861" height="623" alt="image" src="https://github.com/user-attachments/assets/63e2f387-7054-44f1-baff-4b36db716ae0" />

No changes when Midnight is disabled:
<img width="857" height="619" alt="image" src="https://github.com/user-attachments/assets/ffaa6023-2ad6-4989-a1ec-0f2c05eaa577" />
