### PR TITLE
feat: upload sourcemaps for v1 service worker to Sentry [LW-14601]

### DIFF
--- a/.github/actions/build/app/action.yml
+++ b/.github/actions/build/app/action.yml
@@ -117,6 +117,24 @@ runs:
         PUBNUB_SUBSCRIBE_KEY: ${{ inputs.PUBNUB_SUBSCRIBE_KEY }}
         PUBNUB_TOKEN_ENDPOINT: ${{ inputs.PUBNUB_TOKEN_ENDPOINT }}
 
+    - name: Upload SW sourcemaps to Sentry
+      if: inputs.SENTRY_AUTH_TOKEN != '' && inputs.SENTRY_ORG != '' && inputs.SENTRY_PROJECT != ''
+      env:
+        SENTRY_AUTH_TOKEN: ${{ inputs.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ inputs.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
+      run: |
+        VERSION=$(jq -r '.version' manifest.json)
+        HASH=$(git rev-parse --short HEAD)
+        RELEASE="${VERSION}-${HASH}"
+        npx sentry-cli sourcemaps upload \
+          --release "$RELEASE" \
+          --url-prefix "~/sw/" \
+          dist/sw
+        rm -f dist/sw/*.js.map
+      shell: bash
+      working-directory: ${{ inputs.DIR }}
+
     - name: Upload Chrome artifact
       if: ${{ inputs.BROWSER_TARGET == 'chromium' }}
       uses: actions/upload-artifact@v4

--- a/v1/apps/browser-extension-wallet/package.json
+++ b/v1/apps/browser-extension-wallet/package.json
@@ -80,6 +80,7 @@
     "@pdfme/generator": "^4.0.2",
     "@react-rxjs/core": "^0.9.8",
     "@react-rxjs/utils": "^0.9.5",
+    "@sentry/cli": "^2.36.1",
     "@sentry/react": "^8.33.1",
     "@sentry/webpack-plugin": "^2.22.6",
     "@shiroyasha9/axios-fetch-adapter": "^1.0.3",

--- a/v1/apps/browser-extension-wallet/sentry.js
+++ b/v1/apps/browser-extension-wallet/sentry.js
@@ -171,6 +171,8 @@ const reportQuotaWarningIfNeeded = async (errorMessage) => {
 Sentry.init({
   environment: process.env.SENTRY_ENVIRONMENT,
   dsn: process.env.SENTRY_DSN,
+  // APP_VERSION and COMMIT_HASH are always injected by webpack.common.js.
+  release: `${process.env.APP_VERSION}-${String(process.env.COMMIT_HASH).slice(0, 7)}`,
   integrations: [Sentry.browserTracingIntegration(), Sentry.browserProfilingIntegration(), Sentry.replayIntegration()],
   // Set `tracePropagationTargets` to control for which URLs trace propagation should be enabled
   tracePropagationTargets: ['localhost', 'chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk'],

--- a/v1/yarn.lock
+++ b/v1/yarn.lock
@@ -10512,6 +10512,7 @@ __metadata:
     "@pdfme/schemas": ^4.0.2
     "@react-rxjs/core": ^0.9.8
     "@react-rxjs/utils": ^0.9.5
+    "@sentry/cli": ^2.36.1
     "@sentry/react": ^8.33.1
     "@sentry/webpack-plugin": ^2.22.6
     "@shiroyasha9/axios-fetch-adapter": ^1.0.3


### PR DESCRIPTION
# Checklist

- [x] [JIRA](https://input-output.atlassian.net/browse/LW-14601)

---

## Proposed solution

The v1 SW is loaded via `importScripts()` from `sw-bundle.js`, which breaks Sentry's debug ID sourcemap matching (error events end up with empty `debug_meta`). Switched the SW to release-based matching instead and added a sentry-cli sourcemaps upload CI step for release builds. The app bundle keeps using debug IDs unchanged.
