### PR TITLE
fix: fix attempt for prod edge bundle build

### DIFF
--- a/.github/workflows/release-lace-bundle.yml
+++ b/.github/workflows/release-lace-bundle.yml
@@ -366,6 +366,8 @@ jobs:
         run: |
           jq 'del(.key)' dist/manifest.json | jq -c . > dist/manifest.tmp.json
           mv dist/manifest.tmp.json dist/manifest.json
+          sed -i 's#__webpack_require__\.p="chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk/js/"#__webpack_require__.p="/js/"#g' dist/js/*.js
+          sed -i 's#chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk#extension://efeiemlfnahiidnjglmehaihacglceia#g' dist/js/*.js
 
       - name: Upload MS Edge Bundle artifact
         uses: actions/upload-artifact@v4
@@ -427,4 +429,3 @@ jobs:
           else
             exit 1
           fi
-


### PR DESCRIPTION
# Checklist

- [x] JIRA - https://input-output.atlassian.net/browse/LW-14379

## Issue root cause

The cause is that one of the two extension (I guess `midnight-extension` as it is the one impacted by the issue) is built with a webpack configuration which generates chrome dedicated URLs.

The real and elegant solution would require to change the webpack configuration (spread at least between 9 files) to get the same result at build time, but I'm not sure I'm able to cover all the cases our configuration is thought to.

So, also give bundle version should be a temporary solution, I'm proposing this workaround.

## Proposed solution

The explicit chrome extension URL appears in the `dist` directory 12 times, 4 time in a webpack configuration init function (the cause of the issue) and 8 times in some tracking configuration objects (I guess sentry).

The first line changes the URL from `chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk/js/` into `/js/`, this makes the bundle build to work if loaded as unpackaged and hopefully should make it work also if downloaded from edge store.

The second line changes the tracking configuration. This change probably brakes the tracking when the extension is loaded as unpackaged, but should make it work when downloaded from edge store.

## Testing

Since I can't run the CI locally, I applied the same change on local files: it works.
