### PR TITLE
fix: correctly extract token price when asset is quote token in pool [LW-14509]

### DIFF
--- a/v1/apps/browser-extension-wallet/src/lib/scripts/background/services/cardanoTokenPrices.ts
+++ b/v1/apps/browser-extension-wallet/src/lib/scripts/background/services/cardanoTokenPrices.ts
@@ -24,6 +24,7 @@ import {
 } from 'rxjs';
 import { storage } from 'webextension-polyfill';
 import { TokenPrices, Status, MaybeTokenPrice } from '../../types';
+import { extractTokenPriceFromPool } from './geckoTerminalUtils';
 import { Cardano, Milliseconds } from '@cardano-sdk/core';
 import { config } from '@src/config';
 import Bottleneck from 'bottleneck';
@@ -113,28 +114,11 @@ const fetchPrice = (assetId: Cardano.AssetId): Observable<PriceListItem> =>
             return [assetId, { lastFetchTime: Date.now() }];
           }
           const body = await response.json();
-          const data = body.data?.[0]?.attributes;
+          const pool = body.data?.[0];
+          const price = extractTokenPriceFromPool(pool, assetId);
 
-          // If not the expected data, return no price
-          if (typeof data === 'object') {
-            const {
-              base_token_price_native_currency: priceInAda,
-              price_change_percentage: { h24: h24Change }
-            } = data;
-
-            // If not the expected data, return no price
-            if (typeof priceInAda === 'string' && typeof h24Change === 'string') {
-              return [
-                assetId,
-                {
-                  lastFetchTime: Date.now(),
-                  price: {
-                    priceInAda: Number.parseFloat(priceInAda),
-                    priceVariationPercentage24h: Number.parseFloat(h24Change)
-                  }
-                }
-              ];
-            }
+          if (price) {
+            return [assetId, { lastFetchTime: Date.now(), price }];
           }
         } catch (error) {
           console.warn('Error fetching cardano token price', assetId, error);

--- a/v1/apps/browser-extension-wallet/src/lib/scripts/background/services/geckoTerminalUtils.test.ts
+++ b/v1/apps/browser-extension-wallet/src/lib/scripts/background/services/geckoTerminalUtils.test.ts
@@ -1,0 +1,145 @@
+/* eslint-disable camelcase, no-magic-numbers */
+import { Cardano } from '@cardano-sdk/core';
+
+import { extractTokenPriceFromPool } from './geckoTerminalUtils';
+
+const assetId = 'a1b2c3d4e5f6' as Cardano.AssetId;
+
+const makePool = ({
+  baseTokenId,
+  basePriceNative,
+  quotePriceNative,
+  h24Change
+}: {
+  baseTokenId: string;
+  basePriceNative: string;
+  quotePriceNative: string;
+  h24Change: string;
+}) => ({
+  attributes: {
+    base_token_price_native_currency: basePriceNative,
+    quote_token_price_native_currency: quotePriceNative,
+    price_change_percentage: { h24: h24Change }
+  },
+  relationships: {
+    base_token: { data: { id: baseTokenId } }
+  }
+});
+
+describe('extractTokenPriceFromPool', () => {
+  it('returns base token price when queried asset is the base token', () => {
+    const pool = makePool({
+      baseTokenId: `cardano_${assetId}`,
+      basePriceNative: '2.78',
+      quotePriceNative: '0.36',
+      h24Change: '-1.5'
+    });
+
+    const result = extractTokenPriceFromPool(pool, assetId);
+
+    expect(result).toEqual({
+      priceInAda: 2.78,
+      priceVariationPercentage24h: -1.5
+    });
+  });
+
+  it('returns quote token price when queried asset is the quote token', () => {
+    const otherAssetId = 'ff00ff00ff00';
+    const pool = makePool({
+      baseTokenId: `cardano_${otherAssetId}`,
+      basePriceNative: '0.10',
+      quotePriceNative: '2.78',
+      h24Change: '3.2'
+    });
+
+    const result = extractTokenPriceFromPool(pool, assetId);
+
+    expect(result).toEqual({
+      priceInAda: 2.78,
+      priceVariationPercentage24h: 3.2
+    });
+  });
+
+  it('returns undefined when pool is undefined', () => {
+    expect(extractTokenPriceFromPool(undefined, assetId)).toBeUndefined();
+  });
+
+  it('returns undefined when attributes is not the expected shape', () => {
+    const pool = {
+      attributes: 'invalid',
+      relationships: {
+        base_token: { data: { id: `cardano_${assetId}` } }
+      }
+    } as Parameters<typeof extractTokenPriceFromPool>[0];
+    expect(extractTokenPriceFromPool(pool, assetId)).toBeUndefined();
+  });
+
+  it('returns undefined when price fields are not strings', () => {
+    const pool = {
+      attributes: {
+        base_token_price_native_currency: 2.78 as unknown as string,
+        quote_token_price_native_currency: 0.36 as unknown as string,
+        price_change_percentage: { h24: '-1.5' }
+      },
+      relationships: {
+        base_token: { data: { id: `cardano_${assetId}` } }
+      }
+    };
+
+    expect(extractTokenPriceFromPool(pool, assetId)).toBeUndefined();
+  });
+
+  it('returns undefined when h24 change is missing', () => {
+    const pool = {
+      attributes: {
+        base_token_price_native_currency: '2.78',
+        quote_token_price_native_currency: '0.36',
+        price_change_percentage: {}
+      },
+      relationships: {
+        base_token: { data: { id: `cardano_${assetId}` } }
+      }
+    };
+
+    expect(extractTokenPriceFromPool(pool, assetId)).toBeUndefined();
+  });
+
+  it('returns undefined when relationships are missing', () => {
+    const pool = {
+      attributes: {
+        base_token_price_native_currency: '0.10',
+        quote_token_price_native_currency: '2.78',
+        price_change_percentage: { h24: '0.5' }
+      }
+    };
+
+    expect(extractTokenPriceFromPool(pool, assetId)).toBeUndefined();
+  });
+
+  it('uses exact match for base token id, not substring', () => {
+    const pool = makePool({
+      baseTokenId: `cardano_${assetId}abcdef`,
+      basePriceNative: '0.10',
+      quotePriceNative: '2.78',
+      h24Change: '1.0'
+    });
+
+    const result = extractTokenPriceFromPool(pool, assetId);
+
+    expect(result).toEqual({
+      priceInAda: 2.78,
+      priceVariationPercentage24h: 1
+    });
+  });
+
+  it('returns undefined when price string is non-numeric', () => {
+    const pool = makePool({
+      baseTokenId: `cardano_${assetId}`,
+      basePriceNative: '',
+      quotePriceNative: '2.78',
+      h24Change: '0.5'
+    });
+
+    expect(extractTokenPriceFromPool(pool, assetId)).toBeUndefined();
+  });
+});

--- a/v1/apps/browser-extension-wallet/src/lib/scripts/background/services/geckoTerminalUtils.ts
+++ b/v1/apps/browser-extension-wallet/src/lib/scripts/background/services/geckoTerminalUtils.ts
@@ -1,0 +1,53 @@
+import { Cardano } from '@cardano-sdk/core';
+import { TokenPrice } from '../../types';
+
+/** Shape of a pool entry from the GeckoTerminal /tokens/{id}/pools response. */
+export interface GeckoTerminalPool {
+  attributes?: {
+    /* eslint-disable camelcase */
+    base_token_price_native_currency?: string;
+    quote_token_price_native_currency?: string;
+    price_change_percentage?: { h24?: string };
+    /* eslint-enable camelcase */
+  };
+  relationships?: {
+    /* eslint-disable camelcase */
+    base_token?: { data?: { id?: string } };
+    /* eslint-enable camelcase */
+  };
+}
+
+const CHAIN_PREFIX = 'cardano_';
+
+/** Strips the chain prefix (e.g. "cardano_") and checks for an exact match. */
+const normalizeAndMatch = (baseTokenId: string, assetId: Cardano.AssetId): boolean => {
+  const normalized = baseTokenId.startsWith(CHAIN_PREFIX) ? baseTokenId.slice(CHAIN_PREFIX.length) : baseTokenId;
+  return normalized === assetId;
+};
+
+/**
+ * Extracts the token price from a GeckoTerminal pool response.
+ * The pool may have the queried token as either the base or quote token,
+ * so we check the relationship to pick the correct price field.
+ */
+export const extractTokenPriceFromPool = (
+  pool: GeckoTerminalPool | undefined | null,
+  assetId: Cardano.AssetId
+): TokenPrice | undefined => {
+  const data = pool?.attributes;
+  // eslint-disable-next-line camelcase
+  const baseTokenId = pool?.relationships?.base_token?.data?.id;
+  const isBaseToken = typeof baseTokenId === 'string' && normalizeAndMatch(baseTokenId, assetId);
+
+  const tokenPriceNativeCurrency = isBaseToken
+    ? data?.base_token_price_native_currency
+    : data?.quote_token_price_native_currency;
+  const rawPrice = typeof baseTokenId === 'string' ? tokenPriceNativeCurrency : undefined;
+  const h24Change = typeof baseTokenId === 'string' ? data?.price_change_percentage?.h24 : undefined;
+  const priceInAda = typeof rawPrice === 'string' ? Number.parseFloat(rawPrice) : Number.NaN;
+  const priceVariationPercentage24h = typeof h24Change === 'string' ? Number.parseFloat(h24Change) : Number.NaN;
+
+  return Number.isFinite(priceInAda) && Number.isFinite(priceVariationPercentage24h)
+    ? { priceInAda, priceVariationPercentage24h }
+    : undefined;
+};


### PR DESCRIPTION
## Summary

- The GeckoTerminal `/tokens/{id}/pools` endpoint may return the queried token as either the base or quote token in a pool. Previously we unconditionally used `base_token_price_native_currency`, which returned the wrong price (e.g. ~0.06 instead of ~1.00) for tokens like USDCx that appear as the quote token in their primary pool.
- Added `extractTokenPriceFromPool` helper that checks the pool's `base_token` relationship to determine whether to use the base or quote price field.
- Added unit tests covering base token, quote token, missing data, invalid types, and missing relationship scenarios.

## Test plan

- [x] Unit tests pass for `extractTokenPriceFromPool`
- [ ] Load extension locally, navigate to a wallet holding USDCx, and verify the price displays close to $1.00
- [ ] Verify other token prices (e.g. SNEK, MIN) are unaffected
- [x] CI passes


Made with [Cursor](https://cursor.com)